### PR TITLE
Enforce governance structure and add idempotent event application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5987,6 +5987,7 @@ dependencies = [
  "uuid",
  "willow-crypto",
  "willow-identity",
+ "willow-state",
  "willow-transport",
 ]
 

--- a/crates/app/src/ui/channels.rs
+++ b/crates/app/src/ui/channels.rs
@@ -834,13 +834,11 @@ pub fn sync_role_list(
         }
 
         let key_perms = [
-            ("Admin", willow_channel::Permission::Administrator),
+            ("Sync", willow_channel::Permission::SyncProvider),
             ("Send", willow_channel::Permission::SendMessages),
-            ("Read", willow_channel::Permission::ReadMessages),
-            ("Kick", willow_channel::Permission::KickMembers),
             ("Invite", willow_channel::Permission::CreateInvite),
-            ("Files", willow_channel::Permission::AttachFiles),
             ("ManageCh", willow_channel::Permission::ManageChannels),
+            ("ManageRoles", willow_channel::Permission::ManageRoles),
         ];
 
         for role in &roles {
@@ -996,13 +994,11 @@ pub fn handle_toggle_permission(
 
         let role_id = willow_channel::RoleId(uuid::Uuid::parse_str(&button.0).unwrap_or_default());
         let perm = match button.1.as_str() {
-            "Administrator" => willow_channel::Permission::Administrator,
+            "SyncProvider" => willow_channel::Permission::SyncProvider,
             "SendMessages" => willow_channel::Permission::SendMessages,
-            "ReadMessages" => willow_channel::Permission::ReadMessages,
-            "KickMembers" => willow_channel::Permission::KickMembers,
             "CreateInvite" => willow_channel::Permission::CreateInvite,
-            "AttachFiles" => willow_channel::Permission::AttachFiles,
             "ManageChannels" => willow_channel::Permission::ManageChannels,
+            "ManageRoles" => willow_channel::Permission::ManageRoles,
             _ => continue,
         };
 

--- a/crates/app/src/ui/chat.rs
+++ b/crates/app/src/ui/chat.rs
@@ -766,13 +766,11 @@ fn handle_op(
                 let rid =
                     willow_channel::RoleId(uuid::Uuid::parse_str(role_id).unwrap_or_default());
                 let perm = match permission.as_str() {
-                    "Administrator" => willow_channel::Permission::Administrator,
+                    "SyncProvider" => willow_channel::Permission::SyncProvider,
                     "SendMessages" => willow_channel::Permission::SendMessages,
-                    "ReadMessages" => willow_channel::Permission::ReadMessages,
-                    "KickMembers" => willow_channel::Permission::KickMembers,
                     "CreateInvite" => willow_channel::Permission::CreateInvite,
-                    "AttachFiles" => willow_channel::Permission::AttachFiles,
                     "ManageChannels" => willow_channel::Permission::ManageChannels,
+                    "ManageRoles" => willow_channel::Permission::ManageRoles,
                     _ => return true,
                 };
                 let _ = server.set_permission(&rid, perm, *granted);

--- a/crates/channel/Cargo.toml
+++ b/crates/channel/Cargo.toml
@@ -9,6 +9,7 @@ description = "Servers, channels, roles, and permissions for Willow"
 willow-identity = { path = "../identity" }
 willow-transport = { path = "../transport" }
 willow-crypto = { path = "../crypto" }
+willow-state = { path = "../state" }
 
 serde = { workspace = true }
 chrono = { workspace = true }

--- a/crates/channel/src/lib.rs
+++ b/crates/channel/src/lib.rs
@@ -159,34 +159,12 @@ pub enum ChannelError {
 
 // ───── Permissions ───────────────────────────────────────────────────────────
 
-/// Individual permissions that can be granted to roles.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum Permission {
-    /// Send messages in text channels.
-    SendMessages,
-    /// Read message history.
-    ReadMessages,
-    /// Delete other people's messages.
-    ManageMessages,
-    /// Create, rename, or delete channels.
-    ManageChannels,
-    /// Create, edit, or delete roles.
-    ManageRoles,
-    /// Kick members from the server.
-    KickMembers,
-    /// Ban members from the server.
-    BanMembers,
-    /// Create invite links.
-    CreateInvite,
-    /// Connect to voice channels.
-    VoiceConnect,
-    /// Speak in voice channels.
-    VoiceSpeak,
-    /// Share screen in voice channels.
-    ScreenShare,
-    /// Upload files.
-    AttachFiles,
-}
+/// Re-export the single authoritative Permission enum from willow-state.
+///
+/// All permissions are defined in the state crate and enforced by the
+/// event-sourced state machine. Admin status is separate and managed
+/// exclusively through the governance vote path.
+pub use willow_state::Permission;
 
 // ───── Role ──────────────────────────────────────────────────────────────────
 
@@ -737,15 +715,15 @@ mod tests {
         let (owner, server) = owner_and_server();
         assert!(server.admins.contains(&owner));
         assert!(server.has_permission(&owner, Permission::ManageChannels));
-        assert!(server.has_permission(&owner, Permission::KickMembers));
         assert!(server.has_permission(&owner, Permission::SendMessages));
+        assert!(server.has_permission(&owner, Permission::SyncProvider));
     }
 
     #[test]
     fn non_member_has_no_permissions() {
         let (_, server) = owner_and_server();
         let stranger = Identity::generate().endpoint_id();
-        assert!(!server.has_permission(&stranger, Permission::ReadMessages));
+        assert!(!server.has_permission(&stranger, Permission::SendMessages));
     }
 
     #[test]
@@ -797,19 +775,19 @@ mod tests {
         server.add_member(alice.clone());
 
         // Alice starts with no permissions.
-        assert!(!server.has_permission(&alice, Permission::ManageMessages));
+        assert!(!server.has_permission(&alice, Permission::SendMessages));
 
         // Create a moderator role.
         let mut mod_role = Role::new("Moderator");
-        mod_role.permissions.insert(Permission::ManageMessages);
-        mod_role.permissions.insert(Permission::KickMembers);
+        mod_role.permissions.insert(Permission::SendMessages);
+        mod_role.permissions.insert(Permission::ManageChannels);
         let role_id = server.create_role(mod_role);
 
         // Assign it to Alice.
         server.assign_role(&alice, &role_id).unwrap();
 
-        assert!(server.has_permission(&alice, Permission::ManageMessages));
-        assert!(server.has_permission(&alice, Permission::KickMembers));
+        assert!(server.has_permission(&alice, Permission::SendMessages));
+        assert!(server.has_permission(&alice, Permission::ManageChannels));
         assert!(!server.has_permission(&alice, Permission::ManageRoles));
     }
 
@@ -824,8 +802,8 @@ mod tests {
 
         // Admins have all permissions implicitly.
         assert!(server.has_permission(&bob, Permission::ManageChannels));
-        assert!(server.has_permission(&bob, Permission::BanMembers));
-        assert!(server.has_permission(&bob, Permission::ScreenShare));
+        assert!(server.has_permission(&bob, Permission::ManageRoles));
+        assert!(server.has_permission(&bob, Permission::CreateInvite));
     }
 
     #[test]

--- a/crates/client/src/accessors.rs
+++ b/crates/client/src/accessors.rs
@@ -103,7 +103,7 @@ impl<N: willow_network::Network> ClientHandle<N> {
         perm: &willow_state::Permission,
     ) -> bool {
         let pid = *peer_id;
-        let p = perm.clone();
+        let p = *perm;
         willow_actor::state::select(&self.event_state_addr, move |es| {
             es.has_permission(&pid, &p)
         })

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -650,11 +650,9 @@ fn load_identity() -> Identity {
 /// Parse a permission string into a [`willow_channel::Permission`].
 fn parse_permission(s: &str) -> anyhow::Result<willow_channel::Permission> {
     match s {
+        "SyncProvider" => Ok(willow_channel::Permission::SyncProvider),
         "SendMessages" => Ok(willow_channel::Permission::SendMessages),
-        "ReadMessages" => Ok(willow_channel::Permission::ReadMessages),
-        "KickMembers" => Ok(willow_channel::Permission::KickMembers),
         "CreateInvite" => Ok(willow_channel::Permission::CreateInvite),
-        "AttachFiles" => Ok(willow_channel::Permission::AttachFiles),
         "ManageChannels" => Ok(willow_channel::Permission::ManageChannels),
         "ManageRoles" => Ok(willow_channel::Permission::ManageRoles),
         _ => anyhow::bail!("unknown permission: {s}"),
@@ -711,6 +709,7 @@ pub fn test_client() -> (
         0,
     );
     dag_state.dag.insert(genesis).expect("genesis must insert");
+    dag_state.synced = true;
 
     // Materialize initial state from the DAG — this gives us a ServerState
     // with the correct server_id (genesis hash) and genesis author as admin.

--- a/crates/client/src/listeners.rs
+++ b/crates/client/src/listeners.rs
@@ -220,6 +220,14 @@ async fn process_received_message<T: TopicHandle>(
                 try_insert_event(ctx, event).await;
             }
             if count > 0 {
+                // Mark DAG as synced once genesis has been received.
+                willow_actor::state::mutate(&ctx.dag, |ds| {
+                    if !ds.synced && ds.dag.genesis().is_some() {
+                        ds.synced = true;
+                    }
+                })
+                .await;
+
                 let _ =
                     ctx.event_broker
                         .do_send(willow_actor::Publish(ClientEvent::SyncCompleted {

--- a/crates/client/src/mutations.rs
+++ b/crates/client/src/mutations.rs
@@ -74,12 +74,17 @@ impl<N: willow_network::Network> ClientMutations<N> {
         let name = server_name.to_string();
         let ts = util::current_time_ms();
         let state = willow_actor::state::mutate(&self.dag, move |ds| {
+            // Idempotent: if genesis already exists, return current state.
+            if ds.dag.genesis().is_some() {
+                return willow_state::materialize(&ds.dag);
+            }
             let genesis =
                 ds.dag
                     .create_event(&identity, EventKind::CreateServer { name }, vec![], ts);
             ds.dag
                 .insert(genesis)
                 .expect("genesis event must insert successfully");
+            ds.synced = true;
             willow_state::materialize(&ds.dag)
         })
         .await;
@@ -98,13 +103,27 @@ impl<N: willow_network::Network> ClientMutations<N> {
         let identity = self.identity.clone();
         let ts = util::current_time_ms();
         willow_actor::state::mutate(&self.dag, move |ds| {
+            if !ds.synced {
+                return Err(anyhow::anyhow!(
+                    "cannot create events before sync completes"
+                ));
+            }
             let my_id = identity.endpoint_id();
-            let deps: Vec<EventHash> = ds
+            let mut deps: Vec<EventHash> = ds
                 .dag
                 .authors()
                 .filter(|a| **a != my_id)
                 .filter_map(|a| ds.dag.head(a).copied())
                 .collect();
+
+            // Vote events must causally depend on the proposal so
+            // topological sort always places the proposal first.
+            if let EventKind::Vote { proposal, .. } = &kind {
+                if !deps.contains(proposal) {
+                    deps.push(*proposal);
+                }
+            }
+
             let event = ds.dag.create_event(&identity, kind, deps, ts);
             ds.dag
                 .insert(event.clone())

--- a/crates/client/src/state_actors.rs
+++ b/crates/client/src/state_actors.rs
@@ -168,6 +168,10 @@ pub struct DagState {
     pub dag: willow_state::EventDag,
     /// Buffer for events waiting on missing predecessors.
     pub pending: willow_state::PendingBuffer,
+    /// Whether the DAG has been populated (via genesis seed or sync batch).
+    /// Mutations are blocked until this is `true` so events don't get
+    /// created with empty/incorrect causal dependencies.
+    pub synced: bool,
 }
 
 // ───── Source state bundle ───────────────────────────────────────────────

--- a/crates/replay/src/role.rs
+++ b/crates/replay/src/role.rs
@@ -118,6 +118,12 @@ impl ReplayRole {
                 Err(InsertError::InvalidSignature) => {
                     warn!("rejected event with invalid signature");
                 }
+                Err(InsertError::DuplicateGenesis) => {
+                    warn!("rejected duplicate CreateServer event");
+                }
+                Err(InsertError::MissingGovernanceDep { .. }) => {
+                    warn!("rejected Vote event missing proposal dep");
+                }
             }
         }
     }

--- a/crates/state/src/dag.rs
+++ b/crates/state/src/dag.rs
@@ -32,6 +32,13 @@ pub enum InsertError {
     },
     /// Event with this hash already exists.
     Duplicate,
+    /// A CreateServer event was inserted after genesis already exists.
+    DuplicateGenesis,
+    /// A Vote event does not include the proposal hash in its deps.
+    MissingGovernanceDep {
+        vote: EventHash,
+        proposal: EventHash,
+    },
 }
 
 impl std::fmt::Display for InsertError {
@@ -58,6 +65,13 @@ impl std::fmt::Display for InsertError {
                 "prev mismatch for author {author}: expected {expected}, got {got}"
             ),
             Self::Duplicate => write!(f, "duplicate event"),
+            Self::DuplicateGenesis => {
+                write!(f, "CreateServer event rejected: genesis already exists")
+            }
+            Self::MissingGovernanceDep { vote, proposal } => write!(
+                f,
+                "Vote event {vote} must include proposal {proposal} in deps"
+            ),
         }
     }
 }
@@ -107,6 +121,7 @@ impl EventDag {
         }
 
         // 3. Genesis check: first event must be CreateServer.
+        //    After genesis is set, reject any further CreateServer events.
         if self.genesis_hash.is_none() {
             match &event.kind {
                 EventKind::CreateServer { .. } => {
@@ -121,6 +136,8 @@ impl EventDag {
                 }
                 _ => return Err(InsertError::NotGenesis),
             }
+        } else if matches!(event.kind, EventKind::CreateServer { .. }) {
+            return Err(InsertError::DuplicateGenesis);
         }
 
         // 4. Check seq: must be latest_seq + 1.
@@ -147,7 +164,19 @@ impl EventDag {
             });
         }
 
-        // 6. Insert.
+        // 6. Governance structural checks: Vote events must causally
+        //    depend on their proposal (via deps or prev) so topological
+        //    sort always places the proposal before the vote.
+        if let EventKind::Vote { proposal, .. } = &event.kind {
+            if !event.deps.contains(proposal) && event.prev != *proposal {
+                return Err(InsertError::MissingGovernanceDep {
+                    vote: event.hash,
+                    proposal: *proposal,
+                });
+            }
+        }
+
+        // 7. Insert.
         let hash = event.hash;
         let author = event.author;
         self.events.insert(hash, event);
@@ -440,6 +469,133 @@ mod tests {
         dag.insert(genesis.clone()).unwrap();
         let err = dag.insert(genesis).unwrap_err();
         assert!(matches!(err, InsertError::Duplicate));
+    }
+
+    #[test]
+    fn insert_rejects_second_create_server() {
+        let id = Identity::generate();
+        let mut dag = test_dag(&id);
+        // A second CreateServer event has seq=2 and valid prev, but the
+        // DAG must reject it because genesis already exists.
+        let second = dag.create_event(
+            &id,
+            EventKind::CreateServer {
+                name: "Second Server".into(),
+            },
+            vec![],
+            0,
+        );
+        let err = dag.insert(second).unwrap_err();
+        assert!(matches!(err, InsertError::DuplicateGenesis));
+        // DAG still has only the original genesis.
+        assert_eq!(dag.len(), 1);
+    }
+
+    #[test]
+    fn vote_without_proposal_dep_rejected() {
+        let admin = Identity::generate();
+        let admin_b = Identity::generate();
+        let mut dag = test_dag(&admin);
+
+        // Grant admin_b admin status (sole admin, auto-applies).
+        let grant = dag.create_event(
+            &admin,
+            EventKind::Propose {
+                action: crate::event::ProposedAction::GrantAdmin {
+                    peer_id: admin_b.endpoint_id(),
+                },
+            },
+            vec![],
+            0,
+        );
+        dag.insert(grant).unwrap();
+
+        // Admin proposes something new.
+        let prop = dag.create_event(
+            &admin,
+            EventKind::Propose {
+                action: crate::event::ProposedAction::SetVoteThreshold {
+                    threshold: crate::event::VoteThreshold::Unanimous,
+                },
+            },
+            vec![],
+            0,
+        );
+        dag.insert(prop.clone()).unwrap();
+
+        // admin_b votes WITHOUT proposal in deps — prev is NOT the proposal
+        // (admin_b has no prev events yet), so this must be rejected.
+        let vote = dag.create_event(
+            &admin_b,
+            EventKind::Vote {
+                proposal: prop.hash,
+                accept: true,
+            },
+            vec![], // Missing proposal dep!
+            0,
+        );
+        let err = dag.insert(vote).unwrap_err();
+        assert!(matches!(err, InsertError::MissingGovernanceDep { .. }));
+    }
+
+    #[test]
+    fn vote_with_proposal_dep_accepted() {
+        let admin = Identity::generate();
+        let mut dag = test_dag(&admin);
+        let prop = dag.create_event(
+            &admin,
+            EventKind::Propose {
+                action: crate::event::ProposedAction::GrantAdmin {
+                    peer_id: Identity::generate().endpoint_id(),
+                },
+            },
+            vec![],
+            0,
+        );
+        dag.insert(prop.clone()).unwrap();
+        // Vote WITH proposal in deps — should succeed.
+        let vote = dag.create_event(
+            &admin,
+            EventKind::Vote {
+                proposal: prop.hash,
+                accept: true,
+            },
+            vec![prop.hash],
+            0,
+        );
+        assert!(dag.insert(vote).is_ok());
+    }
+
+    #[test]
+    fn vote_with_proposal_as_prev_accepted() {
+        // If the voter is also the proposer, the proposal is the prev event
+        // (previous event from same author), which also satisfies the causal dep.
+        let admin = Identity::generate();
+        let mut dag = test_dag(&admin);
+        let prop = dag.create_event(
+            &admin,
+            EventKind::Propose {
+                action: crate::event::ProposedAction::GrantAdmin {
+                    peer_id: Identity::generate().endpoint_id(),
+                },
+            },
+            vec![],
+            0,
+        );
+        dag.insert(prop.clone()).unwrap();
+        // The admin's prev is now prop.hash, so even with empty deps it works.
+        assert_eq!(dag.head(&admin.endpoint_id()), Some(&prop.hash));
+        // This vote's prev will be prop.hash, satisfying the governance check.
+        let vote = dag.create_event(
+            &admin,
+            EventKind::Vote {
+                proposal: prop.hash,
+                accept: true,
+            },
+            vec![], // prev == proposal, so this is OK
+            0,
+        );
+        assert!(dag.insert(vote).is_ok());
     }
 
     #[test]

--- a/crates/state/src/event.rs
+++ b/crates/state/src/event.rs
@@ -17,7 +17,7 @@ use crate::hash::EventHash;
 /// [`ProposedAction`] and the vote path. This structural separation makes
 /// it impossible for any peer to grant admin via a direct
 /// [`EventKind::GrantPermission`] event.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Permission {
     /// Can sync/provide full history to other peers.
     SyncProvider,

--- a/crates/state/src/materialize.rs
+++ b/crates/state/src/materialize.rs
@@ -22,6 +22,8 @@ pub enum ApplyResult {
     Applied,
     /// The event was rejected (e.g., insufficient permissions).
     Rejected(String),
+    /// The event was already applied (idempotent dedup).
+    AlreadyApplied,
 }
 
 /// Compute the current server state from the full event DAG.
@@ -40,6 +42,7 @@ pub fn materialize(dag: &EventDag) -> ServerState {
     let sorted = dag.topological_sort();
     let mut state = ServerState::new(&server_id, &name, genesis_author);
     for event in sorted {
+        state.applied_events.insert(event.hash);
         apply_unchecked(&mut state, event);
     }
     state
@@ -50,6 +53,9 @@ pub fn materialize(dag: &EventDag) -> ServerState {
 /// Precondition: all causal parents of `event` are already reflected
 /// in `state`. This is O(1) per event.
 pub fn apply_incremental(state: &mut ServerState, event: &Event) -> ApplyResult {
+    if !state.applied_events.insert(event.hash) {
+        return ApplyResult::AlreadyApplied;
+    }
     apply_unchecked(state, event)
 }
 
@@ -305,7 +311,7 @@ fn apply_mutation(state: &mut ServerState, event: &Event) -> ApplyResult {
                 .peer_permissions
                 .entry(*peer_id)
                 .or_default()
-                .insert(permission.clone());
+                .insert(*permission);
             state.members.entry(*peer_id).or_insert_with(|| Member {
                 peer_id: *peer_id,
                 roles: HashSet::new(),
@@ -872,14 +878,15 @@ mod tests {
                 },
             },
         );
-        // Stranger votes — should be rejected.
-        emit(
+        // Stranger votes — should be rejected (not admin).
+        emit_with_deps(
             &mut dag,
             &stranger,
             EventKind::Vote {
                 proposal: prop.hash,
                 accept: true,
             },
+            vec![prop.hash],
         );
         let state = materialize(&dag);
         // With 1 admin and majority, the proposal auto-applied on Propose.
@@ -1142,13 +1149,14 @@ mod tests {
             },
         );
         // Proposal already passed. Late vote from alice — no crash, no-op.
-        emit(
+        emit_with_deps(
             &mut dag,
             &alice,
             EventKind::Vote {
                 proposal: prop.hash,
                 accept: true,
             },
+            vec![prop.hash],
         );
         let state = materialize(&dag);
         assert!(state.is_admin(&alice.endpoint_id()));

--- a/crates/state/src/server.rs
+++ b/crates/state/src/server.rs
@@ -61,6 +61,13 @@ pub struct ServerState {
     pub vote_threshold: VoteThreshold,
     /// Pending proposals awaiting votes.
     pub pending_proposals: HashMap<EventHash, PendingProposal>,
+
+    // -- Dedup state --
+    /// Hashes of events already applied to this state. Used by
+    /// [`apply_incremental`](crate::materialize::apply_incremental) to
+    /// guarantee idempotency — applying the same event twice is a no-op.
+    #[serde(default, skip)]
+    pub applied_events: HashSet<EventHash>,
 }
 
 impl ServerState {
@@ -95,6 +102,7 @@ impl ServerState {
             description: String::new(),
             channel_keys: HashMap::new(),
             pending_proposals: HashMap::new(),
+            applied_events: HashSet::new(),
         }
     }
 

--- a/crates/state/src/tests.rs
+++ b/crates/state/src/tests.rs
@@ -840,3 +840,234 @@ fn assign_nonexistent_role_is_noop() {
     let member = state.members.get(&admin.endpoint_id());
     assert!(member.map(|m| m.roles.is_empty()).unwrap_or(true));
 }
+
+#[test]
+fn apply_incremental_is_idempotent() {
+    use crate::materialize::apply_incremental;
+
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // Grant SendMessages so admin can react.
+    let msg = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            body: "hello".into(),
+            reply_to: None,
+        },
+    );
+    let reaction = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Reaction {
+            message_id: msg.hash,
+            emoji: "👍".into(),
+        },
+    );
+    let mut state = materialize(&dag);
+
+    // Reaction applied once during materialize.
+    let reactions = &state.messages[0].reactions;
+    assert_eq!(reactions.get("👍").map(|v| v.len()), Some(1));
+
+    // Apply the same reaction event again — should be AlreadyApplied.
+    let result = apply_incremental(&mut state, &reaction);
+    assert_eq!(result, crate::materialize::ApplyResult::AlreadyApplied);
+
+    // Still only 1 reaction (not 2).
+    let reactions = &state.messages[0].reactions;
+    assert_eq!(reactions.get("👍").map(|v| v.len()), Some(1));
+}
+
+#[test]
+fn apply_incremental_dedup_across_messages() {
+    use crate::materialize::apply_incremental;
+
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    let msg = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            body: "hello".into(),
+            reply_to: None,
+        },
+    );
+    let mut state = materialize(&dag);
+    assert_eq!(state.messages.len(), 1);
+
+    // Apply the same message event again — should be AlreadyApplied.
+    let result = apply_incremental(&mut state, &msg);
+    assert_eq!(result, crate::materialize::ApplyResult::AlreadyApplied);
+    assert_eq!(state.messages.len(), 1);
+}
+
+#[test]
+fn all_permission_variants_grant_and_revoke() {
+    let admin = Identity::generate();
+    let peer = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // Grant each of the 5 permission variants to peer.
+    for perm in [
+        Permission::SyncProvider,
+        Permission::ManageChannels,
+        Permission::ManageRoles,
+        Permission::SendMessages,
+        Permission::CreateInvite,
+    ] {
+        do_emit(
+            &mut dag,
+            &admin,
+            EventKind::GrantPermission {
+                peer_id: peer.endpoint_id(),
+                permission: perm,
+            },
+        );
+    }
+    let state = materialize(&dag);
+    assert!(state.has_permission(&peer.endpoint_id(), &Permission::SyncProvider));
+    assert!(state.has_permission(&peer.endpoint_id(), &Permission::ManageChannels));
+    assert!(state.has_permission(&peer.endpoint_id(), &Permission::ManageRoles));
+    assert!(state.has_permission(&peer.endpoint_id(), &Permission::SendMessages));
+    assert!(state.has_permission(&peer.endpoint_id(), &Permission::CreateInvite));
+
+    // Revoke one, verify it's removed while others remain.
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::RevokePermission {
+            peer_id: peer.endpoint_id(),
+            permission: Permission::ManageChannels,
+        },
+    );
+    let state = materialize(&dag);
+    assert!(!state.has_permission(&peer.endpoint_id(), &Permission::ManageChannels));
+    assert!(state.has_permission(&peer.endpoint_id(), &Permission::SyncProvider));
+    assert!(state.has_permission(&peer.endpoint_id(), &Permission::SendMessages));
+}
+
+#[test]
+fn vote_ordering_with_deps_ensures_admin_status() {
+    // Scenario: Admin A proposes granting Alice admin. With 1 admin,
+    // proposal auto-applies. Now Alice proposes something. Because
+    // Alice's proposal includes deps on A's head (which is >= the
+    // propose event that granted Alice admin), the topo sort correctly
+    // places the grant before Alice's proposal.
+    use crate::event::VoteThreshold;
+
+    let admin_a = Identity::generate();
+    let alice = Identity::generate();
+    let mut dag = test_dag(&admin_a);
+
+    // Grant Alice admin (sole admin, auto-applies).
+    let _prop = do_emit(
+        &mut dag,
+        &admin_a,
+        EventKind::Propose {
+            action: ProposedAction::GrantAdmin {
+                peer_id: alice.endpoint_id(),
+            },
+        },
+    );
+    let state = materialize(&dag);
+    assert!(
+        state.is_admin(&alice.endpoint_id()),
+        "Alice should be admin after sole-admin proposal"
+    );
+
+    // Alice proposes a threshold change — include admin_a's head as dep
+    // so the proposal is causally after the grant.
+    let admin_head = *dag.head(&admin_a.endpoint_id()).unwrap();
+    let alice_prop_event = dag.create_event(
+        &alice,
+        EventKind::Propose {
+            action: ProposedAction::SetVoteThreshold {
+                threshold: VoteThreshold::Unanimous,
+            },
+        },
+        vec![admin_head],
+        0,
+    );
+    dag.insert(alice_prop_event.clone()).unwrap();
+
+    let state = materialize(&dag);
+    // Alice's proposal should be accepted because she is admin and
+    // the dep ensures correct ordering.
+    assert!(
+        state.pending_proposals.contains_key(&alice_prop_event.hash),
+        "Alice's proposal should be pending (she is admin)"
+    );
+}
+
+#[test]
+fn second_create_server_rejected_by_dag() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+    let state1 = materialize(&dag);
+
+    // Attempt a second CreateServer — DAG rejects it.
+    let second = dag.create_event(
+        &admin,
+        EventKind::CreateServer {
+            name: "Different".into(),
+        },
+        vec![],
+        0,
+    );
+    let err = dag.insert(second).unwrap_err();
+    assert!(matches!(err, crate::dag::InsertError::DuplicateGenesis));
+
+    // Materialized state is unchanged.
+    let state2 = materialize(&dag);
+    assert_eq!(state1.server_id, state2.server_id);
+    assert_eq!(state1.server_name, state2.server_name);
+}
+
+#[test]
+fn kick_only_via_governance() {
+    // Verify that kicking requires ProposedAction::KickMember vote path.
+    // Granting all 5 permissions does NOT let a non-admin propose a kick.
+    let admin = Identity::generate();
+    let peer = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // Grant all 5 permissions to peer.
+    for perm in [
+        Permission::SyncProvider,
+        Permission::ManageChannels,
+        Permission::ManageRoles,
+        Permission::SendMessages,
+        Permission::CreateInvite,
+    ] {
+        do_emit(
+            &mut dag,
+            &admin,
+            EventKind::GrantPermission {
+                peer_id: peer.endpoint_id(),
+                permission: perm,
+            },
+        );
+    }
+
+    // Peer tries to propose a kick — should be rejected (not admin).
+    let admin_head = *dag.head(&admin.endpoint_id()).unwrap();
+    let e = dag.create_event(
+        &peer,
+        EventKind::Propose {
+            action: ProposedAction::KickMember {
+                peer_id: admin.endpoint_id(),
+            },
+        },
+        vec![admin_head],
+        0,
+    );
+    dag.insert(e).unwrap();
+    let state = materialize(&dag);
+    // Proposal rejected because peer is not admin.
+    assert!(state.pending_proposals.is_empty());
+}

--- a/crates/web/src/components/roles.rs
+++ b/crates/web/src/components/roles.rs
@@ -9,7 +9,6 @@ const PERMISSION_NAMES: &[&str] = &[
     "SyncProvider",
     "ManageChannels",
     "ManageRoles",
-    "KickMembers",
     "SendMessages",
     "CreateInvite",
 ];


### PR DESCRIPTION
## Summary
This PR strengthens the event-sourced state machine by enforcing structural constraints on governance events and implementing idempotent event application. It also consolidates the Permission enum into the state crate as the single source of truth.

## Key Changes

- **Governance structural enforcement**: Vote events must now causally depend on their proposal (via deps or prev) to ensure topological sort always places proposals before votes. The DAG rejects votes missing this dependency with `InsertError::MissingGovernanceDep`.

- **Idempotent event application**: Added `applied_events` tracking to `ServerState` to deduplicate events. `apply_incremental()` now returns `ApplyResult::AlreadyApplied` if an event was already applied, preventing duplicate state mutations.

- **Duplicate genesis prevention**: The DAG now rejects any `CreateServer` event after genesis is established with `InsertError::DuplicateGenesis`.

- **Permission enum consolidation**: Moved the authoritative `Permission` enum from `willow-channel` to `willow-state` and re-exported it. Removed obsolete permissions (`Administrator`, `ReadMessages`, `KickMembers`, `BanMembers`, `VoiceConnect`, `VoiceSpeak`, `ScreenShare`, `AttachFiles`) that were not enforced by the state machine. The five enforced permissions are: `SyncProvider`, `ManageChannels`, `ManageRoles`, `SendMessages`, `CreateInvite`.

- **Sync state tracking**: Added `synced` flag to `DagState` to block mutations until genesis is received. Client mutations now check this flag and set it once genesis is available.

- **Vote dependency enforcement in client**: Client mutations now automatically include proposal hashes in vote event deps to satisfy the governance structural check.

## Implementation Details

- The governance check in `dag.rs` validates that `event.deps.contains(proposal) || event.prev == proposal` for all Vote events before insertion.
- `ServerState::applied_events` is a `HashSet<EventHash>` that persists across materialization but is skipped during serialization (marked with `#[serde(default, skip)]`).
- The `synced` flag prevents race conditions where mutations are attempted before the DAG is populated with genesis.
- UI and test code updated to use only the five enforced permissions.

https://claude.ai/code/session_01Sc2ESTNFgv3ggZ91szxRuL