### PR TITLE
Fix 5 state/DAG bugs with thorough tests

### DIFF
--- a/crates/state/src/dag.rs
+++ b/crates/state/src/dag.rs
@@ -141,6 +141,10 @@ impl EventDag {
         }
 
         // 4. Check seq: must be latest_seq + 1.
+        //    This also prevents equivocation: an author cannot insert two
+        //    events at the same seq number because only seq = latest + 1
+        //    is accepted. Combined with the prev-hash check below, this
+        //    makes per-author chain forking structurally impossible.
         let expected_seq = self.latest_seq(&event.author) + 1;
         if event.seq != expected_seq {
             return Err(InsertError::SeqGap {
@@ -342,6 +346,17 @@ impl EventDag {
                 }
             }
         }
+
+        // Cycle detection: if any events remain unprocessed, a cycle exists.
+        // Normal insert() prevents cycles via seq/prev chain checks, so this
+        // is a defensive invariant against data corruption.
+        assert_eq!(
+            result.len(),
+            self.events.len(),
+            "Cycle detected in DAG: {} of {} events unprocessable",
+            self.events.len() - result.len(),
+            self.events.len()
+        );
 
         result
     }

--- a/crates/state/src/materialize.rs
+++ b/crates/state/src/materialize.rs
@@ -90,8 +90,13 @@ fn apply_unchecked(state: &mut ServerState, event: &Event) -> ApplyResult {
             if !state.is_admin(&event.author) {
                 return ApplyResult::Rejected("not an admin".into());
             }
-            if let Some(prop) = state.pending_proposals.get_mut(proposal) {
-                prop.votes.insert(event.author, *accept);
+            match state.pending_proposals.get_mut(proposal) {
+                Some(prop) => {
+                    prop.votes.insert(event.author, *accept);
+                }
+                None => {
+                    return ApplyResult::Rejected(format!("proposal {} not found", proposal));
+                }
             }
             check_and_apply_proposal(state, proposal);
             return ApplyResult::Applied;
@@ -160,10 +165,18 @@ fn apply_proposed_action(state: &mut ServerState, action: &ProposedAction) {
             });
         }
         ProposedAction::RevokeAdmin { peer_id } => {
+            // Prevent 0-admin state — server becomes permanently ungovernable.
+            if state.admins.len() == 1 && state.admins.contains(peer_id) {
+                return;
+            }
             state.admins.remove(peer_id);
             cleanup_votes_and_reevaluate(state, peer_id);
         }
         ProposedAction::KickMember { peer_id } => {
+            // Prevent 0-admin state — server becomes permanently ungovernable.
+            if state.admins.len() == 1 && state.admins.contains(peer_id) {
+                return;
+            }
             state.members.remove(peer_id);
             state.peer_permissions.remove(peer_id);
             state.admins.remove(peer_id);
@@ -393,10 +406,11 @@ fn apply_mutation(state: &mut ServerState, event: &Event) -> ApplyResult {
             channel_id,
             encrypted_keys,
         } => {
-            if let Some((_, key_bytes)) = encrypted_keys.first() {
-                state
-                    .channel_keys
-                    .insert(channel_id.clone(), key_bytes.clone());
+            if !encrypted_keys.is_empty() {
+                let keys = state.channel_keys.entry(channel_id.clone()).or_default();
+                for (peer_id, key_bytes) in encrypted_keys {
+                    keys.insert(*peer_id, key_bytes.clone());
+                }
             }
         }
 

--- a/crates/state/src/server.rs
+++ b/crates/state/src/server.rs
@@ -50,8 +50,9 @@ pub struct ServerState {
     pub profiles: HashMap<EndpointId, Profile>,
     /// Server description.
     pub description: String,
-    /// Encrypted channel key material keyed by channel ID.
-    pub channel_keys: HashMap<String, Vec<u8>>,
+    /// Encrypted channel key material: channel ID → (recipient → encrypted key).
+    /// Each recipient gets their own encrypted copy of the channel key.
+    pub channel_keys: HashMap<String, HashMap<EndpointId, Vec<u8>>>,
 
     // -- Governance state --
     /// The set of peers with admin status. Separate from Permission

--- a/crates/state/src/tests.rs
+++ b/crates/state/src/tests.rs
@@ -715,6 +715,8 @@ fn rotate_channel_key_stores_key_material() {
 
     let state = materialize(&dag);
     assert!(state.channel_keys.contains_key("ch-1"));
+    let keys = &state.channel_keys["ch-1"];
+    assert_eq!(keys[&admin.endpoint_id()], vec![1, 2, 3]);
 }
 
 #[test]
@@ -1070,4 +1072,679 @@ fn kick_only_via_governance() {
     let state = materialize(&dag);
     // Proposal rejected because peer is not admin.
     assert!(state.pending_proposals.is_empty());
+}
+
+// ── Issue #69: Last admin cannot self-kick/revoke ────────────────────
+
+#[test]
+fn last_admin_cannot_self_kick() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // Sole admin proposes self-kick. With majority threshold (1/1),
+    // the proposer's implicit yes vote auto-applies immediately.
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Propose {
+            action: ProposedAction::KickMember {
+                peer_id: admin.endpoint_id(),
+            },
+        },
+    );
+
+    let state = materialize(&dag);
+    // Admin must still be present — 0-admin state is unreachable.
+    assert!(state.admins.contains(&admin.endpoint_id()));
+    assert_eq!(state.admins.len(), 1);
+    // Member should also still be present (kick was blocked).
+    assert!(state.members.contains_key(&admin.endpoint_id()));
+}
+
+#[test]
+fn last_admin_cannot_self_revoke() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Propose {
+            action: ProposedAction::RevokeAdmin {
+                peer_id: admin.endpoint_id(),
+            },
+        },
+    );
+
+    let state = materialize(&dag);
+    assert!(state.admins.contains(&admin.endpoint_id()));
+    assert_eq!(state.admins.len(), 1);
+}
+
+#[test]
+fn second_to_last_admin_can_be_kicked() {
+    let admin_a = Identity::generate();
+    let mut dag = test_dag(&admin_a);
+
+    // While sole admin, set threshold to Count(1) so future proposals
+    // auto-apply with a single vote.
+    do_emit(
+        &mut dag,
+        &admin_a,
+        EventKind::Propose {
+            action: ProposedAction::SetVoteThreshold {
+                threshold: crate::event::VoteThreshold::Count(1),
+            },
+        },
+    );
+
+    // Grant admin to B (auto-applies with Count(1)).
+    let admin_b = Identity::generate();
+    do_emit(
+        &mut dag,
+        &admin_a,
+        EventKind::Propose {
+            action: ProposedAction::GrantAdmin {
+                peer_id: admin_b.endpoint_id(),
+            },
+        },
+    );
+
+    let state = materialize(&dag);
+    assert_eq!(state.admins.len(), 2);
+
+    // Now A proposes to kick B. With Count(1), A's implicit yes auto-applies.
+    do_emit(
+        &mut dag,
+        &admin_a,
+        EventKind::Propose {
+            action: ProposedAction::KickMember {
+                peer_id: admin_b.endpoint_id(),
+            },
+        },
+    );
+
+    let state = materialize(&dag);
+    // B should be kicked, A remains as sole admin.
+    assert_eq!(state.admins.len(), 1);
+    assert!(state.admins.contains(&admin_a.endpoint_id()));
+    assert!(!state.members.contains_key(&admin_b.endpoint_id()));
+}
+
+// ── Issue #70: Topological sort cycle detection ──────────────────────
+
+#[test]
+fn topological_sort_covers_all_events() {
+    let admin = Identity::generate();
+    let alice = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // Create events from multiple authors with cross-deps.
+    let a1 = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "a1".into(),
+        },
+    );
+    // Alice's first event depends on admin's message.
+    let b1 = dag.create_event(
+        &alice,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "b1".into(),
+        },
+        vec![a1.hash],
+        0,
+    );
+    dag.insert(b1).unwrap();
+
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "a2".into(),
+        },
+    );
+
+    let sorted = dag.topological_sort();
+    assert_eq!(sorted.len(), dag.len());
+}
+
+#[test]
+fn topological_sort_diamond_pattern() {
+    // Diamond: genesis → A1, genesis → B1(dep=A1), genesis → C1(dep=A1),
+    //          then D1(deps=[B1,C1]) — D must come last.
+    let admin = Identity::generate();
+    let bob = Identity::generate();
+    let carol = Identity::generate();
+    let dave = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    let a1 = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "a1".into(),
+        },
+    );
+
+    // Bob depends on A1.
+    let b1 = dag.create_event(
+        &bob,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "b1".into(),
+        },
+        vec![a1.hash],
+        0,
+    );
+    dag.insert(b1.clone()).unwrap();
+
+    // Carol depends on A1.
+    let c1 = dag.create_event(
+        &carol,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "c1".into(),
+        },
+        vec![a1.hash],
+        0,
+    );
+    dag.insert(c1.clone()).unwrap();
+
+    // Dave depends on both B1 and C1 (diamond join).
+    let d1 = dag.create_event(
+        &dave,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "d1".into(),
+        },
+        vec![b1.hash, c1.hash],
+        0,
+    );
+    dag.insert(d1.clone()).unwrap();
+
+    let sorted = dag.topological_sort();
+    assert_eq!(sorted.len(), dag.len()); // All 5 events processed (genesis + 4).
+
+    // D1 must come after both B1 and C1.
+    let pos = |hash: EventHash| sorted.iter().position(|e| e.hash == hash).unwrap();
+    assert!(pos(d1.hash) > pos(b1.hash));
+    assert!(pos(d1.hash) > pos(c1.hash));
+    // B1 and C1 both after A1.
+    assert!(pos(b1.hash) > pos(a1.hash));
+    assert!(pos(c1.hash) > pos(a1.hash));
+}
+
+#[test]
+fn topological_sort_deep_chain() {
+    // 6-event causal chain across 3 authors: A1→B1→C1→A2→B2→C2
+    let admin = Identity::generate();
+    let bob = Identity::generate();
+    let carol = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    let a1 = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "a1".into(),
+        },
+    );
+    let b1 = dag.create_event(
+        &bob,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "b1".into(),
+        },
+        vec![a1.hash],
+        0,
+    );
+    dag.insert(b1.clone()).unwrap();
+
+    let c1 = dag.create_event(
+        &carol,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "c1".into(),
+        },
+        vec![b1.hash],
+        0,
+    );
+    dag.insert(c1.clone()).unwrap();
+
+    let a2 = dag.create_event(
+        &admin,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "a2".into(),
+        },
+        vec![c1.hash],
+        0,
+    );
+    dag.insert(a2.clone()).unwrap();
+
+    let b2 = dag.create_event(
+        &bob,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "b2".into(),
+        },
+        vec![a2.hash],
+        0,
+    );
+    dag.insert(b2.clone()).unwrap();
+
+    let c2 = dag.create_event(
+        &carol,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "c2".into(),
+        },
+        vec![b2.hash],
+        0,
+    );
+    dag.insert(c2.clone()).unwrap();
+
+    let sorted = dag.topological_sort();
+    assert_eq!(sorted.len(), dag.len()); // genesis + 6 = 7
+
+    // Verify strict causal ordering.
+    let pos = |hash: EventHash| sorted.iter().position(|e| e.hash == hash).unwrap();
+    assert!(pos(a1.hash) < pos(b1.hash));
+    assert!(pos(b1.hash) < pos(c1.hash));
+    assert!(pos(c1.hash) < pos(a2.hash));
+    assert!(pos(a2.hash) < pos(b2.hash));
+    assert!(pos(b2.hash) < pos(c2.hash));
+}
+
+// ── Issue #71: Equivocation rejected at insert ───────────────────────
+
+#[test]
+fn equivocation_rejected_at_insert() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // Insert first event at seq=2.
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "first".into(),
+        },
+    );
+
+    // Attempt equivocation: different event at seq=2 (but DAG expects seq=3).
+    let equivocating = Event::new(
+        &admin,
+        2,               // same seq as the event we just inserted
+        EventHash::ZERO, // wrong prev — doesn't matter, seq check fires first
+        vec![],
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "equivocation".into(),
+        },
+        999,
+    );
+    let err = dag.insert(equivocating).unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::dag::InsertError::SeqGap {
+                expected: 3,
+                got: 2,
+                ..
+            }
+        ),
+        "Expected SeqGap(expected=3, got=2), got: {err:?}"
+    );
+}
+
+#[test]
+fn equivocation_after_gap_rejected() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // Build chain: genesis(seq=1) → msg(seq=2) → msg(seq=3).
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "m1".into(),
+        },
+    );
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "m2".into(),
+        },
+    );
+
+    // Try inserting at seq=2 (already occupied).
+    let bad = Event::new(
+        &admin,
+        2,
+        EventHash::ZERO,
+        vec![],
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "sneaky".into(),
+        },
+        999,
+    );
+    let err = dag.insert(bad).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::dag::InsertError::SeqGap {
+            expected: 4,
+            got: 2,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn new_author_seq_gap_rejected() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // New author tries to insert at seq=3, skipping 1 and 2.
+    let stranger = Identity::generate();
+    let bad = Event::new(
+        &stranger,
+        3,
+        EventHash::ZERO,
+        vec![],
+        EventKind::Message {
+            channel_id: "ch".into(),
+            reply_to: None,
+            body: "skip".into(),
+        },
+        0,
+    );
+    let err = dag.insert(bad).unwrap_err();
+    assert!(matches!(
+        err,
+        crate::dag::InsertError::SeqGap {
+            expected: 1,
+            got: 3,
+            ..
+        }
+    ));
+}
+
+// ── Issue #72: Vote on missing proposal ──────────────────────────────
+
+#[test]
+fn vote_on_missing_proposal_rejected() {
+    use crate::materialize::apply_incremental;
+
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // Create a vote referencing a non-existent proposal hash.
+    let fake_proposal = EventHash::ZERO;
+    let vote = dag.create_event(
+        &admin,
+        EventKind::Vote {
+            proposal: fake_proposal,
+            accept: true,
+        },
+        vec![fake_proposal], // include in deps to satisfy governance check
+        0,
+    );
+    dag.insert(vote.clone()).unwrap();
+
+    // Apply incrementally and verify rejection.
+    let genesis = dag.genesis().unwrap().clone();
+    let mut state =
+        crate::server::ServerState::new(dag.server_id().unwrap(), "Test", genesis.author);
+    let _ = apply_incremental(&mut state, &genesis);
+    let result = apply_incremental(&mut state, &vote);
+    assert!(
+        matches!(result, crate::materialize::ApplyResult::Rejected(ref msg) if msg.contains("not found")),
+        "Expected Rejected with 'not found', got: {result:?}"
+    );
+}
+
+#[test]
+fn vote_on_already_applied_proposal_is_safe() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // Create a proposal that auto-applies (sole admin, majority 1/1).
+    let alice = Identity::generate();
+    let prop = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Propose {
+            action: ProposedAction::GrantAdmin {
+                peer_id: alice.endpoint_id(),
+            },
+        },
+    );
+
+    // Now alice (newly admin) votes on the already-applied proposal.
+    let vote = dag.create_event(
+        &alice,
+        EventKind::Vote {
+            proposal: prop.hash,
+            accept: true,
+        },
+        vec![prop.hash],
+        0,
+    );
+    dag.insert(vote).unwrap();
+
+    // Full materialize should not crash.
+    let state = materialize(&dag);
+    // Alice should be admin (proposal already applied).
+    assert!(state.admins.contains(&alice.endpoint_id()));
+}
+
+#[test]
+fn multi_admin_kick_requires_majority_vote() {
+    // With 2 admins, a kick proposal needs both votes (majority > 1).
+    let admin_a = Identity::generate();
+    let mut dag = test_dag(&admin_a);
+
+    // Grant admin to B (auto-applies, sole admin majority).
+    let admin_b = Identity::generate();
+    do_emit(
+        &mut dag,
+        &admin_a,
+        EventKind::Propose {
+            action: ProposedAction::GrantAdmin {
+                peer_id: admin_b.endpoint_id(),
+            },
+        },
+    );
+
+    let state = materialize(&dag);
+    assert_eq!(state.admins.len(), 2);
+
+    // Add target as member.
+    let target = Identity::generate();
+    do_emit(
+        &mut dag,
+        &admin_a,
+        EventKind::GrantPermission {
+            peer_id: target.endpoint_id(),
+            permission: Permission::SendMessages,
+        },
+    );
+
+    // A proposes to kick target — 1/2 votes, stays pending.
+    let kick_prop = dag.create_event(
+        &admin_a,
+        EventKind::Propose {
+            action: ProposedAction::KickMember {
+                peer_id: target.endpoint_id(),
+            },
+        },
+        vec![],
+        0,
+    );
+    dag.insert(kick_prop.clone()).unwrap();
+
+    let state = materialize(&dag);
+    assert!(state.pending_proposals.contains_key(&kick_prop.hash));
+    assert!(state.members.contains_key(&target.endpoint_id()));
+
+    // B votes yes → 2/2 = passes majority.
+    let vote_b = dag.create_event(
+        &admin_b,
+        EventKind::Vote {
+            proposal: kick_prop.hash,
+            accept: true,
+        },
+        vec![kick_prop.hash],
+        0,
+    );
+    dag.insert(vote_b).unwrap();
+
+    let state = materialize(&dag);
+    // Kick applied — target removed.
+    assert!(!state.members.contains_key(&target.endpoint_id()));
+    // Proposal consumed.
+    assert!(!state.pending_proposals.contains_key(&kick_prop.hash));
+    // Both admins still present.
+    assert_eq!(state.admins.len(), 2);
+}
+
+// ── Issue #73: RotateChannelKey multi-recipient ──────────────────────
+
+#[test]
+fn rotate_channel_key_stores_all_recipients() {
+    let admin = Identity::generate();
+    let alice = Identity::generate();
+    let bob = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::RotateChannelKey {
+            channel_id: "ch-1".to_string(),
+            encrypted_keys: vec![
+                (admin.endpoint_id(), vec![1, 2, 3]),
+                (alice.endpoint_id(), vec![4, 5, 6]),
+                (bob.endpoint_id(), vec![7, 8, 9]),
+            ],
+        },
+    );
+
+    let state = materialize(&dag);
+    let keys = &state.channel_keys["ch-1"];
+    assert_eq!(keys.len(), 3);
+    assert_eq!(keys[&admin.endpoint_id()], vec![1, 2, 3]);
+    assert_eq!(keys[&alice.endpoint_id()], vec![4, 5, 6]);
+    assert_eq!(keys[&bob.endpoint_id()], vec![7, 8, 9]);
+}
+
+#[test]
+fn rotate_channel_key_overwrites_on_second_rotation() {
+    let admin = Identity::generate();
+    let alice = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // First rotation.
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::RotateChannelKey {
+            channel_id: "ch-1".to_string(),
+            encrypted_keys: vec![
+                (admin.endpoint_id(), vec![1, 1, 1]),
+                (alice.endpoint_id(), vec![2, 2, 2]),
+            ],
+        },
+    );
+
+    // Second rotation with new keys (and alice removed).
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::RotateChannelKey {
+            channel_id: "ch-1".to_string(),
+            encrypted_keys: vec![(admin.endpoint_id(), vec![9, 9, 9])],
+        },
+    );
+
+    let state = materialize(&dag);
+    let keys = &state.channel_keys["ch-1"];
+    // Admin's key overwritten with new value.
+    assert_eq!(keys[&admin.endpoint_id()], vec![9, 9, 9]);
+    // Alice's old key still present (rotation adds/overwrites, doesn't clear).
+    assert_eq!(keys[&alice.endpoint_id()], vec![2, 2, 2]);
+}
+
+#[test]
+fn rotate_channel_key_empty_keys_is_noop() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::RotateChannelKey {
+            channel_id: "ch-1".to_string(),
+            encrypted_keys: vec![],
+        },
+    );
+
+    let state = materialize(&dag);
+    // No entry created for empty key rotation.
+    assert!(!state.channel_keys.contains_key("ch-1"));
+}
+
+#[test]
+fn rotate_channel_key_for_nonexistent_channel() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // No CreateChannel — keys stored independently.
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::RotateChannelKey {
+            channel_id: "nonexistent".to_string(),
+            encrypted_keys: vec![(admin.endpoint_id(), vec![42])],
+        },
+    );
+
+    let state = materialize(&dag);
+    assert!(state.channels.is_empty());
+    assert!(state.channel_keys.contains_key("nonexistent"));
+    assert_eq!(
+        state.channel_keys["nonexistent"][&admin.endpoint_id()],
+        vec![42]
+    );
 }


### PR DESCRIPTION
## Summary

Fixes 5 pure state-machine bugs, all targeting the root cause so invalid state is structurally unreachable. Adds 16 new tests proving correctness.

- **#69** — Last admin can no longer self-kick/revoke. Guard in `apply_proposed_action()` (the only admin-removal path) prevents 0-admin state, which would permanently freeze governance.
- **#70** — `topological_sort()` now asserts all events are processed, panicking on cycle detection. Normal `insert()` prevents cycles via seq/prev checks; this is a defensive invariant against data corruption.
- **#71** — Equivocation is already structurally prevented by seq+prev checks in `insert()`. Added clarifying comment documenting this guarantee and 3 tests proving it.
- **#72** — Vote on a non-existent proposal now returns `Rejected` instead of silently returning `Applied`. Fix at `apply_unchecked()` where the silent drop occurred.
- **#73** — `channel_keys` type changed from `HashMap<String, Vec<u8>>` to `HashMap<String, HashMap<EndpointId, Vec<u8>>>`, making it structurally impossible to lose per-recipient keys during `RotateChannelKey`.

Closes #69, closes #70, closes #71, closes #72, closes #73

## Test plan

- [x] 3 last-admin tests: self-kick blocked, self-revoke blocked, non-last admin can still be kicked
- [x] 3 topo sort tests: all events processed, diamond pattern ordering, deep 6-event causal chain
- [x] 3 equivocation tests: same-seq rejected, after-gap rejected, new-author seq gap rejected
- [x] 3 vote tests: missing proposal rejected, already-applied proposal safe, multi-admin kick flow
- [x] 4 channel key tests: all recipients stored, overwrite on re-rotation, empty keys no-op, nonexistent channel
- [x] All 133 willow-state tests pass
- [x] `cargo fmt` clean, `cargo clippy` zero warnings

https://claude.ai/code/session_01NHc9U9pCo36SGcEG7JzNKz