### PR TITLE
Fix 4 event handling bugs: silent drops, memory leaks, stuck buffers (#50, #51, #52, #75)

### DIFF
--- a/crates/client/src/listeners.rs
+++ b/crates/client/src/listeners.rs
@@ -130,16 +130,32 @@ async fn try_insert_event(ctx: &ListenerCtx, event: willow_state::Event) {
     let (applied, resolved) =
         willow_actor::state::mutate(&ctx.dag, move |ds| match ds.dag.insert(event.clone()) {
             Ok(()) => {
-                let resolved = ds.pending.resolve(&event.hash);
+                let mut resolved = ds.pending.resolve(&event.hash);
+                // If this was genesis, also resolve events buffered under ZERO
+                // (new authors whose first events arrived before genesis).
+                if matches!(event.kind, willow_state::EventKind::CreateServer { .. }) {
+                    resolved.extend(ds.pending.resolve(&willow_state::EventHash::ZERO));
+                }
                 (Some(event), resolved)
             }
-            Err(InsertError::SeqGap { .. }) | Err(InsertError::PrevMismatch { .. }) => {
+            Err(InsertError::SeqGap { .. }) | Err(InsertError::NotGenesis) => {
                 ds.pending.buffer_for_prev(event.prev, event);
+                (None, vec![])
+            }
+            Err(InsertError::PrevMismatch {
+                author,
+                expected,
+                got,
+            }) => {
+                tracing::warn!(
+                    %author, %expected, %got,
+                    "PrevMismatch: equivocation or conflicting chain — dropping event"
+                );
                 (None, vec![])
             }
             Err(InsertError::Duplicate) => (None, vec![]),
             Err(err) => {
-                eprintln!("DAG insert error: {err}");
+                tracing::warn!("DAG insert error: {err}");
                 (None, vec![])
             }
         })

--- a/crates/client/src/mutations.rs
+++ b/crates/client/src/mutations.rs
@@ -190,6 +190,10 @@ impl<N: willow_network::Network> ClientMutations<N> {
     pub(crate) fn broadcast_on_topic(&self, topic: &str, data: Vec<u8>) {
         let topics = self.topics.read().unwrap_or_else(|e| e.into_inner());
         let Some(handle) = topics.get(topic).cloned() else {
+            tracing::warn!(
+                topic,
+                "broadcast_on_topic: topic not subscribed, message dropped"
+            );
             return;
         };
         drop(topics);

--- a/crates/replay/src/role.rs
+++ b/crates/replay/src/role.rs
@@ -8,8 +8,8 @@ use std::collections::HashMap;
 
 use tracing::warn;
 use willow_state::{
-    apply_incremental, Event, EventDag, EventKind, HeadsSummary, InsertError, PendingBuffer,
-    ServerState, Snapshot,
+    apply_incremental, Event, EventDag, EventHash, EventKind, HeadsSummary, InsertError,
+    PendingBuffer, ServerState, Snapshot,
 };
 use willow_worker::{WorkerRequest, WorkerResponse, WorkerRole, WorkerRoleInfo};
 
@@ -95,7 +95,12 @@ impl ReplayRole {
             match data.dag.insert(current.clone()) {
                 Ok(()) => {
                     apply_incremental(&mut data.state, &current);
-                    let resolved = data.pending.resolve(&hash);
+                    let mut resolved = data.pending.resolve(&hash);
+                    // If this was genesis, also drain events buffered under ZERO
+                    // (pre-genesis events from other authors with prev=ZERO).
+                    if matches!(current.kind, EventKind::CreateServer { .. }) {
+                        resolved.extend(data.pending.resolve(&EventHash::ZERO));
+                    }
                     queue.extend(resolved);
                 }
                 Err(InsertError::SeqGap { .. }) => {
@@ -780,5 +785,56 @@ mod tests {
         role.ingest_event("srv-1", &genesis);
         assert_eq!(role.servers["srv-1"].dag.len(), 2); // genesis + msg
         assert_eq!(role.servers["srv-1"].pending.pending_count(), 0);
+    }
+
+    /// Issue #51: A second author's first event (prev=ZERO) arrives before
+    /// genesis. It gets buffered under EventHash::ZERO. When genesis is
+    /// inserted, resolve() is called with genesis.hash — not ZERO — so the
+    /// second author's event stays stuck forever.
+    #[test]
+    fn pre_genesis_event_from_second_author_resolves_after_genesis() {
+        let mut role = ReplayRole::new(ReplayConfig::default());
+        let owner = Identity::generate();
+        let member = Identity::generate();
+
+        // Second author's first event (seq=1, prev=ZERO).
+        let member_event = make_dag_event(
+            &member,
+            1,
+            EventHash::ZERO,
+            EventKind::SetProfile {
+                display_name: "member".into(),
+            },
+        );
+
+        // Genesis from owner.
+        let genesis = Event::new(
+            &owner,
+            1,
+            EventHash::ZERO,
+            vec![],
+            EventKind::CreateServer {
+                name: "srv-1".to_string(),
+            },
+            0,
+        );
+
+        // Deliver member event FIRST (before genesis).
+        role.ingest_event("srv-1", &member_event);
+        assert_eq!(role.servers["srv-1"].dag.len(), 0);
+        assert_eq!(role.servers["srv-1"].pending.pending_count(), 1);
+
+        // Now deliver genesis — should resolve the member's ZERO-buffered event.
+        role.ingest_event("srv-1", &genesis);
+        assert_eq!(
+            role.servers["srv-1"].dag.len(),
+            2,
+            "both genesis and member event should be in DAG"
+        );
+        assert_eq!(
+            role.servers["srv-1"].pending.pending_count(),
+            0,
+            "no events should remain pending"
+        );
     }
 }

--- a/crates/state/src/sync.rs
+++ b/crates/state/src/sync.rs
@@ -521,6 +521,135 @@ mod tests {
         assert_eq!(resolved_b[0].hash, event_c.hash);
     }
 
+    // ── Issue #51: ZERO-buffered events must resolve after genesis ──
+
+    #[test]
+    fn resolve_zero_drains_pre_genesis_events() {
+        let mut buf = PendingBuffer::new();
+        let id = Identity::generate();
+
+        // Simulate a second author's first event (prev=ZERO) arriving
+        // before genesis. It gets buffered under EventHash::ZERO.
+        let event = Event::new(
+            &id,
+            1,
+            EventHash::ZERO,
+            vec![],
+            EventKind::SetProfile {
+                display_name: "newcomer".into(),
+            },
+            0,
+        );
+        buf.buffer_for_prev(EventHash::ZERO, event.clone());
+        assert_eq!(buf.pending_count(), 1);
+
+        // Resolving with a genesis hash (not ZERO) should NOT return it.
+        let genesis_hash = EventHash::from_bytes(b"genesis-hash");
+        let resolved = buf.resolve(&genesis_hash);
+        assert_eq!(resolved.len(), 0, "should not resolve under genesis hash");
+        assert_eq!(buf.pending_count(), 1, "event should still be pending");
+
+        // Resolving with ZERO should return it.
+        let resolved = buf.resolve(&EventHash::ZERO);
+        assert_eq!(resolved.len(), 1, "should resolve under ZERO");
+        assert_eq!(resolved[0].hash, event.hash);
+        assert_eq!(buf.pending_count(), 0);
+    }
+
+    // ── Issue #50: NotGenesis events can be buffered and recovered ──
+
+    #[test]
+    fn buffer_not_genesis_then_resolve_after_genesis() {
+        let owner = Identity::generate();
+        let member = Identity::generate();
+        let mut dag = EventDag::new();
+        let mut buf = PendingBuffer::new();
+
+        // A non-CreateServer event arrives first → NotGenesis.
+        let member_event = Event::new(
+            &member,
+            1,
+            EventHash::ZERO,
+            vec![],
+            EventKind::SetProfile {
+                display_name: "member".into(),
+            },
+            0,
+        );
+        let err = dag.insert(member_event.clone()).unwrap_err();
+        assert!(
+            matches!(err, crate::dag::InsertError::NotGenesis),
+            "should get NotGenesis error"
+        );
+
+        // Buffer under prev (ZERO), same as the fix will do.
+        buf.buffer_for_prev(member_event.prev, member_event.clone());
+
+        // Now genesis arrives and succeeds.
+        let genesis = Event::new(
+            &owner,
+            1,
+            EventHash::ZERO,
+            vec![],
+            EventKind::CreateServer { name: "srv".into() },
+            0,
+        );
+        dag.insert(genesis.clone()).unwrap();
+
+        // Resolve events buffered under the genesis hash — should be empty.
+        let resolved = buf.resolve(&genesis.hash);
+        assert_eq!(resolved.len(), 0);
+
+        // Resolve ZERO — should return the member event.
+        let resolved = buf.resolve(&EventHash::ZERO);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].hash, member_event.hash);
+
+        // The resolved event should now insert successfully.
+        dag.insert(resolved[0].clone()).unwrap();
+        assert_eq!(dag.len(), 2);
+    }
+
+    // ── Issue #52: PrevMismatch is equivocation, not a chain gap ──
+
+    #[test]
+    fn prev_mismatch_indicates_equivocation_not_gap() {
+        let owner = Identity::generate();
+        let mut dag = test_dag(&owner);
+
+        // Create a legitimate event to establish the chain.
+        let e1 = dag.create_event(
+            &owner,
+            EventKind::SetProfile {
+                display_name: "v1".into(),
+            },
+            vec![],
+            0,
+        );
+        dag.insert(e1.clone()).unwrap();
+
+        // Create a competing event with correct seq (3) but pointing
+        // to genesis as prev instead of e1 — this is equivocation.
+        let genesis_hash = dag.genesis().unwrap().hash;
+        let competing = Event::new(
+            &owner,
+            3,
+            genesis_hash, // wrong prev — should be e1.hash
+            vec![],
+            EventKind::SetProfile {
+                display_name: "equivocating".into(),
+            },
+            0,
+        );
+        let err = dag.insert(competing).unwrap_err();
+        assert!(
+            matches!(err, crate::dag::InsertError::PrevMismatch { .. }),
+            "should get PrevMismatch, not SeqGap: got {err:?}"
+        );
+        // PrevMismatch events should be DROPPED (not buffered) because
+        // the predecessor they reference will never become the head.
+    }
+
     // ── Corrective events test ─────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes four tightly-related bugs in the event insertion pipeline (client listener + replay node) that caused silent data loss, unbounded memory growth, and invisible broadcast failures.

- **Fixes #50**: Buffer `NotGenesis` events in client instead of dropping them, and resolve `EventHash::ZERO` after genesis insertion so pre-genesis events from other authors are recovered
- **Fixes #51**: Resolve `EventHash::ZERO` after genesis in replay node's `try_insert()` so second-author events (`prev=ZERO`) don't stay permanently stuck in `PendingBuffer`
- **Fixes #52**: Split `PrevMismatch` from `SeqGap` in client listener — `PrevMismatch` indicates equivocation (unreachable predecessor) and is now dropped with a warning instead of buffered indefinitely (memory leak)
- **Fixes #75**: Add `tracing::warn!` when `broadcast_on_topic` can't find the topic, making silent message drops visible in logs

## Changes

### `crates/client/src/listeners.rs`
- `NotGenesis` errors now buffered for retry (was silently dropped)
- `PrevMismatch` errors now dropped with warning (was buffered forever — memory leak)
- Genesis insertion now resolves `EventHash::ZERO` to recover pre-genesis events from other authors
- Replaced `eprintln!` with `tracing::warn!` for consistency

### `crates/replay/src/role.rs`
- Genesis insertion now also calls `pending.resolve(&EventHash::ZERO)` to drain pre-genesis events from second authors

### `crates/client/src/mutations.rs`
- `broadcast_on_topic` now logs a warning when topic is not subscribed instead of failing silently

### `crates/state/src/sync.rs` (tests)
- `resolve_zero_drains_pre_genesis_events` — confirms ZERO-keyed buffer behavior
- `buffer_not_genesis_then_resolve_after_genesis` — full lifecycle of pre-genesis event recovery
- `prev_mismatch_indicates_equivocation_not_gap` — documents PrevMismatch vs SeqGap distinction

### `crates/replay/src/role.rs` (tests)
- `pre_genesis_event_from_second_author_resolves_after_genesis` — end-to-end: second author event arrives before genesis, resolves after

## Test plan

- [x] 4 new targeted tests all passing
- [x] All 596 workspace tests passing
- [x] Clippy clean (0 warnings)
- [x] `cargo fmt` clean

https://claude.ai/code/session_0138RSFb9mykD86ySfP8s4am