### PR TITLE
Fix 4 bugs: bincode OOM, replay bounds, dropped ops events, stale switch_server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6204,6 +6204,7 @@ name = "willow-worker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode",
  "bytes",
  "clap",

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -701,6 +701,7 @@ pub fn test_client() -> (
     // atomically initialized together.
     let mut dag_state = state_actors::DagState {
         managed: willow_state::ManagedDag::new(&identity, "Test Server", 5000),
+        stashed: HashMap::new(),
     };
 
     // Create the general channel in the DAG so it's part of the
@@ -973,5 +974,41 @@ mod tests {
         let id2 = client.peer_id();
         assert_eq!(id1, id2);
         assert!(!id1.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn switch_server_updates_event_state() {
+        let (client, _rx) = test_client();
+        // test_client creates one server. Get its ID.
+        let server1_id = client.active_server_id().await.unwrap();
+
+        // Create a second server (this switches active to server2).
+        let server2_id = client.create_server("Second Server").await.unwrap();
+        assert_ne!(server1_id, server2_id);
+
+        // Send a message on server2.
+        client
+            .send_message("general", "hello server2")
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Verify the message is on the current (server2) state.
+        let msgs = client.messages("general").await;
+        assert!(
+            msgs.iter().any(|m| m.body == "hello server2"),
+            "message should be on server2"
+        );
+
+        // Switch back to server1.
+        client.switch_server(&server1_id).await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // After switching, messages should NOT contain server2's message.
+        let msgs = client.messages("general").await;
+        assert!(
+            msgs.iter().all(|m| m.body != "hello server2"),
+            "server1 should not have server2's messages"
+        );
     }
 }

--- a/crates/client/src/servers.rs
+++ b/crates/client/src/servers.rs
@@ -2,14 +2,55 @@ use super::*;
 
 impl<N: willow_network::Network> ClientHandle<N> {
     pub async fn switch_server(&self, server_id: &str) {
-        let sid = server_id.to_string();
-        willow_actor::state::mutate(&self.server_registry_addr, move |reg| {
-            if reg.servers.contains_key(&sid) {
-                reg.active_server = Some(sid);
+        let target_sid = server_id.to_string();
+
+        // Check the target exists and get the current active server ID.
+        let (target_exists, current_sid) =
+            willow_actor::state::select(&self.server_registry_addr, {
+                let tid = target_sid.clone();
+                move |reg| (reg.servers.contains_key(&tid), reg.active_server.clone())
+            })
+            .await;
+
+        if !target_exists {
+            return;
+        }
+
+        // Stash the current server's DAG and restore the target's.
+        let tid = target_sid.clone();
+        let state = willow_actor::state::mutate(&self.dag_addr, move |ds| {
+            // Stash current DAG under the old server ID.
+            if let Some(old_id) = current_sid {
+                ds.stashed.insert(old_id, ds.managed.clone());
             }
+            // Restore the target server's DAG (or create an empty one).
+            if let Some(restored) = ds.stashed.remove(&tid) {
+                ds.managed = restored;
+            } else {
+                ds.managed = willow_state::ManagedDag::empty(5000);
+            }
+            ds.managed.state().clone()
         })
         .await;
-        // TODO: re-initialize event_state for the new server (Phase 3 follow-up).
+
+        // Update event_state from the restored DAG's materialized state.
+        willow_actor::state::mutate(&self.event_state_addr, move |es| {
+            *es = state;
+        })
+        .await;
+
+        // Update active server in registry.
+        let sid = target_sid.clone();
+        willow_actor::state::mutate(&self.server_registry_addr, move |reg| {
+            reg.active_server = Some(sid);
+        })
+        .await;
+
+        // Reset current channel to "general" (may not exist on new server).
+        willow_actor::state::mutate(&self.chat_meta_addr, |chat| {
+            chat.current_channel = "general".to_string();
+        })
+        .await;
     }
 
     pub async fn server_list(&self) -> Vec<(String, String)> {
@@ -81,6 +122,18 @@ impl<N: willow_network::Network> ClientHandle<N> {
             },
         )
         .await?;
+
+        // Stash the current server's DAG before seeding the new one.
+        let old_sid = self.active_server_id().await;
+        if let Some(old_id) = old_sid {
+            let oid = old_id.clone();
+            willow_actor::state::mutate(&self.dag_addr, move |ds| {
+                ds.stashed.insert(oid, ds.managed.clone());
+                // Reset managed to empty so seed_genesis creates fresh state.
+                ds.managed = willow_state::ManagedDag::empty(5000);
+            })
+            .await;
+        }
 
         // Seed the DAG with a genesis event and materialize initial state.
         self.mutation_handle.seed_genesis(&name_for_state).await;

--- a/crates/client/src/state_actors.rs
+++ b/crates/client/src/state_actors.rs
@@ -172,6 +172,10 @@ pub struct DagState {
     /// The managed DAG that keeps EventDag, ServerState, and
     /// PendingBuffer in sync atomically.
     pub managed: willow_state::ManagedDag,
+    /// Stashed DAGs for inactive servers, keyed by server ID.
+    /// When switching servers, the current DAG is stashed and the
+    /// target server's DAG is restored (or a fresh one is created).
+    pub stashed: HashMap<String, willow_state::ManagedDag>,
 }
 
 impl DagState {
@@ -198,6 +202,7 @@ impl Default for DagState {
     fn default() -> Self {
         Self {
             managed: willow_state::ManagedDag::empty(MAX_CLIENT_PENDING),
+            stashed: HashMap::new(),
         }
     }
 }

--- a/crates/replay/src/role.rs
+++ b/crates/replay/src/role.rs
@@ -13,6 +13,10 @@ use willow_state::{
 };
 use willow_worker::{WorkerRequest, WorkerResponse, WorkerRole, WorkerRoleInfo};
 
+/// Maximum number of servers the replay node will track simultaneously.
+/// When exceeded, the least recently accessed server is evicted.
+const MAX_SERVERS: usize = 1000;
+
 /// Per-server state held by the replay node.
 struct ServerData {
     /// Per-author Merkle-DAG of events.
@@ -24,6 +28,8 @@ struct ServerData {
     /// Max events per author before compaction (reserved for future use).
     #[allow(dead_code)]
     max_events_per_author: usize,
+    /// Monotonic counter recording last access (for LRU eviction).
+    last_access: u64,
 }
 
 /// Configuration for the replay role.
@@ -44,6 +50,8 @@ impl Default for ReplayConfig {
 pub struct ReplayRole {
     servers: HashMap<String, ServerData>,
     config: ReplayConfig,
+    /// Monotonic counter for LRU tracking.
+    access_counter: u64,
 }
 
 impl ReplayRole {
@@ -52,6 +60,7 @@ impl ReplayRole {
         Self {
             servers: HashMap::new(),
             config,
+            access_counter: 0,
         }
     }
 
@@ -59,6 +68,22 @@ impl ReplayRole {
     pub fn ingest_event(&mut self, server_id: &str, event: &Event) {
         let max_per_author = self.config.max_events_per_author;
         let author = event.author;
+
+        // Evict least-recently-used server when at capacity and this is a new server.
+        if self.servers.len() >= MAX_SERVERS && !self.servers.contains_key(server_id) {
+            if let Some(lru_key) = self
+                .servers
+                .iter()
+                .min_by_key(|(_, d)| d.last_access)
+                .map(|(k, _)| k.clone())
+            {
+                self.servers.remove(&lru_key);
+            }
+        }
+
+        self.access_counter += 1;
+        let access_counter = self.access_counter;
+
         let data = self
             .servers
             .entry(server_id.to_string())
@@ -66,14 +91,24 @@ impl ReplayRole {
                 // Use event.author as placeholder genesis author. When the
                 // actual CreateServer event is applied via apply_incremental,
                 // it properly sets up admins in ServerState.
+                let pending = if max_per_author == 0 {
+                    // Treat zero as unlimited to avoid immediately evicting
+                    // every buffered event (PendingBuffer::with_capacity(0)
+                    // would evict all entries on each insert).
+                    PendingBuffer::new()
+                } else {
+                    PendingBuffer::with_capacity(max_per_author * 10)
+                };
                 ServerData {
                     dag: EventDag::new(),
                     state: ServerState::new(server_id, server_id, author),
-                    pending: PendingBuffer::with_capacity(max_per_author * 10),
+                    pending,
                     max_events_per_author: max_per_author,
+                    last_access: access_counter,
                 }
             });
 
+        data.last_access = access_counter;
         Self::try_insert(data, event.clone());
     }
 
@@ -831,5 +866,51 @@ mod tests {
             0,
             "no events should remain pending"
         );
+    }
+
+    #[test]
+    fn server_count_bounded_by_max() {
+        let mut role = ReplayRole::new(ReplayConfig {
+            max_events_per_author: 100,
+        });
+        // Insert MAX_SERVERS + 10 unique servers.
+        for i in 0..MAX_SERVERS + 10 {
+            let sid = format!("srv-{i}");
+            setup_server(&mut role, &sid);
+        }
+        assert!(
+            role.servers.len() <= MAX_SERVERS,
+            "server count {} exceeds MAX_SERVERS {}",
+            role.servers.len(),
+            MAX_SERVERS,
+        );
+    }
+
+    #[test]
+    fn zero_max_events_does_not_discard_pending() {
+        let mut role = ReplayRole::new(ReplayConfig {
+            max_events_per_author: 0,
+        });
+        let (owner, genesis_hash) = setup_server(&mut role, "srv-1");
+
+        // Build e2 and e3 to form a proper chain: genesis -> e2 -> e3.
+        let e2 = make_message(&owner, 2, genesis_hash);
+        let e3 = make_message(&owner, 3, e2.hash);
+
+        // Insert e3 first (out of order) — it should be buffered because
+        // its prev (e2.hash) hasn't been inserted yet.
+        role.ingest_event("srv-1", &e3);
+
+        assert!(
+            role.servers["srv-1"].pending.pending_count() > 0,
+            "pending events should not be immediately evicted when max_events_per_author=0"
+        );
+
+        // Now insert e2 to resolve the gap.
+        role.ingest_event("srv-1", &e2);
+
+        // Both e2 and e3 should now be in the DAG (genesis + e2 + e3 = 3).
+        assert_eq!(role.servers["srv-1"].dag.len(), 3);
+        assert_eq!(role.servers["srv-1"].pending.pending_count(), 0);
     }
 }

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -29,6 +29,12 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// incompatible way.
 pub const PROTOCOL_VERSION: u16 = 1;
 
+/// Maximum byte size for deserialization. Payloads exceeding this limit are
+/// rejected before allocation. Set above the gossip layer's 64 KB
+/// `max_message_size` to allow for framing overhead while still preventing
+/// malicious payloads from triggering large allocations.
+pub const MAX_DESER_SIZE: u64 = 256 * 1024;
+
 // ───── Errors ────────────────────────────────────────────────────────────────
 
 /// Errors that can occur during serialization or deserialization.
@@ -135,11 +141,24 @@ pub fn pack<T: Serialize>(data: &T) -> Result<Vec<u8>, TransportError> {
 
 /// Deserialize a byte slice back into a concrete type.
 ///
+/// Rejects payloads larger than [`MAX_DESER_SIZE`] before attempting
+/// deserialization. This prevents untrusted data from triggering large
+/// allocations via crafted length prefixes — bincode pre-allocates
+/// collections based on encoded lengths, so bounding input size bounds
+/// the maximum allocation.
+///
 /// # Errors
 ///
-/// Returns [`TransportError::Deserialize`] if bincode decoding fails or the
-/// bytes don't match the expected type.
+/// Returns [`TransportError::Deserialize`] if the payload exceeds the size
+/// limit, bincode decoding fails, or the bytes don't match the expected type.
 pub fn unpack<T: DeserializeOwned>(data: &[u8]) -> Result<T, TransportError> {
+    if data.len() as u64 > MAX_DESER_SIZE {
+        return Err(TransportError::Deserialize(format!(
+            "payload too large: {} bytes (limit: {} bytes)",
+            data.len(),
+            MAX_DESER_SIZE,
+        )));
+    }
     bincode::deserialize(data).map_err(|e| TransportError::Deserialize(e.to_string()))
 }
 
@@ -275,6 +294,27 @@ mod tests {
         let garbage = vec![0xFF, 0xFE, 0xFD];
         let result = unpack::<String>(&garbage);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn unpack_rejects_payload_exceeding_size_limit() {
+        // A valid bincode payload that exceeds the size limit.
+        // Without a deserialization size limit, this would succeed.
+        let big_vec = vec![0u8; MAX_DESER_SIZE as usize + 1];
+        let encoded = bincode::serialize(&big_vec).unwrap();
+        let result = unpack::<Vec<u8>>(&encoded);
+        assert!(
+            result.is_err(),
+            "should reject payload exceeding MAX_DESER_SIZE"
+        );
+    }
+
+    #[test]
+    fn unpack_accepts_payload_within_size_limit() {
+        let small_vec = vec![0u8; 1024];
+        let encoded = pack(&small_vec).unwrap();
+        let decoded: Vec<u8> = unpack(&encoded).unwrap();
+        assert_eq!(decoded.len(), 1024);
     }
 
     #[test]

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -22,4 +22,5 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 willow-network = { path = "../network", features = ["test-utils"] }
+async-trait = { workspace = true }
 tempfile = "3"

--- a/crates/worker/src/actors/network.rs
+++ b/crates/worker/src/actors/network.rs
@@ -17,6 +17,8 @@ pub struct NetworkActor<E: TopicEvents + 'static, T: TopicHandle + 'static> {
     state_addr: Addr<StateActor>,
     local_peer_id: EndpointId,
     events: Option<E>,
+    /// Optional SERVER_OPS topic events stream.
+    ops_events: Option<E>,
     reply_topic: T,
 }
 
@@ -31,8 +33,16 @@ impl<E: TopicEvents + 'static, T: TopicHandle + 'static> NetworkActor<E, T> {
             state_addr,
             local_peer_id,
             events: Some(events),
+            ops_events: None,
             reply_topic,
         }
+    }
+
+    /// Attach a SERVER_OPS topic events stream. Events from this stream are
+    /// parsed with [`parse_server_message`] and forwarded to the state actor.
+    pub fn with_ops_events(mut self, ops_events: E) -> Self {
+        self.ops_events = Some(ops_events);
+        self
     }
 }
 
@@ -42,14 +52,31 @@ impl willow_actor::Message for GossipEventMsg {
     type Result = ();
 }
 
+/// Internal message wrapping a server ops gossip event.
+struct ServerOpsEventMsg(GossipEvent);
+impl willow_actor::Message for ServerOpsEventMsg {
+    type Result = ();
+}
+
 impl<E: TopicEvents + 'static, T: TopicHandle + 'static> Actor for NetworkActor<E, T> {
     fn started(&mut self, ctx: &mut Context<Self>) -> impl std::future::Future<Output = ()> + Send {
-        // Spawn a task that drains TopicEvents and forwards them as messages.
+        // Spawn a task that drains WORKERS topic events.
         if let Some(mut events) = self.events.take() {
             let addr = ctx.address();
             willow_actor::runtime::spawn(async move {
                 while let Some(Ok(event)) = events.next().await {
                     if addr.do_send(GossipEventMsg(event)).is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+        // Spawn a second task that drains SERVER_OPS topic events.
+        if let Some(mut ops_events) = self.ops_events.take() {
+            let addr = ctx.address();
+            willow_actor::runtime::spawn(async move {
+                while let Some(Ok(event)) = ops_events.next().await {
+                    if addr.do_send(ServerOpsEventMsg(event)).is_err() {
                         break;
                     }
                 }
@@ -110,6 +137,32 @@ impl<E: TopicEvents + 'static, T: TopicHandle + 'static> Handler<GossipEventMsg>
     }
 }
 
+impl<E: TopicEvents + 'static, T: TopicHandle + 'static> Handler<ServerOpsEventMsg>
+    for NetworkActor<E, T>
+{
+    fn handle(
+        &mut self,
+        msg: ServerOpsEventMsg,
+        _ctx: &mut Context<Self>,
+    ) -> impl std::future::Future<Output = ()> + Send {
+        let state_addr = self.state_addr.clone();
+        let event = msg.0;
+
+        async move {
+            if let GossipEvent::Received(msg) = event {
+                match parse_server_message(&msg.content) {
+                    ServerMessageAction::Events(events) => {
+                        for event in events {
+                            let _ = state_addr.do_send(EventMsg(event));
+                        }
+                    }
+                    ServerMessageAction::Ignore => {}
+                }
+            }
+        }
+    }
+}
+
 // ───── Pure parse functions (unchanged) ────────────────────────────────────
 
 /// Action produced by parsing an incoming worker topic message.
@@ -131,7 +184,7 @@ pub enum WorkerMessageAction {
 /// This is a pure function — no I/O, no channels — so it's easily
 /// testable. The caller handles the actual I/O.
 pub fn parse_worker_message(data: &[u8], local_peer_id: &EndpointId) -> WorkerMessageAction {
-    let msg = match bincode::deserialize::<WorkerWireMessage>(data) {
+    let msg = match willow_transport::unpack::<WorkerWireMessage>(data) {
         Ok(m) => m,
         Err(e) => return WorkerMessageAction::DeserializeError(e.to_string()),
     };

--- a/crates/worker/src/runtime.rs
+++ b/crates/worker/src/runtime.rs
@@ -30,20 +30,23 @@ pub async fn run<N: Network>(
     let workers_topic_id = willow_network::topic_id(crate::types::WORKERS_TOPIC);
     let (workers_sender, workers_events) = network.subscribe(workers_topic_id, vec![]).await?;
 
-    let _ops_topic_id = willow_network::topic_id(crate::types::SERVER_OPS_TOPIC);
-    let (_ops_sender, _ops_events) = network.subscribe(_ops_topic_id, vec![]).await?;
+    let ops_topic_id = willow_network::topic_id(crate::types::SERVER_OPS_TOPIC);
+    let (_ops_sender, ops_events) = network.subscribe(ops_topic_id, vec![]).await?;
 
     // Create actor system and spawn actors.
     let system = System::new();
 
     let state_addr = system.spawn(StateActor { role });
 
-    let _network = system.spawn(NetworkActor::new(
-        workers_events,
-        state_addr.clone(),
-        peer_id,
-        workers_sender.clone(),
-    ));
+    let _network = system.spawn(
+        NetworkActor::new(
+            workers_events,
+            state_addr.clone(),
+            peer_id,
+            workers_sender.clone(),
+        )
+        .with_ops_events(ops_events),
+    );
 
     let _heartbeat = system.spawn(HeartbeatActor::new(
         peer_id,

--- a/crates/worker/tests/integration.rs
+++ b/crates/worker/tests/integration.rs
@@ -8,7 +8,9 @@ use std::time::Duration;
 use willow_actor::System;
 use willow_common::{WorkerRequest, WorkerResponse, WorkerRole, WorkerRoleInfo};
 use willow_identity::Identity;
+use willow_network::traits::{GossipEvent, GossipMessage, TopicEvents, TopicHandle};
 use willow_state::{Event, EventHash, EventKind, HeadsSummary, Snapshot};
+use willow_worker::actors::network::NetworkActor;
 use willow_worker::actors::state::StateActor;
 use willow_worker::actors::{EventMsg, GetRoleInfoMsg, WorkerRequestMsg};
 
@@ -467,4 +469,112 @@ fn sync_provider_permission_identifies_workers() {
     assert!(state.has_permission(&worker, &Permission::SyncProvider));
     assert!(state.has_permission(&owner, &Permission::SyncProvider));
     assert!(!state.has_permission(&random, &Permission::SyncProvider));
+}
+
+// ───── Mock types for NetworkActor tests ──────────────────────────────────
+
+/// A minimal TopicEvents mock backed by a tokio mpsc channel.
+struct MockTopicEvents {
+    rx: tokio::sync::mpsc::Receiver<GossipEvent>,
+}
+
+#[async_trait::async_trait]
+impl TopicEvents for MockTopicEvents {
+    async fn next(&mut self) -> Option<anyhow::Result<GossipEvent>> {
+        self.rx.recv().await.map(Ok)
+    }
+    async fn joined(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+/// A minimal TopicHandle mock that discards broadcasts.
+#[derive(Clone)]
+struct MockTopicHandle;
+
+#[async_trait::async_trait]
+impl TopicHandle for MockTopicHandle {
+    async fn broadcast(&self, _data: bytes::Bytes) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn broadcast_neighbors(&self, _data: bytes::Bytes) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn neighbors(&self) -> Vec<willow_identity::EndpointId> {
+        vec![]
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_ops_events_forwarded_to_state() {
+    let system = System::new();
+
+    // State actor with a replay role that tracks ingested events.
+    let state_addr = system.spawn(StateActor {
+        role: Box::new(TestReplayRole::new("srv-1", 100)),
+    });
+
+    // Create channels for both WORKERS and SERVER_OPS streams.
+    let (_workers_tx, workers_rx) = tokio::sync::mpsc::channel::<GossipEvent>(16);
+    let (ops_tx, ops_rx) = tokio::sync::mpsc::channel::<GossipEvent>(16);
+
+    let worker_id = Identity::generate();
+    let peer_id = worker_id.endpoint_id();
+
+    let workers_events = MockTopicEvents { rx: workers_rx };
+    let ops_events = MockTopicEvents { rx: ops_rx };
+
+    let _network = system.spawn(
+        NetworkActor::new(workers_events, state_addr.clone(), peer_id, MockTopicHandle)
+            .with_ops_events(ops_events),
+    );
+
+    // Allow the actor to start.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Create a signed server event and send it on the ops stream.
+    let sender_id = Identity::generate();
+    let event = Event::new(
+        &sender_id,
+        1,
+        EventHash::ZERO,
+        vec![],
+        EventKind::CreateServer {
+            name: "srv-1".to_string(),
+        },
+        0,
+    );
+
+    let data = willow_common::pack_wire(
+        &willow_common::WireMessage::Event(event.clone()),
+        &sender_id,
+    )
+    .unwrap();
+
+    ops_tx
+        .send(GossipEvent::Received(GossipMessage {
+            content: bytes::Bytes::from(data),
+            sender: sender_id.endpoint_id(),
+        }))
+        .await
+        .unwrap();
+
+    // Allow the event to be processed.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Verify the state actor received the event.
+    let info = state_addr.ask(GetRoleInfoMsg).await.unwrap();
+    match info {
+        WorkerRoleInfo::Replay {
+            events_buffered, ..
+        } => {
+            assert_eq!(
+                events_buffered, 1,
+                "server ops event should have been forwarded to state actor"
+            );
+        }
+        _ => panic!("expected Replay"),
+    }
+
+    system.shutdown().await;
 }


### PR DESCRIPTION
## Summary

Fixes 4 bugs across 4 crates with test-first methodology (each fix includes a test that fails before the fix and passes after):

- **#80**: Add `MAX_DESER_SIZE` (256KB) limit to `transport::unpack()` to prevent untrusted payloads from triggering large allocations; update worker to use size-limited deserialization
- **#82**: Add `MAX_SERVERS` (1000) with counter-based LRU eviction in replay node; treat `max_events_per_author=0` as unlimited to prevent `PendingBuffer::evict_to(0)` from discarding all pending events
- **#53**: Wire `SERVER_OPS` topic events to `NetworkActor` via `with_ops_events()` and a second listener task using `parse_server_message()`
- **#48**: Implement DAG stash/restore in `switch_server()` and `create_server()` so `event_state` reflects the correct server; reset `chat_meta` channel on switch

Closes #80, closes #82, closes #53, closes #48

## Test plan

- [x] `unpack_rejects_payload_exceeding_size_limit` — confirms oversized payloads are rejected
- [x] `unpack_accepts_payload_within_size_limit` — confirms normal payloads still work
- [x] `server_count_bounded_by_max` — confirms server HashMap is bounded at MAX_SERVERS
- [x] `zero_max_events_does_not_discard_pending` — confirms zero-config doesn't evict pending events
- [x] `server_ops_events_forwarded_to_state` — confirms ops events reach StateActor through NetworkActor
- [x] `switch_server_updates_event_state` — confirms switching servers shows correct state
- [x] All 575+ existing tests pass, zero clippy warnings, WASM compiles clean

https://claude.ai/code/session_01PTEz1MZc8RhEGtbmVfR8fX