### PR TITLE
Add E2E test setup script and improve relay bootstrap discovery

### DIFF
--- a/crates/client/src/connect.rs
+++ b/crates/client/src/connect.rs
@@ -30,8 +30,9 @@ impl<N: willow_network::Network> ClientHandle<N> {
 
         // Subscribe to the server ops topic.
         let ops_topic_str = ops::SERVER_OPS_TOPIC;
+        let bootstrap = self.bootstrap_peers.clone();
         if let Ok((sender, events)) = network
-            .subscribe(willow_network::topic_id(ops_topic_str), vec![])
+            .subscribe(willow_network::topic_id(ops_topic_str), bootstrap)
             .await
         {
             self.topics
@@ -43,8 +44,9 @@ impl<N: willow_network::Network> ClientHandle<N> {
 
         // Subscribe to the global profile broadcast topic.
         let profile_topic_str = ops::PROFILE_TOPIC;
+        let bootstrap = self.bootstrap_peers.clone();
         if let Ok((sender, events)) = network
-            .subscribe(willow_network::topic_id(profile_topic_str), vec![])
+            .subscribe(willow_network::topic_id(profile_topic_str), bootstrap)
             .await
         {
             self.topics
@@ -65,8 +67,9 @@ impl<N: willow_network::Network> ClientHandle<N> {
             .await;
 
         for topic_str in channel_topics {
+            let bootstrap = self.bootstrap_peers.clone();
             if let Ok((sender, events)) = network
-                .subscribe(willow_network::topic_id(&topic_str), vec![])
+                .subscribe(willow_network::topic_id(&topic_str), bootstrap)
                 .await
             {
                 self.topics

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -127,6 +127,8 @@ pub struct ClientConfig {
     pub display_name: Option<String>,
     /// Whether to persist state to disk. Defaults to `true`.
     pub persistence: bool,
+    /// Bootstrap peer endpoint IDs for gossip topic discovery.
+    pub bootstrap_peers: Vec<willow_identity::EndpointId>,
 }
 
 impl Default for ClientConfig {
@@ -135,6 +137,7 @@ impl Default for ClientConfig {
             relay_addr: None,
             display_name: None,
             persistence: true,
+            bootstrap_peers: vec![],
         }
     }
 }
@@ -179,6 +182,8 @@ pub struct ClientHandle<N: willow_network::Network> {
     pub(crate) persistence_enabled: bool,
     /// Active join links (rarely modified, shared across tasks).
     pub(crate) join_links: Arc<std::sync::Mutex<Vec<ops::JoinLink>>>,
+    /// Bootstrap peers for gossip topic subscriptions.
+    pub bootstrap_peers: Vec<willow_identity::EndpointId>,
     /// The per-author Merkle-DAG actor — source of truth for all events.
     pub(crate) dag_addr: willow_actor::Addr<willow_actor::StateActor<state_actors::DagState>>,
 
@@ -206,6 +211,7 @@ impl<N: willow_network::Network> Clone for ClientHandle<N> {
             persistence_addr: self.persistence_addr.clone(),
             persistence_enabled: self.persistence_enabled,
             join_links: Arc::clone(&self.join_links),
+            bootstrap_peers: self.bootstrap_peers.clone(),
             dag_addr: self.dag_addr.clone(),
             view_handle: self.view_handle.clone(),
             mutation_handle: self.mutation_handle.clone(),
@@ -603,6 +609,7 @@ impl<N: willow_network::Network> ClientHandle<N> {
             persistence_addr,
             persistence_enabled,
             join_links,
+            bootstrap_peers: config.bootstrap_peers,
             dag_addr: dag_addr.clone(),
             view_handle,
             mutation_handle,
@@ -905,6 +912,7 @@ pub fn test_client() -> (
         persistence_addr,
         persistence_enabled: false,
         join_links,
+        bootstrap_peers: vec![],
         dag_addr: dag_addr.clone(),
         view_handle,
         mutation_handle,

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -5,6 +5,7 @@
 //! the gossip mesh.
 
 use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -100,6 +101,38 @@ async fn main() -> Result<()> {
     let _ = network.subscribe(profiles_topic, vec![]).await?;
 
     info!("bootstrap node subscribed to system topics");
+
+    // ── Bootstrap ID HTTP endpoint ──────────────────────────────────────
+    // Serve the bootstrap node's endpoint ID so web clients can fetch it.
+    let bootstrap_id = Arc::new(identity.endpoint_id().to_string());
+    let id_for_handler = Arc::clone(&bootstrap_id);
+    let bootstrap_listener =
+        tokio::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, args.relay_port + 1))
+            .await
+            .context("failed to bind bootstrap-id HTTP port")?;
+    let bootstrap_port = bootstrap_listener.local_addr()?.port();
+    info!(port = bootstrap_port, "bootstrap-id endpoint listening");
+    tokio::spawn(async move {
+        loop {
+            if let Ok((stream, _)) = bootstrap_listener.accept().await {
+                let id = Arc::clone(&id_for_handler);
+                tokio::spawn(async move {
+                    let (mut reader, mut writer) = stream.into_split();
+                    // Read the request (we don't care about its contents).
+                    let mut buf = [0u8; 1024];
+                    let _ = tokio::io::AsyncReadExt::read(&mut reader, &mut buf).await;
+                    let body = id.as_str();
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes()).await;
+                });
+            }
+        }
+    });
+
     info!("relay running — press Ctrl+C to stop");
 
     // Wait for shutdown signal or relay task failure.

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -32,6 +32,7 @@ web-sys = { version = "0.3", features = [
     "AudioContext", "BaseAudioContext", "AudioNode",
     "AnalyserNode", "MediaStreamAudioSourceNode",
     "RtcSignalingState", "RtcRtpTransceiver",
+    "Response", "Headers",
 ] }
 js-sys = "0.3"
 wasm-bindgen-futures = "0.4"

--- a/crates/web/index.html
+++ b/crates/web/index.html
@@ -16,12 +16,8 @@
     <link data-trunk rel="copy-file" href="icon-512.svg" />
     <link data-trunk rel="copy-file" href="sw.js" />
     <link data-trunk rel="rust" data-wasm-opt="z" />
-    <script>
-        (function() {
-            var theme = localStorage.getItem('willow-theme') || 'dark';
-            document.documentElement.setAttribute('data-theme', theme);
-        })();
-    </script>
+    <link data-trunk rel="copy-file" href="init.js" />
+    <script src="init.js"></script>
 </head>
 <body>
     <div class="loading" id="loading">Loading Willow...</div>

--- a/crates/web/init.js
+++ b/crates/web/init.js
@@ -1,0 +1,9 @@
+(function() {
+    var theme = localStorage.getItem('willow-theme') || 'dark';
+    document.documentElement.setAttribute('data-theme', theme);
+    // Auto-detect local relay for development.
+    var h = location.hostname;
+    if (!window.__WILLOW_RELAY_URL && (h === '127.0.0.1' || h === 'localhost')) {
+        window.__WILLOW_RELAY_URL = 'http://' + h + ':3340';
+    }
+})();

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -39,13 +39,49 @@ pub type WebClientHandle = SendWrapper<ClientHandle<willow_network::iroh::IrohNe
 /// Wrapper around `Rc<RefCell<VoiceManager>>` that is `Send` for single-threaded WASM.
 pub type VoiceManagerHandle = SendWrapper<Rc<RefCell<VoiceManager>>>;
 
-/// Default relay address for the deployed Willow relay server.
-pub const DEFAULT_RELAY: &str =
-    "/dns4/willow.intendednull.com/tcp/9443/wss/p2p/12D3KooWMBmUF1rHYG5CneKi8JZfKdMAciJd4oCgknTJkbwCUurd";
+/// Default relay URL for the deployed Willow relay server.
+pub const DEFAULT_RELAY_URL: &str = "https://willow.intendednull.com:9443";
+
+/// Resolve the relay URL at runtime: checks `window.__WILLOW_RELAY_URL`,
+/// then falls back to the compiled-in default.
+fn resolve_relay_url() -> String {
+    if let Ok(val) = js_sys::eval("window.__WILLOW_RELAY_URL") {
+        if let Some(s) = val.as_string() {
+            if !s.is_empty() {
+                return s;
+            }
+        }
+    }
+    DEFAULT_RELAY_URL.to_string()
+}
+
+/// Fetch the bootstrap node's endpoint ID from the relay's companion port.
+/// Returns `None` on any failure (network error, parse error, etc.).
+async fn fetch_bootstrap_id(relay_url: &str) -> Option<willow_identity::EndpointId> {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+
+    // The bootstrap-id endpoint runs on relay_port + 1.
+    let url = relay_url
+        .replace(":3340", ":3341")
+        .replace(":9443", ":9444");
+    let bootstrap_url = format!("{url}/bootstrap-id");
+
+    let window = web_sys::window()?;
+    let resp_value = JsFuture::from(window.fetch_with_str(&bootstrap_url))
+        .await
+        .ok()?;
+    let resp: web_sys::Response = resp_value.dyn_into().ok()?;
+    let text_promise = resp.text().ok()?;
+    let text_value = JsFuture::from(text_promise).await.ok()?;
+    let text = text_value.as_string()?;
+    text.trim().parse::<willow_identity::EndpointId>().ok()
+}
 
 fn new_client() -> WebClientHandle {
+    let relay_url = resolve_relay_url();
     let config = ClientConfig {
-        relay_addr: Some(DEFAULT_RELAY.to_string()),
+        relay_addr: Some(relay_url),
         ..ClientConfig::default()
     };
     let (handle, _event_loop) = ClientHandle::<willow_network::iroh::IrohNetwork>::new(config);
@@ -205,10 +241,33 @@ pub fn App() -> impl IntoView {
         // and then processes the resulting ClientEvent stream.
         wasm_bindgen_futures::spawn_local(async move {
             // Build the iroh network configuration from our identity.
+            let relay_url = resolve_relay_url();
+            let parsed_relay = relay_url
+                .parse::<willow_network::iroh::RelayUrl>()
+                .ok();
+            if parsed_relay.is_none() {
+                tracing::warn!(url = %relay_url, "failed to parse relay URL");
+            }
+
+            // Fetch the bootstrap node's endpoint ID from the relay.
+            let bootstrap_peers = match fetch_bootstrap_id(&relay_url).await {
+                Some(id) => {
+                    tracing::info!(%id, "fetched bootstrap peer from relay");
+                    vec![id]
+                }
+                None => {
+                    tracing::warn!("could not fetch bootstrap peer ID from relay");
+                    vec![]
+                }
+            };
+
+            // Set bootstrap peers on the client handle so topic subscriptions use them.
+            handle_for_connect.bootstrap_peers = bootstrap_peers.clone();
+
             let iroh_config = willow_network::iroh::Config {
                 secret_key: handle_for_connect.identity().secret_key().clone(),
-                relay_url: None,
-                bootstrap_peers: vec![],
+                relay_url: parsed_relay,
+                bootstrap_peers,
                 mdns: false,
             };
 

--- a/crates/web/src/components/settings.rs
+++ b/crates/web/src/components/settings.rs
@@ -164,7 +164,7 @@ pub fn SettingsPanel(
                 <div class="settings-section">
                     <label>"Your Peer ID"</label>
                     <div class="peer-id-display">
-                        <code class="peer-id-text">{move || { let id = peer_id.get(); id.get(..10).unwrap_or(&id).to_string() }}</code>
+                        <code class="peer-id-text" data-full-id=move || peer_id.get()>{move || { let id = peer_id.get(); id.get(..10).unwrap_or(&id).to_string() }}</code>
                         <button class="btn btn-sm" on:click=on_copy_peer_id_profile>"Copy"</button>
                     </div>
                 </div>
@@ -314,7 +314,7 @@ pub fn SettingsPanel(
                     <h3>"Your Peer ID"</h3>
                     <p class="settings-hint">"Share this with others so they can invite you to their servers."</p>
                     <div class="peer-id-display">
-                        <code class="peer-id-text">{move || { let id = peer_id.get(); id.get(..10).unwrap_or(&id).to_string() }}</code>
+                        <code class="peer-id-text" data-full-id=move || peer_id.get()>{move || { let id = peer_id.get(); id.get(..10).unwrap_or(&id).to_string() }}</code>
                         <button class="btn btn-sm" on:click=on_copy_peer_id_server>"Copy"</button>
                     </div>
                 </div>

--- a/crates/web/src/components/welcome.rs
+++ b/crates/web/src/components/welcome.rs
@@ -29,7 +29,7 @@ pub fn WelcomeScreen(on_done: impl Fn(()) + Send + Clone + 'static) -> impl Into
                         "Share this with a server owner so they can invite you."
                     </p>
                     <div class="welcome-peer-id">
-                        <code class="peer-id-text">{peer_id_short}</code>
+                        <code class="peer-id-text" data-full-id={peer_id.clone()}>{peer_id_short}</code>
                         <button
                             class="btn btn-sm"
                             on:click={

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -46,19 +46,18 @@ export async function createServer(page: Page, name: string, displayName?: strin
   await page.waitForTimeout(500);
 }
 
-/** Get the peer ID from the welcome screen or settings. */
+/** Get the full peer ID from the welcome screen or settings. */
 export async function getPeerId(page: Page): Promise<string> {
   // Check welcome screen first.
   const peerIdEl = page.locator('.peer-id-text').first();
   if (await peerIdEl.isVisible()) {
-    return (await peerIdEl.textContent()) || '';
+    return (await peerIdEl.getAttribute('data-full-id')) || (await peerIdEl.textContent()) || '';
   }
   // Try settings.
   await page.locator('text=Settings').click();
   await page.waitForTimeout(300);
   const settingsPeerId = page.locator('.peer-id-text').first();
-  const id = (await settingsPeerId.textContent()) || '';
-  return id;
+  return (await settingsPeerId.getAttribute('data-full-id')) || (await settingsPeerId.textContent()) || '';
 }
 
 /** Send a message in the current channel. */

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -75,35 +75,33 @@ fi
 RELAY_IDENTITY="$DEV_DIR/relay.key"
 RELAY_LOG="$LOG_DIR/relay.log"
 
+RELAY_PORT="${WILLOW_RELAY_PORT:-3340}"
+
 echo -e "${BLUE}Starting relay...${NC}"
 cargo run -p willow-relay -- \
-    --tcp-port 9090 \
-    --ws-port 9091 \
+    --relay-port "$RELAY_PORT" \
     --identity "$RELAY_IDENTITY" \
-    --name "Dev Relay" \
     > "$RELAY_LOG" 2>&1 &
 RELAY_PID=$!
 PIDS+=("$RELAY_PID")
 
-# Wait for the relay to log its peer ID (up to 10s)
-RELAY_PEER_ID=""
-for i in $(seq 1 50); do
-    if [ -f "$RELAY_LOG" ]; then
-        RELAY_PEER_ID=$(sed 's/\x1b\[[0-9;]*m//g' "$RELAY_LOG" 2>/dev/null | grep -oP 'peer_id\s*=\s*\K[A-Za-z0-9]+' | head -1 || true)
-        if [ -n "$RELAY_PEER_ID" ]; then
-            break
-        fi
+# Wait for the relay to start (up to 30s — first run may compile)
+RELAY_READY=false
+for i in $(seq 1 150); do
+    if grep -q "relay running" "$RELAY_LOG" 2>/dev/null; then
+        RELAY_READY=true
+        break
     fi
     sleep 0.2
 done
 
-if [ -z "$RELAY_PEER_ID" ]; then
-    echo -e "${RED}Failed to get relay peer ID. Check $RELAY_LOG${NC}"
+if [ "$RELAY_READY" = false ]; then
+    echo -e "${RED}Failed to start relay. Check $RELAY_LOG${NC}"
     exit 1
 fi
 
-RELAY_ADDR="/ip4/127.0.0.1/tcp/9091/ws/p2p/$RELAY_PEER_ID"
-echo -e "${BLUE}Relay started:${NC} $RELAY_ADDR"
+RELAY_URL="http://127.0.0.1:$RELAY_PORT"
+echo -e "${BLUE}Relay started:${NC} $RELAY_URL"
 echo ""
 
 # Tail relay logs with prefix
@@ -118,8 +116,8 @@ REPLAY_IDENTITY="$DEV_DIR/replay.key"
 echo -e "${YELLOW}Starting replay node...${NC}"
 cargo run -p willow-replay -- \
     --identity-path "$REPLAY_IDENTITY" \
-    --relay "$RELAY_ADDR" \
-    --max-events-per-server 1000 \
+    --relay-url "$RELAY_URL" \
+    --max-events-per-author 1000 \
     --sync-interval 10 \
     > "$LOG_DIR/replay.log" 2>&1 &
 PIDS+=($!)
@@ -136,7 +134,7 @@ STORAGE_DB="$DEV_DIR/storage.db"
 echo -e "${MAGENTA}Starting storage node...${NC}"
 cargo run -p willow-storage -- \
     --identity-path "$STORAGE_IDENTITY" \
-    --relay "$RELAY_ADDR" \
+    --relay-url "$RELAY_URL" \
     --db-path "$STORAGE_DB" \
     --sync-interval 15 \
     > "$LOG_DIR/storage.log" 2>&1 &
@@ -161,9 +159,8 @@ echo ""
 echo -e "${GREEN}═══════════════════════════════════════════════${NC}"
 echo -e "${GREEN}  Willow dev stack running${NC}"
 echo -e "${GREEN}═══════════════════════════════════════════════${NC}"
-echo -e "  Relay:   ${BLUE}localhost:9090${NC} (TCP) / ${BLUE}localhost:9091${NC} (WS)"
+echo -e "  Relay:   ${BLUE}$RELAY_URL${NC}"
 echo -e "  Web UI:  ${GREEN}http://localhost:8080${NC}"
-echo -e "  Relay ID: ${RELAY_PEER_ID}"
 echo -e "  Logs:    ${LOG_DIR}/"
 echo -e "${GREEN}═══════════════════════════════════════════════${NC}"
 echo -e "  Press ${RED}Ctrl+C${NC} to stop all services"

--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# scripts/setup-e2e.sh — Prepare the E2E test environment from scratch.
+#
+# Installs tooling, builds all services, starts the full dev stack,
+# and waits until everything is ready for Playwright tests.
+#
+# Usage:
+#   ./scripts/setup-e2e.sh          # full setup + start services
+#   ./scripts/setup-e2e.sh --no-start  # install/build only, don't start services
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEV_DIR="$ROOT/.dev"
+LOG_DIR="$DEV_DIR/logs"
+
+NO_START=false
+for arg in "$@"; do
+    case "$arg" in
+        --no-start) NO_START=true ;;
+    esac
+done
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+step() { echo -e "${GREEN}[setup]${NC} $1"; }
+info() { echo -e "${BLUE}[info]${NC} $1"; }
+fail() { echo -e "${RED}[error]${NC} $1"; exit 1; }
+
+# ── 1. Install tooling ──────────────────────────────────────────────────
+
+step "Installing tooling..."
+
+# WASM target
+if ! rustup target list --installed | grep -q wasm32-unknown-unknown; then
+    step "Adding wasm32-unknown-unknown target..."
+    rustup target add wasm32-unknown-unknown
+fi
+
+# trunk
+if ! command -v trunk &>/dev/null; then
+    step "Installing trunk (WASM bundler)..."
+    cargo install trunk 2>&1 | tail -1
+fi
+
+# just
+if ! command -v just &>/dev/null; then
+    step "Installing just (task runner)..."
+    cargo install just 2>&1 | tail -1
+fi
+
+# npm dependencies
+if [ ! -d "$ROOT/node_modules" ]; then
+    step "Installing npm dependencies..."
+    (cd "$ROOT" && npm install)
+fi
+
+# Playwright browsers
+if ! npx playwright install --dry-run chromium 2>&1 | grep -q "already installed"; then
+    step "Installing Playwright Chromium..."
+    npx playwright install --with-deps chromium
+fi
+
+info "Tooling ready: trunk=$(trunk --version 2>/dev/null || echo missing), just=$(just --version 2>/dev/null || echo missing)"
+
+# ── 2. Build all services ───────────────────────────────────────────────
+
+step "Building relay, replay, and storage..."
+cargo build -p willow-relay -p willow-replay -p willow-storage 2>&1 | tail -1
+
+step "Building web UI (WASM)..."
+(cd "$ROOT/crates/web" && trunk build 2>&1 | tail -1)
+
+info "All builds complete."
+
+if [ "$NO_START" = true ]; then
+    info "Skipping service startup (--no-start)."
+    exit 0
+fi
+
+# ── 3. Start services ───────────────────────────────────────────────────
+
+mkdir -p "$DEV_DIR" "$LOG_DIR"
+
+# Kill any leftover processes from a previous run.
+pkill -f "willow-relay" 2>/dev/null || true
+pkill -f "willow-replay" 2>/dev/null || true
+pkill -f "willow-storage" 2>/dev/null || true
+pkill -f "trunk serve" 2>/dev/null || true
+sleep 1
+
+# Relay
+step "Starting relay..."
+cargo run -p willow-relay -- \
+    --relay-port 3340 \
+    --identity "$DEV_DIR/relay.key" \
+    > "$LOG_DIR/relay.log" 2>&1 &
+RELAY_PID=$!
+
+# Wait for relay to be ready
+RELAY_READY=false
+for i in $(seq 1 60); do
+    if grep -q "relay running" "$LOG_DIR/relay.log" 2>/dev/null; then
+        RELAY_READY=true
+        break
+    fi
+    sleep 1
+done
+if [ "$RELAY_READY" = false ]; then
+    fail "Relay failed to start. Check $LOG_DIR/relay.log"
+fi
+info "Relay running on port 3340 (PID $RELAY_PID)"
+
+RELAY_URL="http://127.0.0.1:3340"
+
+# Replay node
+step "Starting replay node..."
+cargo run -p willow-replay -- \
+    --identity-path "$DEV_DIR/replay.key" \
+    --relay-url "$RELAY_URL" \
+    --max-events-per-author 1000 \
+    --sync-interval 10 \
+    > "$LOG_DIR/replay.log" 2>&1 &
+info "Replay node started (PID $!)"
+
+# Storage node
+step "Starting storage node..."
+cargo run -p willow-storage -- \
+    --identity-path "$DEV_DIR/storage.key" \
+    --relay-url "$RELAY_URL" \
+    --db-path "$DEV_DIR/storage.db" \
+    --sync-interval 15 \
+    > "$LOG_DIR/storage.log" 2>&1 &
+info "Storage node started (PID $!)"
+
+# Web UI
+step "Starting web UI (trunk serve)..."
+(cd "$ROOT/crates/web" && trunk serve) > "$LOG_DIR/web.log" 2>&1 &
+WEB_PID=$!
+
+# Wait for web UI
+WEB_READY=false
+for i in $(seq 1 180); do
+    if curl -s http://127.0.0.1:8080 > /dev/null 2>&1; then
+        WEB_READY=true
+        break
+    fi
+    sleep 1
+done
+if [ "$WEB_READY" = false ]; then
+    fail "Web UI failed to start. Check $LOG_DIR/web.log"
+fi
+info "Web UI running at http://127.0.0.1:8080 (PID $WEB_PID)"
+
+# ── 4. Summary ──────────────────────────────────────────────────────────
+
+echo ""
+echo -e "${GREEN}═══════════════════════════════════════════════${NC}"
+echo -e "${GREEN}  E2E test environment ready${NC}"
+echo -e "${GREEN}═══════════════════════════════════════════════${NC}"
+echo -e "  Relay:   ${BLUE}localhost:3340${NC}"
+echo -e "  Replay:  connected to relay"
+echo -e "  Storage: connected to relay"
+echo -e "  Web UI:  ${BLUE}http://127.0.0.1:8080${NC}"
+echo -e "  Logs:    ${LOG_DIR}/"
+echo -e ""
+echo -e "  Run tests:"
+echo -e "    npx playwright test --project=desktop-chrome"
+echo -e "    just test-e2e-ui"
+echo -e "${GREEN}═══════════════════════════════════════════════${NC}"


### PR DESCRIPTION
## Summary
This PR adds a comprehensive E2E test setup script and refactors the relay/bootstrap discovery mechanism to support dynamic relay URLs and automatic bootstrap peer discovery for web clients.

## Key Changes

### New E2E Setup Script
- **`scripts/setup-e2e.sh`**: New automated setup script that:
  - Installs required tooling (Rust WASM target, trunk, just, npm dependencies, Playwright)
  - Builds all services (relay, replay, storage, web UI)
  - Starts the full dev stack with proper health checks
  - Supports `--no-start` flag for install/build only
  - Provides clear logging and summary output

### Relay Bootstrap Discovery
- **Relay HTTP endpoint**: Added a companion HTTP server on `relay_port + 1` that serves the bootstrap node's endpoint ID, allowing web clients to discover it dynamically
- **Web client bootstrap resolution**: 
  - Added `resolve_relay_url()` to check `window.__WILLOW_RELAY_URL` at runtime, falling back to compiled default
  - Added `fetch_bootstrap_id()` to fetch the bootstrap peer ID from the relay's companion endpoint
  - Web clients now automatically discover and use bootstrap peers for gossip subscriptions

### Configuration Updates
- **`ClientConfig`**: Added `bootstrap_peers` field to support configurable bootstrap peers
- **`ClientHandle`**: Added `bootstrap_peers` field that gets passed to all topic subscriptions
- **Relay CLI**: Changed from `--tcp-port`/`--ws-port` to `--relay-port` for simpler configuration
- **Replay/Storage CLI**: Changed from `--relay` (multiaddr) to `--relay-url` (HTTP URL)

### Web UI Improvements
- **`init.js`**: New initialization script that:
  - Restores theme preference from localStorage
  - Auto-detects local relay for development (localhost/127.0.0.1 on port 3340)
- **Peer ID display**: Added `data-full-id` attribute to peer ID elements for E2E test access to full IDs
- **Web dependencies**: Added `Response` and `Headers` to web-sys features for HTTP fetching

### Development Script Updates
- **`scripts/dev.sh`**: Simplified relay startup to use HTTP URL instead of multiaddr format, improved relay readiness detection

### E2E Test Helpers
- **`e2e/helpers.ts`**: Updated `getPeerId()` to retrieve full peer IDs from `data-full-id` attribute for more reliable test assertions

## Implementation Details
- Bootstrap discovery is graceful: if the relay endpoint is unreachable or returns invalid data, clients continue with empty bootstrap peers
- Relay URL resolution supports both development (http://localhost:3340) and production (https://willow.intendednull.com:9443) configurations
- The setup script includes 60-second timeout for relay startup and 180-second timeout for web UI startup to accommodate first-run compilation

https://claude.ai/code/session_01E1BcZhGT6ZWvkNrGBixxxo