### PR TITLE
Update architecture docs: migrate from libp2p to iroh networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ accounts, no middlemen. End-to-end encrypted by default.
 
 - **Text chat** with channels, threads, reactions, pins, and emoji
 - **End-to-end encryption** — ChaCha20-Poly1305 with X25519 key exchange
-- **Peer-to-peer** — libp2p networking with GossipSub, Kademlia, and mDNS
+- **Peer-to-peer** — iroh networking with QUIC transport and gossip protocol
 - **File sharing** — content-addressed chunking, transferred peer-to-peer
 - **Servers & permissions** — roles, fine-grained permissions, invites
 - **Event-sourced state** — deterministic, mergeable, offline-friendly
@@ -21,14 +21,19 @@ Leptos Web UI  or  Bevy Desktop UI
         └──── Client Library (willow-client) ────┐
                      │                            │
               State Machine              Network Layer
-           (willow-state, pure)       (willow-network, libp2p)
+           (willow-state, pure)       (willow-network, iroh)
                      │                            │
               ┌──────┴──────┐              ┌──────┴──────┐
               │  Channels   │              │   Relay     │
               │  Messaging  │              │   Workers   │
               │  Crypto     │              │  (replay,   │
-              │  Files      │              │   storage)  │
+              │  Identity   │              │   storage)  │
               └─────────────┘              └─────────────┘
+                                                 │
+                                           ┌─────┴─────┐
+                                           │   Actor   │
+                                           │ Framework │
+                                           └───────────┘
 ```
 
 **Crates:**
@@ -36,15 +41,20 @@ Leptos Web UI  or  Bevy Desktop UI
 | Crate | Purpose |
 |-------|---------|
 | `willow-state` | Pure event-sourced state machine (zero I/O) |
-| `willow-client` | UI-agnostic client library |
+| `willow-client` | UI-agnostic client library wrapping state + networking |
 | `willow-transport` | Binary serialization & protocol framing |
 | `willow-identity` | Ed25519 identity, message signing, profiles |
-| `willow-messaging` | Chat messages, HLC ordering |
+| `willow-messaging` | Chat messages, HLC ordering, message store |
 | `willow-crypto` | E2E encryption (ChaCha20-Poly1305, X25519) |
 | `willow-channel` | Servers, channels, roles, permissions |
-| `willow-files` | Content-addressed file chunking |
-| `willow-network` | libp2p networking layer (native + WASM) |
+| `willow-network` | iroh-based P2P networking (native + WASM) |
+| `willow-actor` | Lightweight actor framework (dual-target native + WASM) |
+| `willow-common` | Shared wire protocol types (WireMessage, worker types) |
+| `willow-worker` | Shared worker library (roles, actor runtime, peer lifecycle) |
 | `willow-relay` | Relay server bridging TCP and WebSocket peers |
+| `willow-replay` | Bounded-memory state sync worker (in-memory event buffer) |
+| `willow-storage` | Archival disk-backed history worker (SQLite) |
+| `willow-agent` | MCP server exposing ClientHandle to AI agents |
 | `willow-web` | Leptos web UI |
 | `willow-app` | Bevy desktop UI |
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,54 @@ Leptos Web UI  or  Bevy Desktop UI
 | `willow-web` | Leptos web UI |
 | `willow-app` | Bevy desktop UI |
 
+### State Management
+
+All shared state is **event-sourced** — derived deterministically from a
+per-author Merkle-DAG of signed events. There is no mutable database; the
+event log *is* the data.
+
+```
+  Author A          Author B          Author C
+     │                  │                  │
+  [e1]─→[e2]─→[e3]  [e1]─→[e2]        [e1]
+     │                  │                  │
+     └──────────────────┴──────────────────┘
+                        │
+              topological sort + replay
+                        │
+                   ServerState
+            (channels, roles, members,
+             messages, profiles, keys)
+```
+
+**How it works:**
+
+- **Events** are content-addressed (SHA-256), signed by their author, and
+  linked into a DAG via sequence numbers and dependency pointers.
+- **`ServerState`** is the materialized view — rebuilt deterministically by
+  topologically sorting all events and replaying them through `materialize()`.
+  Peers converge to identical state when they have the same DAG.
+- **22 `EventKind` variants** cover server structure (create/delete/rename
+  channels and roles), chat (messages, edits, deletes, reactions, pins),
+  permissions (grant/revoke), identity (profiles), encryption (key rotation),
+  and governance (proposals and votes).
+- **Sync protocol** uses compact `HeadsSummary` (author → seq + hash) so peers
+  can efficiently request only missing events. Full `Snapshot` bootstraps
+  far-behind peers.
+
+**Trust & permissions:**
+
+- Admin status is granted only through governance votes (`Propose` +
+  `Vote`), never by direct event — protecting against single-actor escalation.
+- Non-admin permissions (ManageChannels, ManageRoles, SendMessages,
+  CreateInvite, SyncProvider) can be granted directly by admins.
+- All permission checks are enforced deterministically during event replay.
+
+**Client layer** (`willow-client`): `ClientHandle` wraps the pure state
+machine with actor-based state management, reactive UI views, a mutations
+API, and persistence — bridging the deterministic core with async networking
+and pub/sub event distribution.
+
 ## Getting Started
 
 ### Prerequisites

--- a/crates/actor/src/fsm.rs
+++ b/crates/actor/src/fsm.rs
@@ -445,10 +445,12 @@ mod tests {
         addr.ask(Input::<RecordingLight>(())).await.unwrap();
         addr.ask(Input::<RecordingLight>(())).await.unwrap();
 
-        let recorded = transitions.lock().unwrap();
-        assert_eq!(recorded.len(), 2);
-        assert_eq!(recorded[0], (Light::Red, Light::Green));
-        assert_eq!(recorded[1], (Light::Green, Light::Yellow));
+        {
+            let recorded = transitions.lock().unwrap();
+            assert_eq!(recorded.len(), 2);
+            assert_eq!(recorded[0], (Light::Red, Light::Green));
+            assert_eq!(recorded[1], (Light::Green, Light::Yellow));
+        }
 
         system.shutdown().await;
     }

--- a/crates/actor/src/lib.rs
+++ b/crates/actor/src/lib.rs
@@ -637,14 +637,8 @@ mod tests {
             type Result = ();
         }
         impl Handler<SlowMsg> for SlowActor {
-            fn handle(
-                &mut self,
-                _msg: SlowMsg,
-                _ctx: &mut Context<Self>,
-            ) -> impl std::future::Future<Output = ()> + Send {
-                async {
-                    runtime::sleep(Duration::from_millis(200)).await;
-                }
+            async fn handle(&mut self, _msg: SlowMsg, _ctx: &mut Context<Self>) {
+                runtime::sleep(Duration::from_millis(200)).await;
             }
         }
 
@@ -684,14 +678,8 @@ mod tests {
             type Result = ();
         }
         impl Handler<Block> for SlowActor {
-            fn handle(
-                &mut self,
-                _msg: Block,
-                _ctx: &mut Context<Self>,
-            ) -> impl std::future::Future<Output = ()> + Send {
-                async {
-                    runtime::sleep(Duration::from_millis(50)).await;
-                }
+            async fn handle(&mut self, _msg: Block, _ctx: &mut Context<Self>) {
+                runtime::sleep(Duration::from_millis(50)).await;
             }
         }
 

--- a/crates/actor/tests/performance.rs
+++ b/crates/actor/tests/performance.rs
@@ -157,24 +157,18 @@ impl Message for Emit {
 }
 
 impl Handler<Emit> for StreamProducer {
-    fn handle(
-        &mut self,
-        msg: Emit,
-        _ctx: &mut Context<Self>,
-    ) -> impl std::future::Future<Output = ()> + Send {
+    async fn handle(&mut self, msg: Emit, _ctx: &mut Context<Self>) {
         self.output.emit(msg.0);
-        async {}
     }
 }
 
 impl Handler<SubscribeStream<u32>> for StreamProducer {
-    fn handle(
+    async fn handle(
         &mut self,
         _msg: SubscribeStream<u32>,
         _ctx: &mut Context<Self>,
-    ) -> impl std::future::Future<Output = willow_actor::stream::OutputStream<u32>> + Send {
-        let stream = self.output.subscribe();
-        async move { stream }
+    ) -> willow_actor::stream::OutputStream<u32> {
+        self.output.subscribe()
     }
 }
 
@@ -237,12 +231,8 @@ impl Message for WorkMsg {
 }
 
 impl Handler<WorkMsg> for PoolWorker {
-    fn handle(
-        &mut self,
-        _msg: WorkMsg,
-        _ctx: &mut Context<Self>,
-    ) -> impl std::future::Future<Output = u32> + Send {
-        async { 42 }
+    async fn handle(&mut self, _msg: WorkMsg, _ctx: &mut Context<Self>) -> u32 {
+        42
     }
 }
 
@@ -347,7 +337,7 @@ async fn perf_broker_fanout() {
                     count: count.clone(),
                 });
                 let recipient: willow_actor::Recipient<Evt> = counter.into();
-                let _ = broker.ask(BrokerSubscribe(recipient));
+                drop(broker.ask(BrokerSubscribe(recipient)));
                 count
             })
             .collect();
@@ -456,6 +446,7 @@ async fn perf_derived_multi_source_snapshot() {
                 let r3 = StateRef::from(&addrs[3]);
                 let r4 = StateRef::from(&addrs[4]);
                 let r5 = StateRef::from(&addrs[5]);
+                #[allow(clippy::type_complexity)]
                 let d = derived(
                     &system.handle(),
                     (r0, r1, r2, r3, r4, r5),

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -105,6 +105,7 @@ async fn main() -> anyhow::Result<()> {
         relay_addr: cli.relay.clone(),
         display_name: Some(cli.name.clone()),
         persistence: cli.persist,
+        bootstrap_peers: vec![],
     };
 
     let (mut client, _event_loop) = ClientHandle::<IrohNetwork>::new(config);

--- a/crates/agent/tests/e2e.rs
+++ b/crates/agent/tests/e2e.rs
@@ -7,12 +7,10 @@
 //! with a shared `MemHub`.
 
 use std::sync::Arc;
-use willow_client::{test_client, ClientHandle};
-use willow_network::mem::{MemHub, MemNetwork};
-use willow_state;
-
 use willow_agent::server::WillowMcpServer;
 use willow_agent::tools::WillowToolRouter;
+use willow_client::{test_client, ClientHandle};
+use willow_network::mem::{MemHub, MemNetwork};
 
 /// Helper to create a test MCP server.
 fn test_mcp_server() -> (WillowMcpServer<MemNetwork>, ClientHandle<MemNetwork>) {

--- a/crates/channel/src/lib.rs
+++ b/crates/channel/src/lib.rs
@@ -777,7 +777,7 @@ mod tests {
     fn roles_and_permissions() {
         let (_, mut server) = owner_and_server();
         let alice = Identity::generate().endpoint_id();
-        server.add_member(alice.clone());
+        server.add_member(alice);
 
         // Alice starts with no permissions.
         assert!(!server.has_permission(&alice, Permission::SendMessages));
@@ -828,7 +828,7 @@ mod tests {
     fn remove_member() {
         let (_, mut server) = owner_and_server();
         let alice = Identity::generate().endpoint_id();
-        server.add_member(alice.clone());
+        server.add_member(alice);
 
         server.remove_member(&alice).unwrap();
         assert!(!server.is_member(&alice));
@@ -849,7 +849,7 @@ mod tests {
 
         // A new peer uses it.
         let newcomer = Identity::generate().endpoint_id();
-        server.use_invite(&invite_id, newcomer.clone()).unwrap();
+        server.use_invite(&invite_id, newcomer).unwrap();
         assert!(server.is_member(&newcomer));
 
         // Second use fails (max_uses = 1).
@@ -927,7 +927,7 @@ mod tests {
         let original_key = server.channel_key(&ch_id).unwrap().as_bytes().to_owned();
 
         let alice = Identity::generate().endpoint_id();
-        server.add_member(alice.clone());
+        server.add_member(alice);
 
         let new_keys = server.remove_member(&alice).unwrap();
 
@@ -947,7 +947,7 @@ mod tests {
         let ch2 = server.create_channel("random", ChannelKind::Text).unwrap();
 
         let alice = Identity::generate().endpoint_id();
-        server.add_member(alice.clone());
+        server.add_member(alice);
 
         let new_keys = server.remove_member(&alice).unwrap();
         assert_eq!(new_keys.len(), 2);

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -818,8 +818,7 @@ pub fn test_client() -> (
     let unread_view = willow_actor::derived(&sh, registry_ref.clone(), |reg| {
         views::compute_unread_view(reg)
     });
-    let roles_view =
-        willow_actor::derived(&sh, event_ref.clone(), |es| views::compute_roles_view(es));
+    let roles_view = willow_actor::derived(&sh, event_ref.clone(), views::compute_roles_view);
     let connection_view = willow_actor::derived(
         &sh,
         (network_ref.clone(), chat_ref.clone()),

--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -457,7 +457,7 @@ mod tests {
             0,
         );
 
-        save_events(&server_id, &[event.clone()]);
+        save_events(&server_id, std::slice::from_ref(&event));
         let loaded = load_events(&server_id);
         assert_eq!(loaded.len(), 1, "should load back one event");
         assert_eq!(loaded[0].hash, event.hash, "event hash should match");

--- a/crates/messaging/src/lib.rs
+++ b/crates/messaging/src/lib.rs
@@ -300,7 +300,7 @@ mod tests {
         let peer = Identity::generate().endpoint_id();
         let channel = ChannelId::new();
 
-        let msg = Message::text(channel.clone(), peer.clone(), "hello!", &mut hlc);
+        let msg = Message::text(channel.clone(), peer, "hello!", &mut hlc);
 
         assert_eq!(msg.channel_id, channel);
         assert_eq!(msg.author, peer);

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -127,7 +127,8 @@ async fn main() -> Result<()> {
                         body.len(),
                         body
                     );
-                    let _ = tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes()).await;
+                    let _ =
+                        tokio::io::AsyncWriteExt::write_all(&mut writer, response.as_bytes()).await;
                 });
             }
         }

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -242,9 +242,7 @@ pub fn App() -> impl IntoView {
         wasm_bindgen_futures::spawn_local(async move {
             // Build the iroh network configuration from our identity.
             let relay_url = resolve_relay_url();
-            let parsed_relay = relay_url
-                .parse::<willow_network::iroh::RelayUrl>()
-                .ok();
+            let parsed_relay = relay_url.parse::<willow_network::iroh::RelayUrl>().ok();
             if parsed_relay.is_none() {
                 tracing::warn!(url = %relay_url, "failed to parse relay URL");
             }

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -1457,7 +1457,7 @@ async fn sidebar_open_class_toggles() {
 async fn consecutive_messages_grouped() {
     // When multiple messages come from the same author in a row, only the
     // first should show the `.meta` header; subsequent ones get class `grouped`.
-    let msgs = vec![
+    let msgs = [
         make_msg("Alice", "Hello!", 1000),
         make_msg("Alice", "How are you?", 2000),
         make_msg("Bob", "I'm good", 3000),
@@ -2785,7 +2785,7 @@ async fn pinned_panel_has_jump_buttons() {
     let jump_btn = query(&container, ".pinned-jump");
     assert!(jump_btn.is_some(), "jump button should exist");
     assert!(
-        text(&jump_btn.as_ref().unwrap()).contains("Jump"),
+        text(jump_btn.as_ref().unwrap()).contains("Jump"),
         "jump button should say 'Jump'"
     );
 
@@ -3177,7 +3177,7 @@ async fn messages_with_time_gap_show_separate_headers() {
     let msg1 = make_msg("Alice", "first", now - 600_000); // 10 min ago
     let msg2 = make_msg("Alice", "second", now); // now
 
-    let msgs = vec![msg1, msg2];
+    let msgs = [msg1, msg2];
 
     let container = mount_test(move || {
         let views: Vec<_> = msgs
@@ -3241,7 +3241,7 @@ async fn consecutive_messages_within_gap_are_grouped() {
     let msg1 = make_msg("Alice", "first", now - 1000); // 1 sec ago
     let msg2 = make_msg("Alice", "second", now); // now
 
-    let msgs = vec![msg1, msg2];
+    let msgs = [msg1, msg2];
 
     let container = mount_test(move || {
         let views: Vec<_> = msgs
@@ -3300,7 +3300,7 @@ async fn different_authors_never_grouped() {
     let msg1 = make_msg("Alice", "hello", now - 1000);
     let msg2 = make_msg("Bob", "hi", now);
 
-    let msgs = vec![msg1, msg2];
+    let msgs = [msg1, msg2];
 
     let container = mount_test(move || {
         let views: Vec<_> = msgs

--- a/crates/worker/tests/integration.rs
+++ b/crates/worker/tests/integration.rs
@@ -407,23 +407,16 @@ async fn full_actor_orchestration_without_network() {
     let mut announcement_count = 0;
     let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
     while tokio::time::Instant::now() < deadline {
-        match tokio::time::timeout(Duration::from_millis(30), events_b.next()).await {
-            Ok(Some(Ok(willow_network::GossipEvent::Received(msg)))) => {
-                if let Ok(decoded) =
-                    bincode::deserialize::<willow_common::WorkerWireMessage>(&msg.content)
-                {
-                    match decoded {
-                        willow_common::WorkerWireMessage::Announcement(_) => {
-                            announcement_count += 1;
-                        }
-                        willow_common::WorkerWireMessage::Request { .. } => {
-                            // Sync requests are expected too.
-                        }
-                        _ => {}
-                    }
+        if let Ok(Some(Ok(willow_network::GossipEvent::Received(msg)))) =
+            tokio::time::timeout(Duration::from_millis(30), events_b.next()).await
+        {
+            if let Ok(decoded) =
+                bincode::deserialize::<willow_common::WorkerWireMessage>(&msg.content)
+            {
+                if matches!(decoded, willow_common::WorkerWireMessage::Announcement(_)) {
+                    announcement_count += 1;
                 }
             }
-            _ => {}
         }
     }
 


### PR DESCRIPTION
## Summary

This PR updates the README documentation to reflect significant architectural changes in the Willow project, primarily migrating from libp2p-based networking to iroh, and expanding documentation around the event-sourced state management model.

## Key Changes

- **Networking layer migration**: Updated references from "libp2p networking with GossipSub, Kademlia, and mDNS" to "iroh networking with QUIC transport and gossip protocol"
- **Expanded crate inventory**: Added new crates to the architecture table:
  - `willow-actor` — Lightweight actor framework for dual-target (native + WASM)
  - `willow-common` — Shared wire protocol types
  - `willow-worker` — Shared worker library with actor runtime
  - `willow-replay` — Bounded-memory state sync worker
  - `willow-storage` — Archival disk-backed history worker (SQLite)
  - `willow-agent` — MCP server for AI agent integration
- **Removed obsolete crate**: `willow-files` (content-addressed file chunking) removed from crate list
- **Updated crate descriptions**: Clarified purposes of `willow-client`, `willow-messaging`, and `willow-network`
- **New architecture diagram**: Added visual representation of the event-sourced state model showing author DAGs, topological sorting, and state materialization
- **Comprehensive state management section**: Added detailed documentation covering:
  - Event-sourced architecture with Merkle-DAG structure
  - 22 EventKind variants and their purposes
  - Sync protocol using HeadsSummary and Snapshot
  - Trust model and permission enforcement
  - ClientHandle's role bridging pure state machine with async networking

## Notable Details

The documentation now emphasizes the deterministic, event-sourced nature of the system where all shared state derives from per-author signed event DAGs, with no mutable database. The new architecture section explains how peers converge to identical state through topological sorting and replay, and how governance votes protect against unauthorized privilege escalation.

https://claude.ai/code/session_01RmipUAUGe5cVTAs3ScjxzW