### PR TITLE
Add ratchet counter DoS protection and RotateChannelKey authorization

### DIFF
--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -46,6 +46,9 @@ pub enum CryptoError {
 
     #[error("ed25519 to x25519 conversion failed")]
     KeyConversionFailed,
+
+    #[error("ratchet counter {claimed} out of range (max {max})")]
+    RatchetCounterOutOfRange { claimed: u64, max: u64 },
 }
 
 // ───── Types ────────────────────────────────────────────────────────────────
@@ -233,11 +236,49 @@ pub fn seal_content_with_counter(
     })
 }
 
-/// Decrypt a [`SealedContent`] back to a [`Content`] value.
+/// Maximum lookahead above the receiver's current ratchet counter that
+/// [`open_content_bounded`] will accept. This exists to bound the work
+/// [`derive_message_key`] has to do before AEAD verification — without
+/// it, an attacker-controlled `ratchet_counter` in a sealed packet
+/// would force the receiver to perform 2 HKDF-Expand operations per
+/// step up to the claimed value, and `u64::MAX` would take hundreds of
+/// thousands of years on a single core.
 ///
-/// If `ratchet_counter > 0`, derives the per-message key from the channel
-/// key + counter. Otherwise uses the channel key directly (backwards compat).
-pub fn open_content(sealed: &SealedContent, key: &ChannelKey) -> Result<Content, CryptoError> {
+/// The value is deliberately generous (1024 messages) so that a
+/// receiver who misses a burst of messages can still catch up.
+pub const MAX_RATCHET_LOOKAHEAD: u64 = 1024;
+
+/// Decrypt a [`SealedContent`] back to a [`Content`] value, bounding
+/// how far ahead of `current_counter` the sealed packet's claimed
+/// `ratchet_counter` may be.
+///
+/// If `sealed.ratchet_counter > current_counter + MAX_RATCHET_LOOKAHEAD`,
+/// returns [`CryptoError::RatchetCounterOutOfRange`] **before** doing
+/// any HKDF work or AEAD verification. This prevents a CPU DoS where
+/// an attacker ships a packet with a huge `ratchet_counter` and
+/// freezes the receiver inside [`derive_message_key`].
+///
+/// Callers should pass the highest counter they have successfully
+/// processed for this channel epoch. Start at 0 for a fresh channel
+/// and advance monotonically.
+///
+/// If `ratchet_counter == 0`, the channel key is used directly
+/// (backwards compat) and no bounds check applies.
+pub fn open_content_bounded(
+    sealed: &SealedContent,
+    key: &ChannelKey,
+    current_counter: u64,
+) -> Result<Content, CryptoError> {
+    if sealed.ratchet_counter > 0 {
+        let max = current_counter.saturating_add(MAX_RATCHET_LOOKAHEAD);
+        if sealed.ratchet_counter > max {
+            return Err(CryptoError::RatchetCounterOutOfRange {
+                claimed: sealed.ratchet_counter,
+                max,
+            });
+        }
+    }
+
     let decrypt_key = if sealed.ratchet_counter > 0 {
         derive_message_key(key, sealed.key_epoch, sealed.ratchet_counter)
     } else {
@@ -251,6 +292,17 @@ pub fn open_content(sealed: &SealedContent, key: &ChannelKey) -> Result<Content,
         .map_err(|_| CryptoError::DecryptionFailed)?;
 
     willow_transport::unpack(&plaintext).map_err(|e| CryptoError::Serialization(e.to_string()))
+}
+
+/// Decrypt a [`SealedContent`] back to a [`Content`] value.
+///
+/// Thin wrapper over [`open_content_bounded`] with a `current_counter`
+/// of 0 — accepts any `ratchet_counter` up to
+/// [`MAX_RATCHET_LOOKAHEAD`]. Callers that track per-channel ratchet
+/// state should prefer [`open_content_bounded`] directly so they can
+/// advance the allowed window as messages are processed.
+pub fn open_content(sealed: &SealedContent, key: &ChannelKey) -> Result<Content, CryptoError> {
+    open_content_bounded(sealed, key, 0)
 }
 
 // ───── Key Exchange ─────────────────────────────────────────────────────────
@@ -695,5 +747,120 @@ mod tests {
         let debug = format!("{key:?}");
         assert!(debug.contains("REDACTED"));
         assert!(!debug.contains(&format!("{:02x}", key.as_bytes()[0])));
+    }
+
+    // ── Issue #110: ratchet counter DoS bound ──────────────────────
+
+    /// Regression guard for issue #110: a sealed packet with a huge
+    /// `ratchet_counter` must be rejected **before** `derive_message_key`
+    /// is called. Without the bound, u64::MAX would take ~584 000 years
+    /// of HKDF work on a single core.
+    #[test]
+    fn open_content_rejects_huge_ratchet_counter() {
+        let key = generate_channel_key();
+        let content = Content::Text { body: "x".into() };
+
+        // Seal a legitimate packet at counter=1 so the ciphertext is valid
+        // for that key, then tamper with the ratchet_counter field.
+        let mut ratchet = KeyRatchet::new(&key, 0);
+        let (msg_key, epoch, counter) = ratchet.next_key();
+        let mut sealed = seal_content_with_counter(&content, &msg_key, epoch, counter).unwrap();
+        sealed.ratchet_counter = u64::MAX;
+
+        let start = std::time::Instant::now();
+        let result = open_content_bounded(&sealed, &key, 1);
+        let elapsed = start.elapsed();
+
+        assert!(matches!(
+            result,
+            Err(CryptoError::RatchetCounterOutOfRange { .. })
+        ));
+        // Should return almost instantly — an unbounded run would not
+        // complete in any realistic test timeout. 500ms gives CI plenty
+        // of headroom over the ~microsecond real cost of the check.
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "bounds check should return instantly, took {elapsed:?}"
+        );
+    }
+
+    /// Regression guard for issue #110: any counter more than
+    /// `MAX_RATCHET_LOOKAHEAD` above the receiver's current counter
+    /// must be rejected.
+    #[test]
+    fn open_content_bounded_rejects_above_lookahead() {
+        let key = generate_channel_key();
+        let content = Content::Text {
+            body: "attack".into(),
+        };
+        let mut sealed = seal_content_with_counter(&content, &key, 0, 1).unwrap();
+        // current_counter = 100, max = 100 + 1024 = 1124. Claim 1125.
+        sealed.ratchet_counter = 100 + MAX_RATCHET_LOOKAHEAD + 1;
+        let err = open_content_bounded(&sealed, &key, 100).unwrap_err();
+        match err {
+            CryptoError::RatchetCounterOutOfRange { claimed, max } => {
+                assert_eq!(claimed, 100 + MAX_RATCHET_LOOKAHEAD + 1);
+                assert_eq!(max, 100 + MAX_RATCHET_LOOKAHEAD);
+            }
+            other => panic!("expected RatchetCounterOutOfRange, got {other:?}"),
+        }
+    }
+
+    /// Regression guard for issue #110: counters at or within the
+    /// lookahead window must still decrypt successfully.
+    #[test]
+    fn open_content_bounded_accepts_within_lookahead() {
+        let key = generate_channel_key();
+        let content = Content::Text {
+            body: "legitimate catch-up".into(),
+        };
+
+        // Sender is at counter=50.
+        let mut ratchet = KeyRatchet::new(&key, 0);
+        let (mut msg_key, mut epoch, mut counter) = ratchet.next_key();
+        for _ in 0..49 {
+            let (k, e, c) = ratchet.next_key();
+            msg_key = k;
+            epoch = e;
+            counter = c;
+        }
+        assert_eq!(counter, 50);
+        let sealed = seal_content_with_counter(&content, &msg_key, epoch, counter).unwrap();
+
+        // Receiver is at counter=0; 50 is well within 1024 lookahead.
+        let decrypted = open_content_bounded(&sealed, &key, 0).unwrap();
+        assert_eq!(decrypted, content);
+    }
+
+    /// Regression guard for issue #110: the zero-arg `open_content`
+    /// shim rejects counters above `MAX_RATCHET_LOOKAHEAD`, since it
+    /// implicitly uses `current_counter = 0`.
+    #[test]
+    fn open_content_shim_rejects_counter_above_lookahead() {
+        let key = generate_channel_key();
+        let content = Content::Text { body: "x".into() };
+        let mut sealed = seal_content_with_counter(&content, &key, 0, 1).unwrap();
+        sealed.ratchet_counter = MAX_RATCHET_LOOKAHEAD + 1;
+        assert!(matches!(
+            open_content(&sealed, &key),
+            Err(CryptoError::RatchetCounterOutOfRange { .. })
+        ));
+    }
+
+    /// `ratchet_counter == 0` bypasses the ratchet derivation entirely
+    /// (backwards compat), so the bounds check must not apply there.
+    #[test]
+    fn open_content_bounded_counter_zero_bypasses_bounds_check() {
+        let key = generate_channel_key();
+        let content = Content::Text {
+            body: "legacy".into(),
+        };
+        let sealed = seal_content(&content, &key, 0).unwrap();
+        assert_eq!(sealed.ratchet_counter, 0);
+
+        // Even with current_counter = 0, ratchet_counter = 0 means "no
+        // ratchet" and should decrypt fine.
+        let decrypted = open_content_bounded(&sealed, &key, 0).unwrap();
+        assert_eq!(decrypted, content);
     }
 }

--- a/crates/state/src/materialize.rs
+++ b/crates/state/src/materialize.rs
@@ -234,8 +234,8 @@ fn required_permission(kind: &EventKind) -> Option<Permission> {
         | EventKind::SetPermission { .. }
         | EventKind::AssignRole { .. } => Some(Permission::ManageRoles),
 
-        // Admin-only, governance, profile, encryption, pinning — no
-        // Permission variant, checked elsewhere or unrestricted.
+        // Admin-only, governance, profile, pinning — no Permission
+        // variant, checked elsewhere or unrestricted.
         _ => None,
     }
 }

--- a/crates/state/src/materialize.rs
+++ b/crates/state/src/materialize.rs
@@ -120,7 +120,7 @@ fn apply_unchecked(state: &mut ServerState, event: &Event) -> ApplyResult {
     // Permission-checked events.
     // required_permission returns:
     //   Message/EditMessage/DeleteMessage/Reaction → SendMessages
-    //   CreateChannel/DeleteChannel/RenameChannel → ManageChannels
+    //   CreateChannel/DeleteChannel/RenameChannel/RotateChannelKey → ManageChannels
     //   CreateRole/DeleteRole/SetPermission/AssignRole → ManageRoles
     //   All others → None
     let required = required_permission(&event.kind);
@@ -226,7 +226,8 @@ fn required_permission(kind: &EventKind) -> Option<Permission> {
 
         EventKind::CreateChannel { .. }
         | EventKind::DeleteChannel { .. }
-        | EventKind::RenameChannel { .. } => Some(Permission::ManageChannels),
+        | EventKind::RenameChannel { .. }
+        | EventKind::RotateChannelKey { .. } => Some(Permission::ManageChannels),
 
         EventKind::CreateRole { .. }
         | EventKind::DeleteRole { .. }
@@ -406,6 +407,14 @@ fn apply_mutation(state: &mut ServerState, event: &Event) -> ApplyResult {
             channel_id,
             encrypted_keys,
         } => {
+            // Defense-in-depth: reject if the author isn't a member of
+            // the server. The ManageChannels permission check in
+            // `required_permission` is the primary gate, but this guards
+            // against any future code path that might grant permissions
+            // without also adding the peer to `members`.
+            if !state.members.contains_key(&event.author) {
+                return ApplyResult::Rejected(format!("author '{}' is not a member", event.author));
+            }
             if !encrypted_keys.is_empty() {
                 let keys = state.channel_keys.entry(channel_id.clone()).or_default();
                 for (peer_id, key_bytes) in encrypted_keys {

--- a/crates/state/src/tests.rs
+++ b/crates/state/src/tests.rs
@@ -1749,6 +1749,152 @@ fn rotate_channel_key_for_nonexistent_channel() {
     );
 }
 
+// ── Issue #109: RotateChannelKey authority ─────────────────────────────
+
+/// Regression guard for issue #109: an outsider (not a member, not an
+/// admin, never granted ManageChannels) must not be able to inject
+/// channel key material via `RotateChannelKey`. The materializer must
+/// reject the event before applying the mutation.
+#[test]
+fn rotate_channel_key_by_outsider_is_rejected() {
+    let admin = Identity::generate();
+    let mallory = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::CreateChannel {
+            name: "general".to_string(),
+            channel_id: "ch-general".to_string(),
+            kind: "text".to_string(),
+        },
+    );
+
+    // Mallory is a brand-new identity with no relationship to the server.
+    // She tries to inject her own encrypted key for the channel.
+    do_emit(
+        &mut dag,
+        &mallory,
+        EventKind::RotateChannelKey {
+            channel_id: "ch-general".to_string(),
+            encrypted_keys: vec![(mallory.endpoint_id(), vec![0xde, 0xad, 0xbe, 0xef])],
+        },
+    );
+
+    let state = materialize(&dag);
+    // Mallory's injected key must NOT appear in state.
+    let mallory_key_present = state
+        .channel_keys
+        .get("ch-general")
+        .map(|keys| keys.contains_key(&mallory.endpoint_id()))
+        .unwrap_or(false);
+    assert!(
+        !mallory_key_present,
+        "outsider must not be able to rotate channel keys"
+    );
+}
+
+/// Regression guard for issue #109: a regular member without
+/// ManageChannels cannot rotate channel keys either — the permission
+/// check is the primary gate.
+#[test]
+fn rotate_channel_key_by_member_without_manage_channels_is_rejected() {
+    use crate::managed::ManagedDag;
+    use crate::materialize::ApplyResult;
+
+    let alice = Identity::generate();
+    let bob = Identity::generate();
+
+    let mut managed = ManagedDag::new(&alice, "Test Server", 5000);
+
+    // Alice creates a channel and grants Bob SendMessages (which also
+    // adds him to `members`). Bob is a legitimate member but lacks
+    // ManageChannels.
+    let create = managed.dag().create_event(
+        &alice,
+        EventKind::CreateChannel {
+            name: "general".into(),
+            channel_id: "ch1".into(),
+            kind: "text".into(),
+        },
+        vec![],
+        10,
+    );
+    managed.insert_and_apply(create).unwrap();
+
+    let grant_send = managed.dag().create_event(
+        &alice,
+        EventKind::GrantPermission {
+            peer_id: bob.endpoint_id(),
+            permission: Permission::SendMessages,
+        },
+        vec![],
+        20,
+    );
+    managed.insert_and_apply(grant_send).unwrap();
+
+    // Bob tries to rotate the channel key. He has SendMessages but not
+    // ManageChannels, so the permission check should reject.
+    let rotate = managed.dag().create_event(
+        &bob,
+        EventKind::RotateChannelKey {
+            channel_id: "ch1".into(),
+            encrypted_keys: vec![(bob.endpoint_id(), vec![1, 2, 3])],
+        },
+        vec![],
+        30,
+    );
+    let outcome = managed.insert_and_apply(rotate).unwrap();
+    assert!(
+        matches!(outcome.apply_result, Some(ApplyResult::Rejected(_))),
+        "Bob's rotate should be rejected: {:?}",
+        outcome.apply_result
+    );
+    // Bob's key material must not have been inserted.
+    let bob_key_present = managed
+        .state()
+        .channel_keys
+        .get("ch1")
+        .map(|keys| keys.contains_key(&bob.endpoint_id()))
+        .unwrap_or(false);
+    assert!(!bob_key_present);
+}
+
+/// Regression guard for issue #109: an admin (implicit all-permissions)
+/// still can rotate channel keys after the fix. Sanity check that the
+/// permission + membership additions did not break the legitimate path.
+#[test]
+fn rotate_channel_key_by_admin_still_works() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::CreateChannel {
+            name: "general".to_string(),
+            channel_id: "ch-general".to_string(),
+            kind: "text".to_string(),
+        },
+    );
+
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::RotateChannelKey {
+            channel_id: "ch-general".to_string(),
+            encrypted_keys: vec![(admin.endpoint_id(), vec![9, 9, 9])],
+        },
+    );
+
+    let state = materialize(&dag);
+    assert_eq!(
+        state.channel_keys["ch-general"][&admin.endpoint_id()],
+        vec![9, 9, 9]
+    );
+}
+
 // ── Issue #74: ManagedDag — atomic insert + apply ──────────────────────
 
 #[test]


### PR DESCRIPTION
Closes #109
Closes #110
Progresses #108

## Summary

This PR addresses two critical security findings from the code quality review tracked in #108:

1. **#109**: Restricts `RotateChannelKey` events to users with `ManageChannels` permission and adds defense-in-depth membership validation. Before this, any outsider with a valid signature could inject arbitrary encrypted-key bytes into `ServerState.channel_keys`.
2. **#110**: Adds DoS protection against unbounded ratchet counter derivation by introducing a bounded decryption function with a configurable lookahead window. Before this, one malformed packet with `ratchet_counter = u64::MAX` could freeze every recipient's CPU for ~584 000 years on a single core.

## Key Changes

### Crypto Module (`crates/crypto/src/lib.rs`)

- **New error variant**: `RatchetCounterOutOfRange { claimed, max }` to report when a sealed packet's counter exceeds acceptable bounds
- **New constant**: `MAX_RATCHET_LOOKAHEAD = 1024` defines the maximum counter advance a receiver will accept before AEAD verification
- **New function**: `open_content_bounded(sealed, key, current_counter)` performs bounded decryption:
  - Rejects packets with `ratchet_counter > current_counter + MAX_RATCHET_LOOKAHEAD` **before** any HKDF work
  - Prevents CPU DoS where an attacker could force `u64::MAX` iterations of key derivation
  - Allows legitimate catch-up within the lookahead window
  - Bypasses bounds check when `ratchet_counter == 0` (backwards compatibility)
- **Refactored**: `open_content()` now wraps `open_content_bounded()` with `current_counter = 0` for backwards compatibility
- **Comprehensive tests**: Five regression tests covering huge counter rejection, lookahead boundary enforcement, legitimate catch-up, shim rejection above lookahead, and legacy zero-counter behavior

### State Module (`crates/state/src/materialize.rs`)

- **Permission check**: Added `RotateChannelKey` to the list of events requiring `ManageChannels` permission
- **Defense-in-depth**: Added explicit membership validation in `apply_mutation` for `RotateChannelKey` events to reject non-members even if permission checks are bypassed
- **Documentation**: Updated comments to reflect that encryption events now have permission requirements

### State Tests (`crates/state/src/tests.rs`)

- **Three regression tests** for #109:
  - `rotate_channel_key_by_outsider_is_rejected`: Verifies outsiders cannot inject key material
  - `rotate_channel_key_by_member_without_manage_channels_is_rejected`: Verifies permission enforcement
  - `rotate_channel_key_by_admin_still_works`: Sanity check that legitimate admins can still rotate keys

## Implementation Details

- The ratchet counter bounds check uses `saturating_add` to safely handle `current_counter` near `u64::MAX`
- The lookahead window (1024 messages) is deliberately generous to allow receivers to catch up after missing bursts
- The zero-counter special case preserves backwards compatibility with legacy sealed content that doesn't use ratcheting
- Permission checks are layered: `required_permission()` provides the primary gate, and membership validation provides defense-in-depth
- Neither code path has production callers today — the features are dormant at the emission level, so these fixes pre-empt live vulnerabilities rather than patching an exploited surface

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 0 failures (30 crypto tests, 155 state tests, all other crates green)
- [x] `cargo check --target wasm32-unknown-unknown` — clean for all library crates
- [x] Five new crypto regression tests pass in < 10ms total (bounds check returns instantly even for `u64::MAX`)
- [x] Three new state regression tests pass

https://claude.ai/code/session_011cBQL95mF4j2DGCeLgxrsr