### PR TITLE
state: dedupe Reaction events by author

### DIFF
--- a/crates/state/src/materialize.rs
+++ b/crates/state/src/materialize.rs
@@ -386,7 +386,7 @@ fn apply_mutation(state: &mut ServerState, event: &Event) -> ApplyResult {
                 msg.reactions
                     .entry(emoji.clone())
                     .or_default()
-                    .push(event.author);
+                    .insert(event.author);
             }
         }
 

--- a/crates/state/src/tests.rs
+++ b/crates/state/src/tests.rs
@@ -628,8 +628,59 @@ fn duplicate_reaction_from_same_peer() {
     );
 
     let state = materialize(&dag);
-    // Implementation-dependent: may deduplicate or not.
-    assert!(!state.messages[0].reactions.is_empty());
+    // The same author reacting twice with the same emoji collapses to a
+    // single entry — reactions are stored as a set keyed by author.
+    let reactors = state.messages[0]
+        .reactions
+        .get("👍")
+        .expect("emoji should be present");
+    assert_eq!(reactors.len(), 1);
+    assert!(reactors.contains(&admin.endpoint_id()));
+}
+
+#[test]
+fn same_author_duplicate_reaction_is_idempotent() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    let msg = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch-1".to_string(),
+            body: "react to me".to_string(),
+            reply_to: None,
+        },
+    );
+
+    // Apply two distinct Reaction events with the same emoji from the
+    // same author. The events themselves are unique (different hashes
+    // because of timestamps/parents), so dedup must happen at
+    // materialization time.
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Reaction {
+            message_id: msg.hash,
+            emoji: "🎉".to_string(),
+        },
+    );
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Reaction {
+            message_id: msg.hash,
+            emoji: "🎉".to_string(),
+        },
+    );
+
+    let state = materialize(&dag);
+    let reactors = state.messages[0]
+        .reactions
+        .get("🎉")
+        .expect("emoji should be present");
+    assert_eq!(reactors.len(), 1, "duplicate reactions must be deduped");
+    assert!(reactors.contains(&admin.endpoint_id()));
 }
 
 #[test]

--- a/crates/state/src/types.rs
+++ b/crates/state/src/types.rs
@@ -70,8 +70,10 @@ pub struct ChatMessage {
     pub edited: bool,
     /// Whether this message has been soft-deleted.
     pub deleted: bool,
-    /// Reactions: emoji string -> list of reactor endpoint IDs.
-    pub reactions: BTreeMap<String, Vec<EndpointId>>,
+    /// Reactions: emoji string -> set of reactor endpoint IDs.
+    /// Stored as a `BTreeSet` so each peer can only react once with a
+    /// given emoji to a given message.
+    pub reactions: BTreeMap<String, BTreeSet<EndpointId>>,
     /// If this is a reply, the EventHash of the parent message.
     pub reply_to: Option<EventHash>,
 }


### PR DESCRIPTION
## Summary

- Switch `ChatMessage::reactions` from `BTreeMap<String, Vec<EndpointId>>` to `BTreeMap<String, BTreeSet<EndpointId>>` so each peer can only be registered once per (message, emoji).
- Change the `EventKind::Reaction` handler in `materialize.rs` to use `BTreeSet::insert` instead of `Vec::push`, eliminating duplicate reactor entries when the same author emits (or replays) the same Reaction event twice.
- Add a state-machine regression test `same_author_duplicate_reaction_is_idempotent` and tighten the existing `duplicate_reaction_from_same_peer` assertion from "may dedupe or not" to "must dedupe exactly".

## Why

The previous `Vec`-backed shape meant a retransmitted or replayed Reaction would inflate the reactor list, causing UI reaction miscounts and `StateHash` divergence between peers that received different delivery counts of the same event. Deduping by author in the materialized state is both the simplest fix and the most compatible — the wire format of `EventKind::Reaction` is unchanged.

## Scope notes

- The wire/event format is untouched. Only the in-memory materialized state shape changed.
- `DisplayMessage.reactions` in `willow-client` is a separate `HashMap<String, Vec<String>>` of display names and is unaffected.
- Consumers that iterate `.reactions` (e.g. `willow-client::views::messages_view`) work unchanged because they only use `.iter()`.

## Test plan

- [x] `cargo test -p willow-state` — 156 tests pass including the new `same_author_duplicate_reaction_is_idempotent` regression
- [x] `cargo test -p willow-client` — 66 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check --target wasm32-unknown-unknown` for the state/client/channel/messaging/crypto/identity/transport/common/network/actor crates — clean

Closes #111
Progresses #108