### PR TITLE
fix: E2E audit fixes — coverage gaps, broken tests, admin channel gates

### DIFF
--- a/crates/web/src/components/sidebar.rs
+++ b/crates/web/src/components/sidebar.rs
@@ -46,9 +46,11 @@ pub fn Sidebar(
     let handle = use_context::<WebClientHandle>().unwrap();
     let app_state = use_context::<crate::state::AppState>().unwrap();
 
-    // Determine if the local user can create channels (owner only for now).
+    // Admins (including the genesis owner) can create and delete channels.
+    // `admin_ids` always contains the genesis author (server.rs ensures this),
+    // so this check covers the owner as well as any governance-promoted admins.
     let peer_id = app_state.network.peer_id;
-    let is_owner = move || app_state.server.server_owner.get() == peer_id.get();
+    let can_manage_channels = move || app_state.server.admin_ids.get().contains(&peer_id.get());
 
     let (creating, set_creating) = signal(false);
     let (new_name, set_new_name) = signal(String::new());
@@ -113,7 +115,7 @@ pub fn Sidebar(
             <div class="channel-list">
                 <div class="channel-list-header">
                     <span class="channel-list-title">"CHANNELS"</span>
-                    {move || is_owner().then(|| view! {
+                    {move || can_manage_channels().then(|| view! {
                         <button
                             class="channel-add-btn"
                             title="Create channel"
@@ -216,18 +218,23 @@ pub fn Sidebar(
                                     }
                                     {
                                         let ch_d = ch_delete.clone();
-                                        view! {
-                                            <button
-                                                class="delete-btn"
-                                                title="Delete channel"
-                                                on:click=move |ev| {
-                                                    ev.stop_propagation();
-                                                    set_pending_del_channel.set(Some(ch_d.clone()));
-                                                    set_show_del_confirm.set(true);
-                                                }
-                                            >
-                                                "x"
-                                            </button>
+                                        // Clone ch_d inside the reactive closure so it
+                                        // remains FnMut (String is not Copy).
+                                        move || {
+                                            let ch_d = ch_d.clone();
+                                            can_manage_channels().then(|| view! {
+                                                <button
+                                                    class="delete-btn"
+                                                    title="Delete channel"
+                                                    on:click=move |ev| {
+                                                        ev.stop_propagation();
+                                                        set_pending_del_channel.set(Some(ch_d.clone()));
+                                                        set_show_del_confirm.set(true);
+                                                    }
+                                                >
+                                                    "x"
+                                                </button>
+                                            })
                                         }
                                     }
                                 </span>

--- a/crates/web/src/components/sidebar.rs
+++ b/crates/web/src/components/sidebar.rs
@@ -46,6 +46,10 @@ pub fn Sidebar(
     let handle = use_context::<WebClientHandle>().unwrap();
     let app_state = use_context::<crate::state::AppState>().unwrap();
 
+    // Determine if the local user can create channels (owner only for now).
+    let peer_id = app_state.network.peer_id;
+    let is_owner = move || app_state.server.server_owner.get() == peer_id.get();
+
     let (creating, set_creating) = signal(false);
     let (new_name, set_new_name) = signal(String::new());
     let (create_voice, set_create_voice) = signal(false);
@@ -109,13 +113,15 @@ pub fn Sidebar(
             <div class="channel-list">
                 <div class="channel-list-header">
                     <span class="channel-list-title">"CHANNELS"</span>
-                    <button
-                        class="channel-add-btn"
-                        title="Create channel"
-                        on:click=move |_| set_creating.set(true)
-                    >
-                        {icons::icon_plus()}
-                    </button>
+                    {move || is_owner().then(|| view! {
+                        <button
+                            class="channel-add-btn"
+                            title="Create channel"
+                            on:click=move |_| set_creating.set(true)
+                        >
+                            {icons::icon_plus()}
+                        </button>
+                    })}
                 </div>
                 {move || {
                     if creating.get() {

--- a/e2e/cross-browser-sync.spec.ts
+++ b/e2e/cross-browser-sync.spec.ts
@@ -79,10 +79,13 @@ test.describe('Cross-browser peer sync', () => {
       await expect(mobilePage.locator('.channel-item', { hasText: 'general' }))
         .toBeVisible({ timeout: 5_000 });
 
-      // Wait until desktop Firefox sees mobile Chrome as a member — this confirms
-      // the gossip mesh is bidirectionally established (NeighborUp fired on both
-      // sides) before we test the Firefox→Chrome direction, which is the slow path.
-      await desktopPage.locator('.member-item').nth(1).waitFor({ timeout: 30_000 });
+      // Establish bidirectional gossip mesh: Chrome→Firefox is the reliable direction.
+      // Waiting for Firefox to *receive* a Chrome message proves both gossip paths are
+      // open — round-trip delivery requires NeighborUp to have fired on both sides.
+      // (member-item appearance on Firefox alone only confirms Firefox's NeighborUp,
+      // not Chrome's reverse path which is required for the main assertion below.)
+      await sendMessage(mobilePage, 'warmup');
+      await waitForMessage(desktopPage, 'warmup', 30_000);
 
       // Desktop Firefox: send a message.
       await sendMessage(desktopPage, 'Hello from Firefox desktop');

--- a/e2e/cross-browser-sync.spec.ts
+++ b/e2e/cross-browser-sync.spec.ts
@@ -107,7 +107,7 @@ test.describe('Cross-browser peer sync', () => {
     }
   });
 
-  test('desktop Firefox to mobile Chrome — invite + channel sync', async () => {
+  test('mobile Chrome to desktop Firefox — server owner sends, joiner receives', async () => {
     const mobileBrowser = await chromium.launch();
     const mobileCtx = await mobileBrowser.newContext({
       ...devices['Pixel 7'],

--- a/e2e/cross-browser-sync.spec.ts
+++ b/e2e/cross-browser-sync.spec.ts
@@ -1,7 +1,9 @@
 import { test, expect, chromium, firefox, devices } from '@playwright/test';
 
-// Custom Firefox context options — avoids the relay connectivity issue
-// caused by devices['Desktop Firefox'] (Windows UA + screen dimensions).
+// Custom Firefox context options — avoids flakiness seen with the full
+// devices['Desktop Firefox'] preset (which sets a Windows UA + specific screen
+// dimensions that appear to slow gossip mesh formation, cause unknown).
+// Using a plain viewport gives consistent behaviour.
 const desktopFirefoxContext = {
   viewport: { width: 1280, height: 720 },
   hasTouch: false,
@@ -68,11 +70,8 @@ test.describe('Cross-browser peer sync', () => {
       await mobilePage.waitForTimeout(500);
       await mobilePage.locator('button', { hasText: 'Join Server' }).click();
       await mobilePage.waitForSelector('.sidebar, .app', { timeout: 20_000 });
-      await mobilePage.waitForTimeout(5000); // Wait for P2P sync.
 
-      // Verify mobile sees the server (sidebar should have "general" channel).
-      // First wait for the channel item to be in the DOM regardless of sidebar state
-      // (gossip sync can take time; sidebar may close during the wait on mobile).
+      // Verify mobile sees the server — wait for DOM attachment first (gossip may lag).
       await expect(mobilePage.locator('.channel-item', { hasText: 'general' }))
         .toBeAttached({ timeout: 60_000 });
       // Now open the sidebar and confirm the item is visible.
@@ -80,12 +79,10 @@ test.describe('Cross-browser peer sync', () => {
       await expect(mobilePage.locator('.channel-item', { hasText: 'general' }))
         .toBeVisible({ timeout: 5_000 });
 
-      // Warmup: Mobile Chrome sends first — this direction is reliable and
-      // ensures the gossip mesh is bidirectionally established before the
-      // main assertion. The relay's QUIC-dial to Firefox WASM peers can fail,
-      // so we need Chrome→Firefox traffic to stabilise the mesh first.
-      await sendMessage(mobilePage, 'mobile warmup');
-      await waitForMessage(desktopPage, 'mobile warmup', 30_000);
+      // Wait until desktop Firefox sees mobile Chrome as a member — this confirms
+      // the gossip mesh is bidirectionally established (NeighborUp fired on both
+      // sides) before we test the Firefox→Chrome direction, which is the slow path.
+      await desktopPage.locator('.member-item').nth(1).waitFor({ timeout: 30_000 });
 
       // Desktop Firefox: send a message.
       await sendMessage(desktopPage, 'Hello from Firefox desktop');
@@ -150,12 +147,12 @@ test.describe('Cross-browser peer sync', () => {
       await desktopPage.waitForTimeout(500);
       await desktopPage.locator('button', { hasText: 'Join Server' }).click();
       await desktopPage.waitForSelector('.sidebar', { timeout: 20_000 });
-      await desktopPage.waitForTimeout(5000);
 
-      // Desktop should see "general" channel.
-      // Gossip sync after joining can be slow; wait up to 60s for the channel list.
+      // Gossip sync after joining can be slow — wait for DOM attachment before visibility.
       await expect(desktopPage.locator('.channel-item', { hasText: 'general' }))
-        .toBeVisible({ timeout: 60_000 });
+        .toBeAttached({ timeout: 60_000 });
+      await expect(desktopPage.locator('.channel-item', { hasText: 'general' }))
+        .toBeVisible({ timeout: 5_000 });
 
       // Mobile sends a message.
       await sendMessage(mobilePage, 'Cross browser works!');

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -282,7 +282,9 @@ export async function setupTwoPeers(
       await page1.locator('.member-item', { hasText: peer2Name })
         .waitFor({ timeout: 20_000 });
     } catch {
-      // Display name sync may be slow; proceed anyway.
+      // Display name sync may be slow; proceed anyway — but warn so failures
+      // here don't produce misleading timeouts in downstream assertions.
+      console.warn('[setupTwoPeers] peer2 display name did not sync in time — P2P may be slow');
     }
     await closeMemberList(page1);
   }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -303,13 +303,6 @@ export async function createChannel(page: Page, name: string) {
   await closeSidebar(page);
 }
 
-/** Switches to a channel by name on mobile (opens sidebar, clicks channel). */
-export async function switchChannelMobile(page: Page, channelName: string) {
-  await openSidebar(page);
-  await page.locator('.channel-item', { hasText: channelName }).click();
-  await page.waitForTimeout(300);
-}
-
 // ── Message actions ───────────────────────────────────────────────────
 
 /** Performs a named action on a message (desktop: hover+dropdown, mobile: long-press+sheet). */
@@ -346,7 +339,7 @@ export async function editMessage(page: Page, originalText: string, newText: str
 export async function deleteMessage(page: Page, text: string) {
   await messageAction(page, text, 'Delete');
   // Confirm the deletion dialog.
-  const confirmBtn = page.locator('.confirm-dialog .btn-danger, .confirm-dialog button', { hasText: 'Delete' });
+  const confirmBtn = page.locator('.confirm-dialog .btn-danger', { hasText: 'Delete' });
   await confirmBtn.waitFor({ timeout: 3000 });
   await confirmBtn.click();
   await page.waitForTimeout(500);
@@ -410,7 +403,7 @@ export async function kickPeer(page: Page, peerName: string) {
   await member.locator('.btn-danger', { hasText: 'Kick' }).click();
   await page.waitForTimeout(500);
   // Confirm the kick dialog.
-  const confirmBtn = page.locator('.confirm-dialog .btn-danger, .confirm-dialog button', { hasText: 'Kick' });
+  const confirmBtn = page.locator('.confirm-dialog .btn-danger', { hasText: 'Kick' });
   await confirmBtn.waitFor({ timeout: 5_000 });
   await confirmBtn.click();
   await page.waitForTimeout(500);

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -412,9 +412,3 @@ export async function kickPeer(page: Page, peerName: string) {
   await closeMemberList(page);
 }
 
-/** Waits until the member list shows the expected count of members. */
-export async function waitForPeerCount(page: Page, count: number, timeout = 20_000) {
-  await openMemberList(page);
-  await expect(page.locator('.member-item')).toHaveCount(count, { timeout });
-  await closeMemberList(page);
-}

--- a/e2e/join-links.spec.ts
+++ b/e2e/join-links.spec.ts
@@ -68,19 +68,21 @@ test.describe('Join via shareable link', () => {
     await ctxB.close();
   });
 
-  test('invalid invite code does not proceed to join form', async ({ browser }) => {
-    // Entering a garbage code and clicking Next should NOT show the Join Server
-    // button — the server lookup must fail gracefully rather than proceeding to
-    // a broken join form or hanging silently.
+  test('joining with invalid code does not reach the chat', async ({ browser }) => {
+    // Entering a garbage invite code and attempting to join should not navigate
+    // to a server. The app must fail gracefully — no channel list, no chat area.
     const ctx = await browser.newContext();
     const page = await ctx.newPage();
     try {
       await freshStart(page);
       await page.locator('.welcome-invite-input').fill('this-is-definitely-not-a-valid-invite-code');
       await page.locator('button', { hasText: 'Next' }).click();
-      // The join form should not appear — server lookup fails for invalid codes.
-      await expect(page.locator('button', { hasText: 'Join Server' }))
-        .toBeHidden({ timeout: 5_000 });
+      // Current behaviour: Next shows the join form for any non-empty input
+      // (server lookup is deferred to the join step).
+      await page.locator('button', { hasText: 'Join Server' }).waitFor({ timeout: 3_000 });
+      await page.locator('button', { hasText: 'Join Server' }).click();
+      // The join should fail — no channel list should ever appear.
+      await expect(page.locator('.channel-item')).toBeHidden({ timeout: 10_000 });
     } finally {
       await ctx.close();
     }

--- a/e2e/join-links.spec.ts
+++ b/e2e/join-links.spec.ts
@@ -50,12 +50,13 @@ test.describe('Join via shareable link', () => {
 
     // Wait for join to complete (join page disappears, chat appears).
     await pageB.waitForSelector('.sidebar, .app', { timeout: 30000 });
-    await pageB.waitForTimeout(5000);
 
-    // Verify B sees the server.
+    // Verify B sees the server — wait for DOM attachment first (gossip may lag).
+    await expect(pageB.locator('.channel-item', { hasText: 'general' }))
+      .toBeAttached({ timeout: 30_000 });
     await openSidebar(pageB);
     await expect(pageB.locator('.channel-item', { hasText: 'general' }))
-      .toBeVisible({ timeout: 20000 });
+      .toBeVisible({ timeout: 5_000 });
 
     // A sends a message.
     await sendMessage(pageA, 'Welcome Bob!');
@@ -65,5 +66,23 @@ test.describe('Join via shareable link', () => {
 
     await ctxA.close();
     await ctxB.close();
+  });
+
+  test('invalid invite code does not proceed to join form', async ({ browser }) => {
+    // Entering a garbage code and clicking Next should NOT show the Join Server
+    // button — the server lookup must fail gracefully rather than proceeding to
+    // a broken join form or hanging silently.
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    try {
+      await freshStart(page);
+      await page.locator('.welcome-invite-input').fill('this-is-definitely-not-a-valid-invite-code');
+      await page.locator('button', { hasText: 'Next' }).click();
+      // The join form should not appear — server lookup fails for invalid codes.
+      await expect(page.locator('button', { hasText: 'Join Server' }))
+        .toBeHidden({ timeout: 5_000 });
+    } finally {
+      await ctx.close();
+    }
   });
 });

--- a/e2e/multi-peer-mobile.spec.ts
+++ b/e2e/multi-peer-mobile.spec.ts
@@ -7,7 +7,7 @@ import {
   openSidebar,
   openMemberList,
   closeMemberList,
-  switchChannelMobile,
+  switchChannel,
 } from './helpers';
 
 test.describe('Multi-peer mobile', () => {
@@ -87,11 +87,11 @@ test.describe('Multi-peer mobile', () => {
         .toBeAttached({ timeout: 60_000 });
 
       // Alice switches to the new channel and sends a message.
-      await switchChannelMobile(page1, 'mobile-dev');
+      await switchChannel(page1, 'mobile-dev');
       await sendMessage(page1, 'dev channel msg');
 
       // Bob switches to the new channel and should see the message.
-      await switchChannelMobile(page2, 'mobile-dev');
+      await switchChannel(page2, 'mobile-dev');
       await waitForMessage(page2, 'dev channel msg', 30_000);
     } finally {
       await ctx1.close();

--- a/e2e/multi-peer-sync.spec.ts
+++ b/e2e/multi-peer-sync.spec.ts
@@ -325,6 +325,8 @@ test.describe('Multi-peer state synchronization', () => {
       // Peer 2 reopens in the same context (localStorage preserved — server key intact).
       const page2new = await ctx2.newPage();
       await page2new.goto('/');
+      // Wait for WASM to load before checking for messages — a timeout here is a
+      // load failure, not a P2P failure, and should appear as such in CI logs.
       await waitForApp(page2new);
 
       // On reconnect Peer 2 sends a SyncRequest; Peer 1 responds with the missed event.

--- a/e2e/multi-peer-sync.spec.ts
+++ b/e2e/multi-peer-sync.spec.ts
@@ -14,7 +14,6 @@ import {
   editMessage,
   deleteMessage,
   reactToMessage,
-  waitForPeerCount,
   openSidebar,
 } from './helpers';
 
@@ -336,29 +335,23 @@ test.describe('Multi-peer state synchronization', () => {
     }
   });
 
-  test('concurrent channel creation — both channels appear on both peers', async ({ browser }) => {
-    // Both peers create a channel at the same time; the gossip merge must
-    // converge so both channels are visible on both sides. Mirrors the
-    // state-machine stress_concurrent_channel_creates test at the E2E layer.
+  test('rapid channel creation by owner — both channels propagate to peer', async ({ browser }) => {
+    // Owner creates two channels in quick succession; the gossip mesh must
+    // deliver both events to the remote peer without dropping or reordering.
+    // E2E companion to the state-machine stress_concurrent_channel_creates test.
+    // Note: only the owner (Alice) can create channels — non-owners lack
+    // ManageChannels permission and their creation attempts are rejected.
     const { ctx1, ctx2, page1, page2 } = await setupTwoPeers(browser);
     try {
-      // Create channels concurrently.
-      await Promise.all([
-        createChannel(page1, 'chan-alice'),
-        createChannel(page2, 'chan-bob'),
-      ]);
+      // Alice (owner) creates two channels back-to-back.
+      await createChannel(page1, 'chan-a');
+      await createChannel(page1, 'chan-b');
 
-      // Both channels should appear on both peers after gossip merge.
-      await openSidebar(page1);
-      await expect(page1.locator('.channel-item', { hasText: 'chan-alice' }))
-        .toBeVisible({ timeout: 30_000 });
-      await expect(page1.locator('.channel-item', { hasText: 'chan-bob' }))
-        .toBeVisible({ timeout: 30_000 });
-
+      // Both should appear on Bob's side after gossip delivery.
       await openSidebar(page2);
-      await expect(page2.locator('.channel-item', { hasText: 'chan-alice' }))
+      await expect(page2.locator('.channel-item', { hasText: 'chan-a' }))
         .toBeVisible({ timeout: 30_000 });
-      await expect(page2.locator('.channel-item', { hasText: 'chan-bob' }))
+      await expect(page2.locator('.channel-item', { hasText: 'chan-b' }))
         .toBeVisible({ timeout: 30_000 });
     } finally {
       await ctx1.close();

--- a/e2e/multi-peer-sync.spec.ts
+++ b/e2e/multi-peer-sync.spec.ts
@@ -269,4 +269,100 @@ test.describe('Multi-peer state synchronization', () => {
       await ctx2.close();
     }
   });
+
+  test('pre-existing messages visible to peer who joins later', async ({ browser }) => {
+    // Manual setup — Peer 1 sends messages BEFORE Peer 2 joins.
+    // Verifies the SyncBatch history-replay path in the WASM client.
+    const ctx1 = await browser.newContext();
+    const ctx2 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+    const page2 = await ctx2.newPage();
+
+    try {
+      // Peer 1: Create server and send messages before anyone else joins.
+      await freshStart(page1);
+      await createServer(page1, 'History Server', 'Alice');
+
+      await sendMessage(page1, 'msg before join 1');
+      await sendMessage(page1, 'msg before join 2');
+      await sendMessage(page1, 'msg before join 3');
+
+      // Peer 2: Get peer ID.
+      await freshStart(page2);
+      const peer2Id = await getPeerId(page2);
+
+      // Peer 1: Generate invite.
+      const inviteCode = await generateInvite(page1, peer2Id);
+
+      // Peer 2: Join (Peer 1 is still online — Peer 2 gets history via SyncBatch).
+      await joinViaInvite(page2, inviteCode, 'Bob');
+
+      // All three pre-existing messages should arrive via SyncBatch from Peer 1.
+      await waitForMessage(page2, 'msg before join 1', 30_000);
+      await waitForMessage(page2, 'msg before join 2', 30_000);
+      await waitForMessage(page2, 'msg before join 3', 30_000);
+    } finally {
+      await ctx1.close();
+      await ctx2.close();
+    }
+  });
+
+  test('missed messages received after peer reconnects', async ({ browser }) => {
+    // Peer 2 goes offline, Peer 1 sends a message, Peer 2 comes back and
+    // receives the missed message via SyncRequest on reconnect.
+    const { ctx1, ctx2, page1, page2 } = await setupTwoPeers(browser);
+    try {
+      // Establish baseline — both peers online.
+      await sendMessage(page1, 'before disconnect');
+      await waitForMessage(page2, 'before disconnect', 30_000);
+
+      // Peer 2 closes its page (simulates browser tab close / brief offline).
+      await page2.close();
+
+      // Peer 1 sends a message while Peer 2 is offline.
+      await sendMessage(page1, 'sent while offline');
+      await page1.waitForTimeout(1000);
+
+      // Peer 2 reopens in the same context (localStorage preserved — server key intact).
+      const page2new = await ctx2.newPage();
+      await page2new.goto('/');
+      await waitForApp(page2new);
+
+      // On reconnect Peer 2 sends a SyncRequest; Peer 1 responds with the missed event.
+      await waitForMessage(page2new, 'sent while offline', 30_000);
+    } finally {
+      await ctx1.close();
+      await ctx2.close();
+    }
+  });
+
+  test('concurrent channel creation — both channels appear on both peers', async ({ browser }) => {
+    // Both peers create a channel at the same time; the gossip merge must
+    // converge so both channels are visible on both sides. Mirrors the
+    // state-machine stress_concurrent_channel_creates test at the E2E layer.
+    const { ctx1, ctx2, page1, page2 } = await setupTwoPeers(browser);
+    try {
+      // Create channels concurrently.
+      await Promise.all([
+        createChannel(page1, 'chan-alice'),
+        createChannel(page2, 'chan-bob'),
+      ]);
+
+      // Both channels should appear on both peers after gossip merge.
+      await openSidebar(page1);
+      await expect(page1.locator('.channel-item', { hasText: 'chan-alice' }))
+        .toBeVisible({ timeout: 30_000 });
+      await expect(page1.locator('.channel-item', { hasText: 'chan-bob' }))
+        .toBeVisible({ timeout: 30_000 });
+
+      await openSidebar(page2);
+      await expect(page2.locator('.channel-item', { hasText: 'chan-alice' }))
+        .toBeVisible({ timeout: 30_000 });
+      await expect(page2.locator('.channel-item', { hasText: 'chan-bob' }))
+        .toBeVisible({ timeout: 30_000 });
+    } finally {
+      await ctx1.close();
+      await ctx2.close();
+    }
+  });
 });

--- a/e2e/permissions.spec.ts
+++ b/e2e/permissions.spec.ts
@@ -164,9 +164,9 @@ test.describe('Permissions and trust', () => {
 
     const { ctx1, ctx2, page1, page2 } = await setupTwoPeers(browser, 'Chan Perm', 'Alice', 'Bob');
     try {
-      // Bob (non-owner, no ManageChannels grant) should not see the channel-add button.
-      // The state machine rejects ManageChannels mutations from non-owners, but the
-      // UI must also hide the control — otherwise errors are swallowed silently.
+      // Bob (non-admin) should not see the channel-add or delete buttons.
+      // The state machine rejects ManageChannels mutations from non-admins, but the
+      // UI must also hide the controls — otherwise errors are swallowed silently.
       await expect(page2.locator('.channel-add-btn')).toBeHidden({ timeout: 5_000 });
     } finally {
       await ctx1.close();

--- a/e2e/permissions.spec.ts
+++ b/e2e/permissions.spec.ts
@@ -158,6 +158,22 @@ test.describe('Permissions and trust', () => {
     }
   });
 
+  test('non-owner cannot create a channel — add button absent', async ({ browser }, testInfo) => {
+    // Desktop only — easier to assert button visibility without sidebar toggle.
+    test.skip(testInfo.project.name.startsWith('mobile'), 'desktop only');
+
+    const { ctx1, ctx2, page1, page2 } = await setupTwoPeers(browser, 'Chan Perm', 'Alice', 'Bob');
+    try {
+      // Bob (non-owner, no ManageChannels grant) should not see the channel-add button.
+      // The state machine rejects ManageChannels mutations from non-owners, but the
+      // UI must also hide the control — otherwise errors are swallowed silently.
+      await expect(page2.locator('.channel-add-btn')).toBeHidden({ timeout: 5_000 });
+    } finally {
+      await ctx1.close();
+      await ctx2.close();
+    }
+  });
+
   test('non-owner has no action buttons in member list', async ({ browser }, testInfo) => {
     // Skip on mobile — two-peer setup + member list toggle is flaky on narrow viewports.
     test.skip(testInfo.project.name.startsWith('mobile'), 'desktop only');

--- a/e2e/worker-nodes.spec.ts
+++ b/e2e/worker-nodes.spec.ts
@@ -8,12 +8,9 @@ import {
 test.describe('Worker nodes infrastructure', () => {
   test.setTimeout(60_000);
 
-  // Skip on mobile — member list toggle behavior differs.
-  test.beforeEach(({}, testInfo) => {
-    test.skip(testInfo.project.name.startsWith('mobile'), 'desktop only');
-  });
-
-  test('member list renders with correct section structure', async ({ page }) => {
+  test('member list renders with correct section structure', async ({ page }, testInfo) => {
+    // Member list is always visible on desktop; toggling differs on mobile.
+    test.skip(testInfo.project.name.startsWith('mobile'), 'member list always-visible on desktop only');
     await freshStart(page);
     await createServer(page, 'Section Test', 'Alice');
     await page.waitForTimeout(3000);
@@ -44,7 +41,8 @@ test.describe('Worker nodes infrastructure', () => {
     await expect(members).toHaveCount(1, { timeout: 5_000 });
   });
 
-  test('infrastructure section hidden when no workers have SyncProvider', async ({ page }) => {
+  test('infrastructure section hidden when no workers have SyncProvider', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name.startsWith('mobile'), 'member list always-visible on desktop only');
     await freshStart(page);
     await createServer(page, 'No Workers', 'Alice');
     await page.waitForTimeout(3000);


### PR DESCRIPTION
## Summary

Follow-up to #148 — five commits that landed on the branch after the initial PR merged.

- **Coverage gaps**: 5 new E2E tests added (`pre-existing messages`, `missed messages after reconnect`, `rapid channel creation`, `non-owner add button absent`, `invalid invite code rejected`)
- **Broken tests fixed**: concurrent-channel test rewritten as owner-only, invalid-invite test updated to match actual join flow, cross-browser warmup restored to message-based round-trip
- **Dead code removed**: `switchChannelMobile` and `waitForPeerCount` exports deleted from `helpers.ts`; test name corrected
- **Admin channel gate**: `sidebar.rs` now uses `admin_ids.contains(peer_id)` (covers governance-promoted admins) instead of `server_owner ==`; `.delete-btn` gated on same signal with FnMut-safe clone pattern

## Test plan

- [ ] CI passes (fmt, clippy, test, WASM check)
- [ ] `npx playwright test` green on the new E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)