### PR TITLE
docs(relay): document transport-layer role and SyncProvider trust model (#67)

### DIFF
--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -4,6 +4,42 @@
 //! thin library wrapper so that the bootstrap-handler logic and topic
 //! validation can be exercised by integration tests in
 //! `crates/relay/tests/`. The actual `main` lives in `src/main.rs`.
+//!
+//! ## Scope: transport only
+//!
+//! All routines in this crate operate at the **transport layer**.
+//! They forward bytes, manage gossip subscriptions, and rate-limit
+//! incoming connections. They do **not** inspect, validate, or filter
+//! application-level payloads:
+//!
+//! - No Ed25519 signature verification on relayed messages.
+//! - No event-sourced state machine application (see `willow-state`).
+//! - No permission, role, or governance enforcement.
+//! - No content-based routing or filtering.
+//!
+//! The only semantic work performed here is syntactic topic-string
+//! validation in [`topic_str_is_valid`] (length + allowed characters),
+//! which is purely a DoS guard, not a trust or governance check.
+//!
+//! ## Trust model
+//!
+//! The relay is a **regular client** in the DAG sync protocol. Its
+//! Ed25519 identity carries **no implicit authority** over any server.
+//! Per the DAG spec
+//! (`docs/specs/2026-04-01-per-author-merkle-dag-state-design.md`)
+//! and `CLAUDE.md` "Trust Model":
+//!
+//! > The relay is a regular client — trusted only if explicitly granted
+//! > `SyncProvider` permission by the owner.
+//!
+//! A hostile or compromised relay can affect **availability** (drop,
+//! delay, or reorder messages) but cannot forge events, bypass
+//! permissions, or corrupt state — those invariants are enforced
+//! cryptographically and deterministically at each **client**.
+//! Clients are therefore responsible for **all** DAG validation:
+//! signatures, parent-hash chain integrity, permission checks, and
+//! merge/replay correctness. Relayed bytes are never trusted on the
+//! strength of having passed through this crate.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -128,6 +164,14 @@ pub async fn run_bootstrap_listener(
 /// dynamically subscribe to announced channel topics. Topics are
 /// validated against [`topic_str_is_valid`] and the number of distinct
 /// subscribed topics is capped at [`MAX_TOPICS`].
+///
+/// This is a **transport-layer** routine. The relay simply joins the
+/// announced gossip topics so clients on those topics can reach each
+/// other through it; it performs no governance check on who is
+/// announcing, no signature verification on the underlying events, and
+/// no authority check against the server's DAG state. Clients are
+/// responsible for validating any messages that arrive on those
+/// topics. See the crate-level docs for the full trust model.
 pub async fn topic_announce_listener<N>(mut events: N::Events, network: N)
 where
     N: Network,

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -4,6 +4,66 @@
 //! gossip node that subscribes to system topics so new peers can join
 //! the gossip mesh. Dynamically subscribes to channel topics announced
 //! by peers via [`TopicAnnounce`](willow_common::WireMessage::TopicAnnounce).
+//!
+//! ## Role: transport-layer only
+//!
+//! The relay is a **transparent transport layer**. It forwards gossip
+//! traffic and helps NATed peers discover each other, but it performs
+//! **no application-level validation**:
+//!
+//! - It does **not** verify Ed25519 signatures on relayed messages.
+//! - It does **not** apply or check the event-sourced state machine
+//!   (see `willow-state`). Chain integrity, parent-hash verification,
+//!   permission checks, dedup, and governance rules (roles, bans,
+//!   channel ACLs) are *not* enforced here.
+//! - It does **not** inspect, filter, or re-route messages based on
+//!   their semantic content — all payloads are opaque bytes to the relay.
+//!
+//! The only semantic work this binary does is:
+//!
+//! 1. Validating that `TopicAnnounce` strings are syntactically
+//!    well-formed (length + allowed character set) before subscribing
+//!    to them. This is a DoS guard, not a governance check.
+//! 2. Rate/cap limiting (max concurrent bootstrap connections, max
+//!    distinct topics) to protect the relay itself.
+//!
+//! All DAG-level validation — signature checking, parent-hash
+//! verification, permission enforcement, merge/replay correctness — is
+//! the responsibility of **each client**. Clients must never trust
+//! relayed bytes just because they arrived through the relay.
+//!
+//! ## Trust model
+//!
+//! From the DAG spec (see
+//! [`docs/specs/2026-04-01-per-author-merkle-dag-state-design.md`](../../../docs/specs/2026-04-01-per-author-merkle-dag-state-design.md))
+//! and `CLAUDE.md` "Trust Model":
+//!
+//! > The relay is a regular client — trusted only if explicitly granted
+//! > `SyncProvider` permission by the owner.
+//!
+//! Concretely:
+//!
+//! - The relay operator's identity (the bootstrap node's Ed25519 key)
+//!   has **no** implicit authority over any server. The owner of a
+//!   server must explicitly grant `SyncProvider` via a `GrantPermission`
+//!   event for the relay's peer ID to be considered an authoritative
+//!   sync source for that server.
+//! - Without such a grant, clients treat the relay like any other
+//!   untrusted peer: they accept forwarded bytes for DAG sync but
+//!   validate everything locally before applying it.
+//! - A hostile or compromised relay can drop, delay, or reorder
+//!   messages (availability impact) but cannot forge events, bypass
+//!   permissions, or corrupt state — those are prevented by
+//!   cryptographic signatures and deterministic state machine
+//!   validation at the client.
+//!
+//! ## Cross-references
+//!
+//! - Trust model summary: `CLAUDE.md` → "Trust Model".
+//! - DAG design + `SyncProvider` permission:
+//!   `docs/specs/2026-04-01-per-author-merkle-dag-state-design.md`.
+//! - State-authority checks enforced at clients:
+//!   `docs/specs/2026-04-12-state-authority-and-mutations.md`.
 
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;


### PR DESCRIPTION
## Summary
- Adds crate-level `//!` docs to `crates/relay/src/main.rs` and `crates/relay/src/lib.rs` explaining that the relay is a transparent transport — it does not verify signatures, apply the state machine, or enforce governance.
- Records the DAG-spec trust model: the relay is a regular client, trusted only if explicitly granted `SyncProvider` permission by the owner.
- Cross-references `docs/specs/2026-04-01-per-author-merkle-dag-state-design.md` and `docs/specs/2026-04-12-state-authority-and-mutations.md`.
- Adds a short clarifying note on `topic_announce_listener` reinforcing that the subscribe action is transport-only.

Docs-only change; no behavior modifications.

Closes #67