### PR TITLE
relay: serve bootstrap id on /bootstrap-id (#101)

### DIFF
--- a/crates/relay/src/lib.rs
+++ b/crates/relay/src/lib.rs
@@ -6,10 +6,12 @@
 //! `crates/relay/tests/`. The actual `main` lives in `src/main.rs`.
 
 use std::collections::HashSet;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::TcpStream;
 use tokio::sync::Semaphore;
 use tracing::{info, warn};
 use willow_network::traits::{GossipEvent, TopicEvents};
@@ -19,6 +21,18 @@ use willow_network::Network;
 /// HTTP endpoint. Excess accepts are dropped immediately to prevent
 /// FD/memory exhaustion under a connection-flood DoS.
 pub const MAX_CONCURRENT_BOOTSTRAP_CONNECTIONS: usize = 1024;
+
+/// HTTP path served by [`handle_bootstrap_connection`] to expose the
+/// bootstrap node's endpoint ID. The public proxy routes requests to
+/// this path into the bootstrap handler; any other path is proxied to
+/// the internal iroh-relay server.
+pub const BOOTSTRAP_ID_PATH: &str = "/bootstrap-id";
+
+/// Maximum number of bytes to buffer while peeking the HTTP request
+/// line during proxy dispatch. HTTP/1.1 permits long request URIs, but
+/// for our single-route dispatch we only need the first line which
+/// should always fit comfortably.
+const PROXY_REQUEST_LINE_BUFFER: usize = 8 * 1024;
 
 /// I/O deadline for any single read or write on a bootstrap-id
 /// connection. Slow clients (Slowloris) are dropped at this deadline.
@@ -119,6 +133,188 @@ pub async fn run_bootstrap_listener(
                 tracing::debug!(%e, %peer, "bootstrap connection error");
             }
             // Hold the permit for the lifetime of the per-connection task.
+            drop(permit);
+        });
+    }
+}
+
+/// Dispatch a single accepted connection to either the bootstrap-id
+/// handler or the upstream iroh-relay, based on the HTTP request line.
+///
+/// Peeks at the incoming bytes until a `\r\n` delimits the request
+/// line. If the path is exactly [`BOOTSTRAP_ID_PATH`] the connection is
+/// answered locally; otherwise a TCP connection is opened to
+/// `upstream_addr`, the already-read bytes are replayed, and the two
+/// streams are proxied bidirectionally (which transparently handles
+/// WebSocket upgrades used by the iroh-relay protocol).
+pub async fn dispatch_connection(
+    mut client: TcpStream,
+    upstream_addr: SocketAddr,
+    bootstrap_id: Arc<String>,
+) -> std::io::Result<()> {
+    // Disable Nagle — the iroh-relay expects the upstream path to be
+    // responsive, and responses from the bootstrap handler are small
+    // single-shot writes.
+    let _ = client.set_nodelay(true);
+
+    // Read until we have a full HTTP request line (terminated by CRLF)
+    // or hit the buffer cap. We do NOT attempt to parse the full
+    // headers — the upstream server does that.
+    let mut buffered = Vec::with_capacity(1024);
+    let mut chunk = [0u8; 1024];
+    let request_line_end = loop {
+        if buffered.len() >= PROXY_REQUEST_LINE_BUFFER {
+            // Request line too long — give up and proxy to upstream.
+            break None;
+        }
+        let read_fut = client.read(&mut chunk);
+        let n = match tokio::time::timeout(BOOTSTRAP_IO_TIMEOUT, read_fut).await {
+            Ok(Ok(0)) => break None, // EOF before a request line.
+            Ok(Ok(n)) => n,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "timed out reading request line",
+                ));
+            }
+        };
+        buffered.extend_from_slice(&chunk[..n]);
+        if let Some(pos) = buffered.windows(2).position(|w| w == b"\r\n") {
+            break Some(pos);
+        }
+    };
+
+    // If we have a request line, try to match the bootstrap-id path.
+    if let Some(end) = request_line_end {
+        let line = &buffered[..end];
+        if request_line_matches_bootstrap_id(line) {
+            return handle_bootstrap_request_after_line(client, &buffered, &bootstrap_id).await;
+        }
+    }
+
+    // Fall through: forward everything we've buffered so far plus the
+    // remainder of the stream to the upstream iroh-relay.
+    let mut upstream = TcpStream::connect(upstream_addr).await?;
+    let _ = upstream.set_nodelay(true);
+    if !buffered.is_empty() {
+        upstream.write_all(&buffered).await?;
+    }
+    // Bidirectional copy exits when either side hits EOF or errors.
+    // We deliberately drop any error — it's the normal way for HTTP/1.1
+    // responses with Connection: close to terminate.
+    let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await;
+    Ok(())
+}
+
+/// Returns `true` iff the HTTP request line (without trailing CRLF)
+/// targets [`BOOTSTRAP_ID_PATH`] with method `GET`. We match the path
+/// verbatim (no query string support) because the endpoint does not
+/// use any request parameters.
+fn request_line_matches_bootstrap_id(line: &[u8]) -> bool {
+    // Expected shape: "GET /bootstrap-id HTTP/1.x"
+    let mut parts = line.splitn(3, |b| *b == b' ');
+    let Some(method) = parts.next() else {
+        return false;
+    };
+    let Some(path) = parts.next() else {
+        return false;
+    };
+    method == b"GET" && path == BOOTSTRAP_ID_PATH.as_bytes()
+}
+
+/// Complete a bootstrap-id request once the proxy has identified the
+/// path. Drains any remaining bytes of the request (up to the
+/// end-of-headers marker) so the client sees a well-formed response
+/// before the connection is closed.
+async fn handle_bootstrap_request_after_line(
+    mut client: TcpStream,
+    already_read: &[u8],
+    id: &str,
+) -> std::io::Result<()> {
+    // Drain the rest of the request (best effort). If the
+    // end-of-headers marker "\r\n\r\n" is already in what we read, we
+    // don't need to read more.
+    if !already_read.windows(4).any(|w| w == b"\r\n\r\n") {
+        let mut chunk = [0u8; 1024];
+        let deadline = tokio::time::sleep(BOOTSTRAP_IO_TIMEOUT);
+        tokio::pin!(deadline);
+        loop {
+            tokio::select! {
+                _ = &mut deadline => break,
+                res = client.read(&mut chunk) => match res {
+                    Ok(0) => break,
+                    Ok(_n) => {
+                        // We don't care about the content; just look
+                        // for the blank line terminator.
+                        if chunk.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        }
+    }
+
+    let response = format!(
+        "HTTP/1.1 200 OK\r\n\
+         Access-Control-Allow-Origin: *\r\n\
+         Content-Type: text/plain\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        id.len(),
+        id
+    );
+
+    tokio::time::timeout(BOOTSTRAP_IO_TIMEOUT, client.write_all(response.as_bytes()))
+        .await
+        .map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::TimedOut, "bootstrap write timed out")
+        })??;
+    Ok(())
+}
+
+/// Run the public HTTP accept loop that fronts the iroh-relay. Each
+/// accepted connection is dispatched by [`dispatch_connection`]:
+/// requests for [`BOOTSTRAP_ID_PATH`] are answered locally, everything
+/// else is proxied to `upstream_addr`.
+///
+/// This loop runs forever — callers should `tokio::spawn` it.
+pub async fn run_proxy_listener(
+    listener: tokio::net::TcpListener,
+    upstream_addr: SocketAddr,
+    id: Arc<String>,
+    semaphore: Arc<Semaphore>,
+) {
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!(%e, "relay proxy accept failed");
+                continue;
+            }
+        };
+
+        let permit = match Arc::clone(&semaphore).try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                warn!(
+                    %peer,
+                    "relay proxy connection cap reached; dropping connection"
+                );
+                drop(stream);
+                continue;
+            }
+        };
+
+        let id = Arc::clone(&id);
+        tokio::spawn(async move {
+            if let Err(e) = dispatch_connection(stream, upstream_addr, id).await {
+                tracing::debug!(%e, %peer, "relay proxy connection error");
+            }
             drop(permit);
         });
     }

--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -17,7 +17,7 @@ use tracing::info;
 use willow_identity::Identity;
 use willow_network::Network;
 use willow_relay::{
-    run_bootstrap_listener, topic_announce_listener, MAX_CONCURRENT_BOOTSTRAP_CONNECTIONS,
+    run_proxy_listener, topic_announce_listener, MAX_CONCURRENT_BOOTSTRAP_CONNECTIONS,
 };
 
 #[derive(Parser)]
@@ -60,8 +60,22 @@ async fn main() -> Result<()> {
 
     info!(id = %identity.endpoint_id().fmt_short(), "bootstrap node identity");
 
-    // ── iroh-relay server (plain HTTP, no TLS) ───────────────────────────
-    let relay_bind: SocketAddr = (Ipv4Addr::UNSPECIFIED, args.relay_port).into();
+    // ── Public listener (HTTP dispatch: /bootstrap-id + proxy) ───────────
+    // Bind the public-facing TCP port FIRST so `relay_port = 0` can pick
+    // an ephemeral port that we can then advertise. The iroh-relay is
+    // bound to a loopback ephemeral port below, and the proxy below
+    // forwards non-bootstrap traffic to it.
+    let public_bind: SocketAddr = (Ipv4Addr::UNSPECIFIED, args.relay_port).into();
+    let public_listener = tokio::net::TcpListener::bind(public_bind)
+        .await
+        .context("failed to bind public relay HTTP port")?;
+    let public_port = public_listener.local_addr()?.port();
+    info!(port = public_port, "public relay HTTP listener ready");
+
+    // ── iroh-relay server (loopback only, plain HTTP, no TLS) ────────────
+    // The iroh-relay is only reachable through the proxy above; binding
+    // to 127.0.0.1 prevents direct access from the network.
+    let relay_bind: SocketAddr = (Ipv4Addr::LOCALHOST, 0).into();
 
     let mut relay_server = Server::spawn(ServerConfig::<(), ()> {
         relay: Some(RelayConfig::<(), ()> {
@@ -77,21 +91,20 @@ async fn main() -> Result<()> {
     .await
     .context("failed to start iroh-relay server")?;
 
-    let relay_addr = relay_server
+    let upstream_relay_addr = relay_server
         .http_addr()
         .context("relay server has no HTTP address")?;
-    // The bootstrap node must connect to the relay via a loopback address
-    // (127.0.0.1), not the bind address (0.0.0.0). 0.0.0.0 is a valid bind
-    // address but not a valid destination to connect to.
-    let connect_addr: SocketAddr = if relay_addr.ip().is_unspecified() {
-        (std::net::Ipv4Addr::LOCALHOST, relay_addr.port()).into()
-    } else {
-        relay_addr
-    };
-    let relay_url: RelayUrl = format!("http://{connect_addr}")
+    // Advertise the PUBLIC port to bootstrap node and clients, not the
+    // loopback upstream port.
+    let advertised_addr: SocketAddr = (Ipv4Addr::LOCALHOST, public_port).into();
+    let relay_url: RelayUrl = format!("http://{advertised_addr}")
         .parse()
         .context("failed to parse relay URL")?;
-    info!(%relay_url, "iroh-relay server running");
+    info!(
+        %relay_url,
+        upstream = %upstream_relay_addr,
+        "iroh-relay server running"
+    );
 
     // ── Bootstrap gossip node ────────────────────────────────────────────
     let config = willow_network::iroh::Config {
@@ -116,24 +129,26 @@ async fn main() -> Result<()> {
 
     info!("bootstrap node subscribed to system topics");
 
-    // ── Bootstrap ID HTTP endpoint ──────────────────────────────────────
-    // Serve the bootstrap node's endpoint ID so web clients can fetch it.
+    // ── Public dispatch loop ────────────────────────────────────────────
+    // The public listener multiplexes two concerns on ONE port:
+    //   * `GET /bootstrap-id` → serves the bootstrap node's endpoint ID
+    //   * everything else     → proxied to the loopback iroh-relay
+    //
     // The accept loop applies per-connection I/O timeouts and is gated
     // by a semaphore so a connection-flood DoS cannot exhaust file
-    // descriptors. See `willow_relay::run_bootstrap_listener`.
+    // descriptors. See `willow_relay::run_proxy_listener`.
     let bootstrap_id = Arc::new(identity.endpoint_id().to_string());
-    let bootstrap_listener =
-        tokio::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, args.relay_port + 1))
-            .await
-            .context("failed to bind bootstrap-id HTTP port")?;
-    let bootstrap_port = bootstrap_listener.local_addr()?.port();
-    info!(port = bootstrap_port, "bootstrap-id endpoint listening");
-    let bootstrap_semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_BOOTSTRAP_CONNECTIONS));
-    tokio::spawn(run_bootstrap_listener(
-        bootstrap_listener,
+    let proxy_semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_BOOTSTRAP_CONNECTIONS));
+    tokio::spawn(run_proxy_listener(
+        public_listener,
+        upstream_relay_addr,
         Arc::clone(&bootstrap_id),
-        bootstrap_semaphore,
+        proxy_semaphore,
     ));
+    info!(
+        port = public_port,
+        "serving /bootstrap-id + iroh-relay proxy"
+    );
 
     // Spawn a task that listens for TopicAnnounce messages on _willow_server_ops
     // and dynamically subscribes to announced channel topics.

--- a/crates/relay/tests/bootstrap_endpoint.rs
+++ b/crates/relay/tests/bootstrap_endpoint.rs
@@ -12,8 +12,8 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Semaphore;
 
 use willow_relay::{
-    handle_bootstrap_connection, run_bootstrap_listener, topic_str_is_valid, BOOTSTRAP_IO_TIMEOUT,
-    MAX_TOPIC_LEN,
+    handle_bootstrap_connection, run_bootstrap_listener, run_proxy_listener, topic_str_is_valid,
+    BOOTSTRAP_IO_TIMEOUT, MAX_TOPIC_LEN,
 };
 
 const TEST_ID: &str = "0123456789abcdef0123456789abcdef";
@@ -182,6 +182,131 @@ async fn bootstrap_listener_recovers_after_permit_released() {
         response.contains(TEST_ID),
         "second request failed: {response}"
     );
+}
+
+// ── Proxy dispatch (#101) ───────────────────────────────────────────────
+//
+// The public relay listener multiplexes `/bootstrap-id` onto the same
+// port that serves the iroh-relay protocol. These tests exercise the
+// dispatch logic without standing up a real iroh-relay upstream — we
+// stub the upstream with a dummy TCP server that just records that it
+// was contacted.
+
+/// Spawn a dummy upstream that accepts any connection, reads briefly,
+/// then closes. Returns its bound address and a receiver that signals
+/// whenever a connection is accepted.
+async fn spawn_dummy_upstream() -> (std::net::SocketAddr, tokio::sync::mpsc::Receiver<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
+    tokio::spawn(async move {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let _ = tx.send(()).await;
+                // Drain a little so the client sees EOF rather than RST.
+                let mut buf = [0u8; 1024];
+                let _ =
+                    tokio::time::timeout(Duration::from_millis(100), stream.read(&mut buf)).await;
+                drop(stream);
+            });
+        }
+    });
+    (addr, rx)
+}
+
+/// Spawn the public proxy listener backed by `upstream_addr` and
+/// return its bound address.
+async fn spawn_proxy(upstream_addr: std::net::SocketAddr) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    let semaphore = Arc::new(Semaphore::new(16));
+    let id = Arc::new(TEST_ID.to_string());
+    tokio::spawn(run_proxy_listener(listener, upstream_addr, id, semaphore));
+    addr
+}
+
+#[tokio::test]
+async fn proxy_serves_bootstrap_id_on_same_port() {
+    // GET /bootstrap-id must be served locally with a 200 + id body.
+    let (upstream, _rx) = spawn_dummy_upstream().await;
+    let addr = spawn_proxy(upstream).await;
+
+    let mut stream = TcpStream::connect(addr).await.expect("connect");
+    stream
+        .write_all(b"GET /bootstrap-id HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .await
+        .expect("write request");
+
+    let response = read_full_response(&mut stream).await;
+    assert!(
+        response.starts_with("HTTP/1.1 200 OK\r\n"),
+        "response: {response}"
+    );
+    assert!(response.contains(TEST_ID), "body missing id: {response:?}");
+    // CORS header must be present so browsers can fetch from any origin.
+    assert!(
+        response.contains("Access-Control-Allow-Origin: *"),
+        "missing CORS header: {response:?}"
+    );
+}
+
+#[tokio::test]
+async fn proxy_forwards_non_bootstrap_requests_to_upstream() {
+    // Any request that is NOT /bootstrap-id must be proxied to the
+    // upstream iroh-relay listener.
+    let (upstream, mut rx) = spawn_dummy_upstream().await;
+    let addr = spawn_proxy(upstream).await;
+
+    let mut stream = TcpStream::connect(addr).await.expect("connect");
+    stream
+        .write_all(b"GET /relay HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\n\r\n")
+        .await
+        .expect("write request");
+
+    // The upstream must receive a connection.
+    let got = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("upstream connection not observed within timeout");
+    assert!(got.is_some(), "upstream channel closed unexpectedly");
+}
+
+#[tokio::test]
+async fn proxy_rejects_non_matching_path_with_upstream_proxy() {
+    // A GET to a path that happens to share a prefix with /bootstrap-id
+    // must NOT be served locally — we match the path verbatim.
+    let (upstream, mut rx) = spawn_dummy_upstream().await;
+    let addr = spawn_proxy(upstream).await;
+
+    let mut stream = TcpStream::connect(addr).await.expect("connect");
+    stream
+        .write_all(b"GET /bootstrap-id-extra HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .await
+        .expect("write request");
+
+    let got = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("prefix-only path should fall through to upstream proxy");
+    assert!(got.is_some(), "upstream channel closed unexpectedly");
+}
+
+#[tokio::test]
+async fn proxy_rejects_non_get_method_with_upstream_proxy() {
+    // Only GET /bootstrap-id is handled locally; POST /bootstrap-id is
+    // proxied to upstream like any other request.
+    let (upstream, mut rx) = spawn_dummy_upstream().await;
+    let addr = spawn_proxy(upstream).await;
+
+    let mut stream = TcpStream::connect(addr).await.expect("connect");
+    stream
+        .write_all(b"POST /bootstrap-id HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .await
+        .expect("write request");
+
+    let got = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("POST /bootstrap-id should fall through to upstream proxy");
+    assert!(got.is_some(), "upstream channel closed unexpectedly");
 }
 
 // ── Topic validation (#113) ─────────────────────────────────────────────

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -57,17 +57,36 @@ fn resolve_relay_url() -> String {
     DEFAULT_RELAY_URL.to_string()
 }
 
-/// Fetch the bootstrap node's endpoint ID from the relay's companion port.
-/// Returns `None` on any failure (network error, parse error, etc.).
+/// Derive the HTTP URL for the relay's `/bootstrap-id` endpoint from a
+/// relay URL. Handles `ws://` → `http://` and `wss://` → `https://`
+/// scheme rewrites so clients can fetch the endpoint ID from the same
+/// port as the relay's main HTTP/WebSocket listener.
+///
+/// This function is pure so it can be unit-tested without a browser.
+pub(crate) fn bootstrap_id_url(relay_url: &str) -> String {
+    let trimmed = relay_url.trim_end_matches('/');
+    // Swap the scheme to the HTTP equivalent so `fetch` works even
+    // when the caller configured a ws(s) URL (the iroh-relay serves
+    // HTTP and WebSocket on the same port).
+    let base = if let Some(rest) = trimmed.strip_prefix("wss://") {
+        format!("https://{rest}")
+    } else if let Some(rest) = trimmed.strip_prefix("ws://") {
+        format!("http://{rest}")
+    } else {
+        trimmed.to_string()
+    };
+    format!("{base}/bootstrap-id")
+}
+
+/// Fetch the bootstrap node's endpoint ID from the relay. The relay
+/// multiplexes `/bootstrap-id` onto its main HTTP/WebSocket port — no
+/// companion port required — see issue #101. Returns `None` on any
+/// failure (network error, parse error, etc.).
 async fn fetch_bootstrap_id(relay_url: &str) -> Option<willow_identity::EndpointId> {
     use wasm_bindgen::JsCast;
     use wasm_bindgen_futures::JsFuture;
 
-    // The bootstrap-id endpoint runs on relay_port + 1.
-    let url = relay_url
-        .replace(":3340", ":3341")
-        .replace(":9443", ":9444");
-    let bootstrap_url = format!("{url}/bootstrap-id");
+    let bootstrap_url = bootstrap_id_url(relay_url);
 
     let window = web_sys::window()?;
     let resp_value = JsFuture::from(window.fetch_with_str(&bootstrap_url))
@@ -839,4 +858,65 @@ pub async fn handle_voice_offer(vm: VoiceManagerHandle, from: String, sdp: Strin
 pub async fn handle_voice_answer(vm: VoiceManagerHandle, from: String, sdp: String) {
     let mgr = vm.borrow();
     mgr.handle_answer(&from, &sdp).await.ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::bootstrap_id_url;
+
+    #[test]
+    fn bootstrap_id_url_http_is_passthrough() {
+        assert_eq!(
+            bootstrap_id_url("http://localhost:3340"),
+            "http://localhost:3340/bootstrap-id"
+        );
+    }
+
+    #[test]
+    fn bootstrap_id_url_https_is_passthrough() {
+        assert_eq!(
+            bootstrap_id_url("https://willow.example.com:9443"),
+            "https://willow.example.com:9443/bootstrap-id"
+        );
+    }
+
+    #[test]
+    fn bootstrap_id_url_ws_becomes_http() {
+        assert_eq!(
+            bootstrap_id_url("ws://localhost:3340"),
+            "http://localhost:3340/bootstrap-id"
+        );
+    }
+
+    #[test]
+    fn bootstrap_id_url_wss_becomes_https() {
+        assert_eq!(
+            bootstrap_id_url("wss://willow.example.com:9443"),
+            "https://willow.example.com:9443/bootstrap-id"
+        );
+    }
+
+    #[test]
+    fn bootstrap_id_url_strips_trailing_slash() {
+        assert_eq!(
+            bootstrap_id_url("https://willow.example.com:9443/"),
+            "https://willow.example.com:9443/bootstrap-id"
+        );
+    }
+
+    #[test]
+    fn bootstrap_id_url_uses_same_port_as_relay() {
+        // Regression test for issue #101: the old behaviour rewrote
+        // ":9443" to ":9444" / ":3340" to ":3341". The derived URL must
+        // use the SAME port as the relay URL.
+        let derived = bootstrap_id_url("https://relay.example.com:9443");
+        assert!(
+            derived.contains(":9443/"),
+            "derived URL should use the same port: {derived}"
+        );
+        assert!(
+            !derived.contains(":9444"),
+            "derived URL must not use the deprecated +1 port: {derived}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- The relay now multiplexes `/bootstrap-id` onto its main HTTP/WebSocket port instead of the brittle `relay_port + 1` convention. The public listener peeks the request line, serves `/bootstrap-id` locally, and transparently proxies everything else (including WebSocket upgrades) to a loopback-bound iroh-relay.
- The web app drops the `:3340` → `:3341` / `:9443` → `:9444` string replace in favor of a pure `bootstrap_id_url` helper that rewrites only the URL scheme (`ws(s)` → `http(s)`).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p willow-relay --all-targets -- -D warnings`
- [x] `cargo clippy -p willow-web --all-targets -- -D warnings`
- [x] `cargo test -p willow-relay` — 10/10 pass, includes 4 new proxy tests (same-port service, upstream proxy for non-matching paths, prefix-match fall-through, non-GET fall-through)
- [x] `cargo check --target wasm32-unknown-unknown -p willow-web`
- [x] `cargo test -p willow-web --bin willow-web bootstrap` — 6 new unit tests for `bootstrap_id_url` (http/https passthrough, ws/wss scheme rewrite, trailing slash, same-port regression)

Closes #101

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>