### PR TITLE
fix(worker): add pending_count to test fixture (main broken)

### DIFF
--- a/crates/worker/src/actors/network.rs
+++ b/crates/worker/src/actors/network.rs
@@ -457,6 +457,7 @@ mod tests {
                 servers_loaded: 1,
                 events_buffered: 0,
                 max_events: 1000,
+                pending_count: 0,
             },
             servers: vec![],
             timestamp: 0,


### PR DESCRIPTION
## Summary
Main is red. Merge race between #151 and #157:
- #157 added `pending_count` field to `WorkerRoleInfo::Replay`
- #151's sad-path test fixture for `WorkerAnnouncement` landed without the new field
- `cargo test --workspace` now fails on `main` with `E0063: missing field pending_count`

One-line fix in `crates/worker/src/actors/network.rs:456`.

## Test plan
- [x] `cargo test --workspace --no-run` compiles clean locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)