### PR TITLE
refactor(web): extract voice reset helper

### DIFF
--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -407,18 +407,7 @@ pub fn App() -> impl IntoView {
             handle_voice_leave.leave_voice().await;
         });
         vm_disconnect.borrow_mut().close_all();
-        write.voice.set_voice_channel.set(None);
-        write.voice.set_voice_channel_name.set(String::new());
-        write.voice.set_voice_muted.set(false);
-        write.voice.set_voice_deafened.set(false);
-        write.voice.set_video_source.set(None);
-        write.voice.set_local_video_stream.set(None);
-        write.voice.set_remote_video_streams.update(|m| m.clear());
-        write
-            .voice
-            .set_speaking_peers
-            .set(std::collections::HashSet::new());
-        write.voice.set_voice_participants_map.update(|m| m.clear());
+        write.voice.reset();
         write.ui.set_show_call_page.set(false);
         write
             .ui
@@ -551,15 +540,7 @@ pub fn App() -> impl IntoView {
                                             vc_leave.leave_voice().await;
                                         });
                                         vm.borrow_mut().close_all();
-                                        write.voice.set_voice_channel.set(None);
-                                        write.voice.set_voice_channel_name.set(String::new());
-                                        write.voice.set_voice_muted.set(false);
-                                        write.voice.set_voice_deafened.set(false);
-                                        write.voice.set_video_source.set(None);
-                                        write.voice.set_local_video_stream.set(None);
-                                        write.voice.set_remote_video_streams.update(|m| m.clear());
-                                        write.voice.set_speaking_peers.set(std::collections::HashSet::new());
-                                        write.voice.set_voice_participants_map.update(|m| m.clear());
+                                        write.voice.reset();
                                     }
 
                                     // If already in this voice channel, just navigate to the call page.
@@ -626,8 +607,7 @@ pub fn App() -> impl IntoView {
                                     });
                                     let on_error = wasm_bindgen::closure::Closure::once(move |_err: wasm_bindgen::JsValue| {
                                         tracing::error!("Microphone access denied");
-                                        write.voice.set_voice_channel.set(None);
-                                        write.voice.set_voice_channel_name.set(String::new());
+                                        write.voice.reset();
                                         write.ui.set_show_call_page.set(false);
                                     });
                                     drop(promise.then2(&on_success, &on_error));

--- a/crates/web/src/state.rs
+++ b/crates/web/src/state.rs
@@ -199,6 +199,26 @@ pub struct VoiceWriteSignals {
         WriteSignal<Option<send_wrapper::SendWrapper<web_sys::MediaStream>>>,
 }
 
+impl VoiceWriteSignals {
+    /// Reset all voice-related UI signals to their defaults: no active
+    /// voice channel, unmuted/undeafened, no local or remote media
+    /// streams, no speaking peers, and an empty participants map.
+    ///
+    /// Used when leaving a voice channel, switching between channels,
+    /// and when microphone permission is denied.
+    pub fn reset(&self) {
+        self.set_voice_channel.set(None);
+        self.set_voice_channel_name.set(String::new());
+        self.set_voice_muted.set(false);
+        self.set_voice_deafened.set(false);
+        self.set_video_source.set(None);
+        self.set_local_video_stream.set(None);
+        self.set_remote_video_streams.update(|m| m.clear());
+        self.set_speaking_peers.set(HashSet::new());
+        self.set_voice_participants_map.update(|m| m.clear());
+    }
+}
+
 /// Create all signal pairs and return the read/write halves.
 ///
 /// Signals that reflect `SharedState` are created via `derived_signal()` when


### PR DESCRIPTION
## Summary

- Adds `VoiceWriteSignals::reset` in `crates/web/src/state.rs` that clears every voice-related UI signal (channel, mute/deafen flags, video source, local + remote streams, speaking peers, participants map).
- Replaces three duplicated reset blocks in `crates/web/src/app.rs` with a single `write.voice.reset()` call:
  1. `on_voice_disconnect` handler (~L407).
  2. `on_voice_join` closure, "switching between channels" branch (~L540).
  3. `on_error` closure in the `getUserMedia` failure path (~L607).
- Pure mechanical extraction — no behavior change. End state at each call site is identical; site 3 previously only reset a subset of the fields, but those remaining fields are already at their defaults in that code path (we had just optimistically set `voice_channel` / `voice_channel_name`).

## Test plan

- [x] `cargo fmt` / `cargo clippy -p willow-web -- -D warnings` clean
- [x] `cargo test -p willow-web` passes
- [x] `just check-wasm` compiles
- [ ] Manual smoke: join voice, switch voice channel, leave voice, deny mic permission — all should leave voice UI in a clean state

Note: `just check` also surfaces pre-existing failures on `main` (`willow-worker` missing `pending_count` in a test fixture, flaky timing tests in `willow-actor`). Those are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)