### PR TITLE
security: zeroize crypto key material + guard HLC counter overflow

### DIFF
--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -21,7 +21,7 @@ use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use x25519_dalek::{PublicKey as X25519Public, StaticSecret as X25519Secret};
-use zeroize::ZeroizeOnDrop;
+use zeroize::{ZeroizeOnDrop, Zeroizing};
 
 use willow_identity::Identity;
 
@@ -98,10 +98,12 @@ pub struct EncryptedChannelKey {
 ///
 /// The ratchet is seeded from a [`ChannelKey`] and can be re-seeded on
 /// key rotation (epoch change).
-#[derive(Clone)]
+#[derive(Clone, ZeroizeOnDrop)]
 pub struct KeyRatchet {
     seed: [u8; 32],
+    #[zeroize(skip)]
     counter: u64,
+    #[zeroize(skip)]
     epoch: u32,
 }
 
@@ -355,9 +357,11 @@ pub fn encrypt_channel_key_for(
     let shared_secret = ephemeral_secret.diffie_hellman(&recipient_x25519);
 
     // Derive wrapping key via HKDF-SHA256.
+    // Wrapped in `Zeroizing` so the derived key is wiped on drop rather
+    // than lingering on the stack after `cipher` is consumed.
     let hk = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
-    let mut wrapping_key = [0u8; 32];
-    hk.expand(b"willow-channel-key-wrap", &mut wrapping_key)
+    let mut wrapping_key: Zeroizing<[u8; 32]> = Zeroizing::new([0u8; 32]);
+    hk.expand(b"willow-channel-key-wrap", wrapping_key.as_mut())
         .map_err(|_| CryptoError::KeyDerivationFailed)?;
 
     let cipher = ChaCha20Poly1305::new(wrapping_key.as_ref().into());
@@ -385,9 +389,11 @@ pub fn decrypt_channel_key(
     let sender_ephemeral = X25519Public::from(encrypted.ephemeral_public);
     let shared_secret = our_x25519.diffie_hellman(&sender_ephemeral);
 
+    // Wrap the derived key in `Zeroizing` so it's wiped on drop rather
+    // than lingering on the stack after `cipher` is consumed.
     let hk = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
-    let mut wrapping_key = [0u8; 32];
-    hk.expand(b"willow-channel-key-wrap", &mut wrapping_key)
+    let mut wrapping_key: Zeroizing<[u8; 32]> = Zeroizing::new([0u8; 32]);
+    hk.expand(b"willow-channel-key-wrap", wrapping_key.as_mut())
         .map_err(|_| CryptoError::KeyDerivationFailed)?;
 
     let cipher = ChaCha20Poly1305::new(wrapping_key.as_ref().into());

--- a/crates/messaging/src/hlc.rs
+++ b/crates/messaging/src/hlc.rs
@@ -89,6 +89,23 @@ fn wall_clock_ms() -> u64 {
     js_sys::Date::now() as u64
 }
 
+/// Advance `counter` by one within `millis`, rolling over into the next
+/// millisecond if the u32 counter would overflow.
+///
+/// The counter field is only 32 bits wide, so a node that generates more
+/// than `u32::MAX` timestamps inside a single millisecond would otherwise
+/// wrap around and break monotonicity. When that happens we borrow from
+/// the millisecond field instead: bump `millis` by 1 and reset the counter
+/// to 0. This keeps every generated timestamp strictly greater than the
+/// previous one.
+fn bump_counter(millis: u64, counter: u32) -> (u64, u32) {
+    match counter.checked_add(1) {
+        Some(next) => (millis, next),
+        // Saturated: roll into the next millisecond to preserve monotonicity.
+        None => (millis.saturating_add(1), 0),
+    }
+}
+
 /// A Hybrid Logical Clock instance.
 ///
 /// Each node in the network maintains its own `HLC`. It must be used to
@@ -131,10 +148,10 @@ impl HLC {
         let wall = wall_clock_ms();
         let millis = wall.max(self.latest.millis);
 
-        let counter = if millis == self.latest.millis {
-            self.latest.counter + 1
+        let (millis, counter) = if millis == self.latest.millis {
+            bump_counter(millis, self.latest.counter)
         } else {
-            0
+            (millis, 0)
         };
 
         self.latest = HlcTimestamp { millis, counter };
@@ -149,14 +166,14 @@ impl HLC {
         let wall = wall_clock_ms();
         let millis = wall.max(self.latest.millis).max(remote.millis);
 
-        let counter = if millis == self.latest.millis && millis == remote.millis {
-            self.latest.counter.max(remote.counter) + 1
+        let (millis, counter) = if millis == self.latest.millis && millis == remote.millis {
+            bump_counter(millis, self.latest.counter.max(remote.counter))
         } else if millis == self.latest.millis {
-            self.latest.counter + 1
+            bump_counter(millis, self.latest.counter)
         } else if millis == remote.millis {
-            remote.counter + 1
+            bump_counter(millis, remote.counter)
         } else {
-            0
+            (millis, 0)
         };
 
         self.latest = HlcTimestamp { millis, counter };
@@ -308,6 +325,75 @@ mod tests {
             "now() must be monotonically greater than the previous latest \
              even when the wall clock is behind (got {t} <= {before})"
         );
+    }
+
+    #[test]
+    fn now_rolls_into_next_millis_when_counter_saturates() {
+        let mut clock = HLC::new();
+
+        // Force the clock into a far-future millisecond with the counter
+        // already at u32::MAX so the real wall clock stays below it.
+        let future_millis = u64::MAX / 2;
+        clock.latest = HlcTimestamp {
+            millis: future_millis,
+            counter: u32::MAX,
+        };
+
+        let t = clock.now();
+
+        // The counter cannot go higher within the same millisecond without
+        // wrapping, so we must have borrowed from the next millisecond.
+        assert_eq!(t.millis, future_millis + 1);
+        assert_eq!(t.counter, 0);
+
+        // And monotonicity still holds.
+        let t2 = clock.now();
+        assert!(t2 > t);
+    }
+
+    #[test]
+    fn receive_rolls_into_next_millis_when_counter_saturates() {
+        let mut clock = HLC::new();
+
+        let future_millis = u64::MAX / 2;
+        clock.latest = HlcTimestamp {
+            millis: future_millis,
+            counter: u32::MAX,
+        };
+
+        // Remote is in the same millisecond with the same saturated counter.
+        let remote = HlcTimestamp {
+            millis: future_millis,
+            counter: u32::MAX,
+        };
+
+        let t = clock.receive(remote);
+
+        assert_eq!(t.millis, future_millis + 1);
+        assert_eq!(t.counter, 0);
+        assert!(t > remote);
+    }
+
+    #[test]
+    fn now_near_overflow_preserves_monotonicity_across_boundary() {
+        let mut clock = HLC::new();
+
+        // Position the clock one step away from saturation in a future
+        // millisecond the wall clock can't catch up with.
+        let future_millis = u64::MAX / 2;
+        clock.latest = HlcTimestamp {
+            millis: future_millis,
+            counter: u32::MAX - 1,
+        };
+
+        let t1 = clock.now(); // should land at counter = u32::MAX
+        assert_eq!(t1.millis, future_millis);
+        assert_eq!(t1.counter, u32::MAX);
+
+        let t2 = clock.now(); // next tick must roll over, not wrap
+        assert!(t2 > t1, "got {t2} <= {t1}");
+        assert_eq!(t2.millis, future_millis + 1);
+        assert_eq!(t2.counter, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three small crypto hardening fixes to close gaps around secret-material lifetime and integer overflow.

1. **HLC counter overflow guard** (`crates/messaging/src/hlc.rs`) — `counter + 1` on a `u32` could wrap after more than `u32::MAX` timestamps inside a single millisecond, breaking HLC monotonicity. `now()` and `receive()` now route through a `bump_counter` helper that uses `checked_add` and rolls into the next millisecond (with `counter = 0`) when it saturates.
2. **`KeyRatchet` seed zeroization** (`crates/crypto/src/lib.rs`) — `KeyRatchet` holds a 32-byte secret seed; now derives `ZeroizeOnDrop` so the seed is wiped on drop. `counter`/`epoch` are non-secret and marked `#[zeroize(skip)]`.
3. **HKDF wrapping key zeroization** (`crates/crypto/src/lib.rs`) — the 32-byte HKDF output in `encrypt_channel_key_for` and `decrypt_channel_key` is now stored in `zeroize::Zeroizing<[u8; 32]>` so it's wiped after `cipher` is consumed rather than lingering on the stack.

## Test plan

- [x] `cargo test -p willow-messaging` — 40 tests pass, including three new HLC near-overflow / saturation regressions (`now_rolls_into_next_millis_when_counter_saturates`, `receive_rolls_into_next_millis_when_counter_saturates`, `now_near_overflow_preserves_monotonicity_across_boundary`)
- [x] `cargo test -p willow-crypto` — all 50+ crypto tests pass (including the existing `channel_key_is_zeroize_on_drop` compile-time check)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `just check-wasm` — WASM target builds clean
- [x] `cargo test --workspace --exclude willow-worker` — all pass (the `willow-worker` test failure is a pre-existing `WorkerRoleInfo::Replay { pending_count }` test-fixture bug already being addressed in `fix/worker-pending-count-merge-race`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)