### PR TITLE
chore: dead code + stale annotation cleanup

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -263,7 +263,6 @@ impl<N: willow_network::Network> ClientHandle<N> {
 /// compatibility but its [`run()`](ClientEventLoop::run) method is a no-op
 /// that simply drains the internal channel.
 pub struct ClientEventLoop {
-    #[allow(dead_code)]
     pub(crate) _system: willow_actor::System,
 }
 
@@ -644,7 +643,6 @@ fn load_identity() -> Identity {
 /// # Returns
 ///
 /// A new map with only the entries whose key parsed successfully.
-#[allow(dead_code)]
 pub fn reconcile_topic_map<V: Clone>(
     raw: &std::collections::HashMap<String, V>,
 ) -> std::collections::HashMap<willow_messaging::ChannelId, V> {
@@ -660,19 +658,6 @@ pub fn reconcile_topic_map<V: Clone>(
         out.insert(cid, value.clone());
     }
     out
-}
-
-/// Parse a permission string into a [`willow_state::Permission`].
-#[allow(dead_code)]
-fn parse_permission(s: &str) -> anyhow::Result<willow_state::Permission> {
-    match s {
-        "SyncProvider" => Ok(willow_state::Permission::SyncProvider),
-        "SendMessages" => Ok(willow_state::Permission::SendMessages),
-        "CreateInvite" => Ok(willow_state::Permission::CreateInvite),
-        "ManageChannels" => Ok(willow_state::Permission::ManageChannels),
-        "ManageRoles" => Ok(willow_state::Permission::ManageRoles),
-        _ => anyhow::bail!("unknown permission: {s}"),
-    }
 }
 
 /// Create a test-only ClientHandle without connecting to the network.

--- a/crates/network/src/mem.rs
+++ b/crates/network/src/mem.rs
@@ -39,8 +39,6 @@ use crate::traits::*;
 struct HubMessage {
     sender: EndpointId,
     data: Bytes,
-    #[allow(dead_code)]
-    neighbors_only: bool,
 }
 
 /// Subscriber tracking for neighbor events.
@@ -202,14 +200,12 @@ impl TopicHandle for MemTopicHandle {
             let _ = sender.send(HubMessage {
                 sender: self.id,
                 data,
-                neighbors_only: false,
             });
         }
         Ok(())
     }
 
-    /// Broadcast to all topic subscribers regardless of the `neighbors_only`
-    /// flag.
+    /// Broadcast to all topic subscribers.
     ///
     /// # MemNetwork divergence from real iroh
     ///
@@ -217,8 +213,8 @@ impl TopicHandle for MemTopicHandle {
     /// gossip-mesh neighbors (the immediate peers this node is connected to).
     /// `MemNetwork` has no concept of per-peer connections: the `HubMessage`
     /// is placed on the shared broadcast channel and received by every
-    /// subscriber on the topic. The `neighbors_only` flag is recorded in the
-    /// message but **has no effect on delivery** — all subscribers receive it.
+    /// subscriber on the topic, so this method behaves identically to
+    /// [`broadcast`](Self::broadcast).
     ///
     /// Tests that specifically rely on neighbor-scoped delivery will produce
     /// false-positive results here and should use the real `IrohNetwork` or
@@ -228,7 +224,6 @@ impl TopicHandle for MemTopicHandle {
             let _ = sender.send(HubMessage {
                 sender: self.id,
                 data,
-                neighbors_only: true,
             });
         }
         Ok(())

--- a/crates/web/src/components/confirm_dialog.rs
+++ b/crates/web/src/components/confirm_dialog.rs
@@ -5,7 +5,6 @@ use leptos::prelude::*;
 /// Shows an overlay with backdrop blur and a centered card. The confirm
 /// button turns red when `danger` is `true`. Pressing Escape closes the
 /// dialog via a keydown handler on the overlay.
-#[allow(dead_code)]
 #[component]
 pub fn ConfirmDialog(
     /// Whether the dialog is visible.

--- a/crates/web/src/components/roles.rs
+++ b/crates/web/src/components/roles.rs
@@ -21,7 +21,6 @@ type RoleEntry = (String, String, Vec<String>);
 ///
 /// Only the server owner sees management controls (create, delete,
 /// permission toggles, assign). Non-owners see a read-only list.
-#[allow(dead_code)]
 #[component]
 pub fn RoleManager(
     peer_id: ReadSignal<String>,

--- a/crates/worker/src/actors/network.rs
+++ b/crates/worker/src/actors/network.rs
@@ -457,6 +457,7 @@ mod tests {
                 servers_loaded: 1,
                 events_buffered: 0,
                 max_events: 1000,
+                pending_count: 0,
             },
             servers: vec![],
             timestamp: 0,

--- a/docs/plans/2026-03-29-iroh-migration.md
+++ b/docs/plans/2026-03-29-iroh-migration.md
@@ -1,5 +1,7 @@
 # Iroh Migration Implementation Plan
 
+> **Status:** completed 2026-04-18. The Bevy app (`crates/app/`) has been retired and removed from the workspace; any references to `crates/app/` in this plan are historical only. Retained for historical record.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Replace libp2p with iroh as Willow's networking layer. Iroh-shaped trait abstraction (`Network`, `TopicHandle`, `TopicEvents`, `BlobStore`) with `IrohNetwork` for production and `MemNetwork` for tests. `EndpointId` replaces `String` for peer identity throughout. Clean break — no backward compatibility.

--- a/docs/specs/2026-03-29-iroh-migration-design.md
+++ b/docs/specs/2026-03-29-iroh-migration-design.md
@@ -1,7 +1,9 @@
 # Iroh Migration Design Spec
 
 **Date**: 2026-03-29
-**Status**: Approved
+**Status**: Completed 2026-04-18. The Bevy app (`crates/app/`) has been retired
+and removed from the workspace; references to `crates/app/` tests below are
+historical only.
 
 ## Overview
 

--- a/docs/specs/2026-03-31-reactive-client-state-design.md
+++ b/docs/specs/2026-03-31-reactive-client-state-design.md
@@ -1,7 +1,9 @@
 # Reactive Client State — Domain Actor Decomposition
 
 **Date**: 2026-03-31
-**Status**: Draft
+**Status**: Draft. Note (2026-04-18): the Bevy app (`crates/app/`) has been
+retired and removed from the workspace; any references to `crates/app/` are
+historical only.
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Verifies and cleans up `#[allow(dead_code)]` markers across the workspace. Most of the annotations turned out to be wrong (the item IS used) or redundant (the item was already suppressed another way). A few items were genuinely dead and were deleted. Stale references to the retired `crates/app/` (Bevy) were marked as historical in older plan/spec docs.

### Targets

1. **`crates/network/src/mem.rs`** — `HubMessage.neighbors_only` deleted.
   The field was marked `#[allow(dead_code)]` and never read; producers in `broadcast` and `broadcast_neighbors` removed the field too. Doc comment on `broadcast_neighbors` updated to note it now behaves identically to `broadcast` (MemNetwork has no per-peer topology concept).

2. **`crates/web/src/components/confirm_dialog.rs`** — annotation removed.
   `ConfirmDialog` is used from `sidebar`, `server_list`, `roles`, `member_list`, and `message` components. Annotation was wrong.

3. **`crates/web/src/components/roles.rs`** — annotation removed.
   `RoleManager` is used from `settings.rs`. Annotation was wrong.

4. **`crates/client/src/lib.rs`** — three items:
   - `ClientEventLoop._system`: redundant `#[allow(dead_code)]` removed. The `_` prefix already suppresses the lint for struct fields in Rust (verified by minimal repro).
   - `reconcile_topic_map`: annotation removed. It is a `pub fn` (public items never trigger `dead_code`) and is exercised by a regression test for issue #141.
   - `parse_permission`: deleted. Genuinely unused private helper; the 2026-04-12 channel-removal spec already noted this as removable.

5. **Docs** — status notes added:
   - `docs/plans/2026-03-29-iroh-migration.md` — status header noting plan is complete and `crates/app/` refs are historical.
   - `docs/specs/2026-03-29-iroh-migration-design.md` — same note.
   - `docs/specs/2026-03-31-reactive-client-state-design.md` — same note.

### Also included (required to make `just check` pass)

- **`crates/worker/src/actors/network.rs`**: added the missing `pending_count: 0` field to a `WorkerRoleInfo::Replay` struct literal in `parse_worker_announcement_rejected_when_peer_id_mismatches_signer`. This is a pre-existing compile error on `main` introduced by commit `b127dfd` ("state: timeout + capacity eviction for PendingBuffer"), which added the new field to `WorkerRoleInfo::Replay` but missed updating this test. Without this fix `cargo test --workspace` (and therefore `just check`) cannot even compile.

## Test plan

- [x] `just check` passes locally (fmt + clippy + workspace tests + WASM)
- [x] `cargo test -p willow-network --features test-utils` — all 15+5 tests pass (mem + iroh integration)
- [x] `cargo test -p willow-client` — 74 tests pass, including the `reconcile_topic_map_skips_malformed_id` regression test
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo check --target wasm32-unknown-unknown ...` via `just check-wasm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)