### PR TITLE
chore: unify workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6200,7 +6200,6 @@ dependencies = [
  "bincode",
  "bytes",
  "clap",
- "futures-core",
  "serde",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ thiserror = "1"
 # Async runtime — no features at workspace level to avoid WASM mio conflict
 tokio = { version = "1" }
 
+# Async utilities (Stream/Future combinators)
+futures = "0.3"
+
 # Crypto & Networking
 zeroize = { version = "1", features = ["derive"] }
 iroh = "0.97"

--- a/crates/actor/Cargo.toml
+++ b/crates/actor/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 description = "Lightweight actor framework for Willow — dual-target (native + WASM)"
 
 [dependencies]
-futures = "0.3"
+futures = { workspace = true }
 futures-core = "0.3"
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -24,8 +24,8 @@ rmcp = { version = "1.3", features = ["server", "transport-io", "transport-strea
 axum = "0.8"
 tokio-util = "0.7"
 schemars = "1.0"
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true }
 serde_json = "1"
 clap = { version = "4", features = ["derive"] }
 tracing = { workspace = true }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
 parking_lot = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["full"] }
@@ -34,7 +34,6 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = "0.4"
-futures = "0.3"
 web-sys = { version = "0.3", features = ["Window", "Storage"] }
 js-sys = "0.3"
 gloo-timers = { version = "0.3", features = ["futures"] }

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -40,7 +40,7 @@ wasm-bindgen-futures = "0.4"
 console_error_panic_hook = "0.1"
 tracing-wasm = "0.2"
 send_wrapper = "0.6"
-futures = "0.3"
+futures = { workspace = true }
 gloo-timers = { version = "0.3", features = ["futures"] }
 
 [dev-dependencies]

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -10,7 +10,6 @@ willow-state = { path = "../state" }
 willow-identity = { path = "../identity" }
 willow-transport = { path = "../transport" }
 willow-network = { path = "../network" }
-futures-core = "0.3"
 serde = { workspace = true }
 bytes = { workspace = true }
 bincode = { workspace = true }

--- a/crates/worker/src/actors/network.rs
+++ b/crates/worker/src/actors/network.rs
@@ -457,6 +457,7 @@ mod tests {
                 servers_loaded: 1,
                 events_buffered: 0,
                 max_events: 1000,
+                pending_count: 0,
             },
             servers: vec![],
             timestamp: 0,


### PR DESCRIPTION
## Summary

Consolidates common crate versions into `[workspace.dependencies]` so member crates reference a single source of truth. Also removes an unused dep and fixes an unrelated test compile error blocking `just check`.

## Changes per crate

### Root `Cargo.toml`
- Added `futures = "0.3"` to `[workspace.dependencies]`.

### `crates/actor/Cargo.toml`
- `futures = "0.3"` -> `futures = { workspace = true }`.
- Left `futures-core = "0.3"` alone — it is genuinely imported (`use futures_core::Stream;` in `stream.rs`, `context.rs`, and `runtime.rs`).

### `crates/client/Cargo.toml`
- `futures = "0.3"` -> `futures = { workspace = true }` in the main deps.
- Removed the duplicate `futures = "0.3"` from the `cfg(target_arch = "wasm32")` block — the main deps entry already applies to wasm.

### `crates/web/Cargo.toml`
- `futures = "0.3"` -> `futures = { workspace = true }`.

### `crates/agent/Cargo.toml`
- `serde = { version = "1", features = ["derive"] }` -> `serde = { workspace = true }` (workspace already pins `derive` + `rc`).
- `tokio = { version = "1", features = ["full"] }` -> `tokio = { workspace = true, features = ["full"] }` (workspace pins no features, crate keeps `full` override as required).

### `crates/worker/Cargo.toml`
- Removed `futures-core = "0.3"` entirely. Grep confirmed zero `futures_core::*` imports in this crate — it was dead weight, not an actually-needed narrower dep. Original Finding 3 suggested adding a comment if it was needed; since it is not used at all, removal is cleaner.

### Deviations from the original findings
- Finding 1 listed `agent` as one of four crates hardcoding `futures = "0.3"`. Agent's manifest does not actually depend on `futures` at all, so it was not part of the `futures` sweep.

## Drive-by fix
- `crates/worker/src/actors/network.rs` had a test fixture missing the `pending_count` field on `WorkerRoleInfo::Replay`, causing `cargo test --workspace` to fail on main. Added `pending_count: 0` so `just check` passes. Two other occurrences in the same file already had the field — this one was simply missed when the field was introduced.

## Verification
- `just check` passes locally (fmt + clippy + full workspace tests + wasm check).

## Test plan
- [x] `just check` passes (fmt, clippy -D warnings, `cargo test --workspace`, wasm target check)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)