### PR TITLE
fix(state): rebuild message_index on deserialize

### DIFF
--- a/crates/state/src/materialize.rs
+++ b/crates/state/src/materialize.rs
@@ -52,7 +52,18 @@ pub fn materialize(dag: &EventDag) -> ServerState {
 ///
 /// Precondition: all causal parents of `event` are already reflected
 /// in `state`. This is O(1) per event.
+///
+/// If the state was just deserialized from disk — recognized by a
+/// populated `messages` vector paired with an empty `message_index` —
+/// the index is transparently rebuilt once here. This prevents the
+/// silent no-op on `EditMessage`/`DeleteMessage`/`Reaction` that would
+/// otherwise happen because `message_index` is `#[serde(skip)]`.
 pub fn apply_incremental(state: &mut ServerState, event: &Event) -> ApplyResult {
+    // Lazy index rebuild for deserialized states. Triggers at most once per
+    // loaded state (subsequent calls observe a populated index and skip).
+    if !state.messages.is_empty() && state.message_index.len() != state.messages.len() {
+        state.rebuild_message_index();
+    }
     if !state.applied_events.insert(event.hash) {
         return ApplyResult::AlreadyApplied;
     }

--- a/crates/state/src/server.rs
+++ b/crates/state/src/server.rs
@@ -85,12 +85,14 @@ pub struct ServerState {
     /// their target in O(1) instead of O(N).
     ///
     /// This field is excluded from serialization (`#[serde(skip)]`). It is
-    /// always empty on a freshly deserialized `ServerState` and is rebuilt
-    /// incrementally by each subsequent `apply_event` call, or all at once
-    /// by a full `materialize()`. Code that deserializes `ServerState` and
-    /// then calls `apply_incremental` without a prior full materialize will
-    /// silently no-op on `EditMessage`/`DeleteMessage`/`Reaction` events until
-    /// the index is warmed. The intended usage is always through `materialize`.
+    /// always empty on a freshly deserialized `ServerState`. To protect
+    /// against silent mutation loss when a caller deserializes state and
+    /// then applies incremental `EditMessage`/`DeleteMessage`/`Reaction`
+    /// events, [`apply_incremental`](crate::materialize::apply_incremental)
+    /// lazily rebuilds the index on first use via
+    /// [`rebuild_message_index`](Self::rebuild_message_index). Callers that
+    /// load state from disk may also invoke `rebuild_message_index` eagerly
+    /// to amortize the O(N) cost up front.
     #[serde(default, skip)]
     pub message_index: HashMap<EventHash, usize>,
 }
@@ -154,6 +156,28 @@ impl ServerState {
     /// Check if a peer can provide sync (trusted for history).
     pub fn is_sync_provider(&self, peer_id: &EndpointId) -> bool {
         self.has_permission(peer_id, &Permission::SyncProvider)
+    }
+
+    /// Rebuild [`message_index`](Self::message_index) from `messages`.
+    ///
+    /// This is O(N) in the number of messages. It exists because
+    /// `message_index` is `#[serde(skip)]` and is therefore empty on a
+    /// freshly deserialized `ServerState`. Without rebuilding, the
+    /// `EditMessage`, `DeleteMessage`, and `Reaction` handlers would
+    /// silently no-op against the stale (empty) index — a silent
+    /// data-loss bug on persisted clients.
+    ///
+    /// Callers that deserialize state from disk should either invoke this
+    /// method eagerly after load, or rely on the lazy rebuild performed
+    /// automatically by
+    /// [`apply_incremental`](crate::materialize::apply_incremental).
+    pub fn rebuild_message_index(&mut self) {
+        self.message_index = self
+            .messages
+            .iter()
+            .enumerate()
+            .map(|(i, m)| (m.id, i))
+            .collect();
     }
 
     /// Check if a yes-vote count meets the current threshold.

--- a/crates/state/src/tests.rs
+++ b/crates/state/src/tests.rs
@@ -3456,3 +3456,162 @@ fn stress_concurrent_channel_creates_count_is_stable() {
         "channel count must be identical across materializations of the same DAG"
     );
 }
+
+// ── Regression: message_index must survive round-trip serialization ────────
+
+/// `ServerState.message_index` is `#[serde(skip)]`, so it is empty after
+/// deserialize. Previously this caused Edit/Delete/Reaction events applied
+/// via `apply_incremental` on a deserialized state to silently no-op,
+/// producing data loss on persisted clients that didn't run a full
+/// `materialize()` first. This test guards against that regression.
+#[test]
+fn deserialized_state_accepts_edit_delete_reaction_via_apply_incremental() {
+    use crate::materialize::apply_incremental;
+
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    // Seed the DAG with a channel plus messages to edit, delete, and react to.
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::CreateChannel {
+            name: "general".into(),
+            channel_id: "ch-1".into(),
+            kind: crate::types::ChannelKind::Text,
+        },
+    );
+    let msg_edit = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch-1".into(),
+            body: "typo".into(),
+            reply_to: None,
+        },
+    );
+    let msg_delete = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch-1".into(),
+            body: "to delete".into(),
+            reply_to: None,
+        },
+    );
+    let msg_react = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "ch-1".into(),
+            body: "react to me".into(),
+            reply_to: None,
+        },
+    );
+
+    let state = materialize(&dag);
+
+    // Simulate persistence: round-trip through bincode.
+    let bytes = bincode::serialize(&state).expect("serialize ServerState");
+    let mut restored: crate::ServerState =
+        bincode::deserialize(&bytes).expect("deserialize ServerState");
+
+    // Sanity: message_index was skipped during serialization.
+    assert!(
+        restored.message_index.is_empty(),
+        "message_index is #[serde(skip)] — must be empty after deserialize"
+    );
+
+    // Craft follow-up mutations. These are "new" events that arrive after
+    // the state was loaded from disk, exactly like the apply_incremental
+    // flow in the client after load_server_state().
+    let edit = dag.create_event(
+        &admin,
+        EventKind::EditMessage {
+            message_id: msg_edit.hash,
+            new_body: "fixed".into(),
+        },
+        vec![],
+        1,
+    );
+    let delete = dag.create_event(
+        &admin,
+        EventKind::DeleteMessage {
+            message_id: msg_delete.hash,
+        },
+        vec![],
+        2,
+    );
+    let react = dag.create_event(
+        &admin,
+        EventKind::Reaction {
+            message_id: msg_react.hash,
+            emoji: "👍".into(),
+        },
+        vec![],
+        3,
+    );
+
+    // Apply to the deserialized state WITHOUT a full materialize() first.
+    // Before the fix, message_index is empty and these mutations silently
+    // no-op.
+    apply_incremental(&mut restored, &edit);
+    apply_incremental(&mut restored, &delete);
+    apply_incremental(&mut restored, &react);
+
+    let edited = restored
+        .messages
+        .iter()
+        .find(|m| m.id == msg_edit.hash)
+        .expect("edit target still present");
+    assert_eq!(edited.body, "fixed", "EditMessage must take effect");
+    assert!(edited.edited, "message must be flagged edited");
+
+    let deleted = restored
+        .messages
+        .iter()
+        .find(|m| m.id == msg_delete.hash)
+        .expect("delete target still present");
+    assert!(deleted.deleted, "DeleteMessage must take effect");
+    assert_eq!(deleted.body, "[message deleted]");
+
+    let reacted = restored
+        .messages
+        .iter()
+        .find(|m| m.id == msg_react.hash)
+        .expect("reaction target still present");
+    assert!(
+        reacted.reactions.contains_key("👍"),
+        "Reaction must take effect"
+    );
+}
+
+/// Directly exercises `rebuild_message_index` — after clearing the index by
+/// hand, calling the method should reconstruct the hash→position map.
+#[test]
+fn rebuild_message_index_restores_mapping() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    let msg = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::Message {
+            channel_id: "general".into(),
+            body: "hello".into(),
+            reply_to: None,
+        },
+    );
+    let mut state = materialize(&dag);
+    state.message_index.clear();
+    assert!(state.message_index.is_empty());
+
+    state.rebuild_message_index();
+
+    assert_eq!(
+        state.message_index.get(&msg.hash).copied(),
+        Some(0),
+        "rebuild_message_index must map each message's hash to its vec index",
+    );
+    assert_eq!(state.message_index.len(), state.messages.len());
+}


### PR DESCRIPTION
## Summary

`ServerState.message_index: HashMap<EventHash, usize>` in `crates/state/src/server.rs` is `#[serde(skip)]`, so the map is empty after a state is loaded from disk. The `EditMessage`, `DeleteMessage`, and `Reaction` handlers in `crates/state/src/materialize.rs` (around lines 427–457) use `message_index.get()` and silently return `None` without falling back to an O(N) scan. As a result, edit/delete/reaction events applied via `apply_incremental` on a freshly-deserialized state silently no-op — a silent data-loss bug.

This path is triggerable in production via the client's `load_server_state()` → `apply_incremental` flow (see `crates/client/src/lib.rs:350`, `crates/client/src/storage.rs:163`). The previous doc comment on `message_index` even admitted this: "will silently no-op on EditMessage/DeleteMessage/Reaction events until the index is warmed."

## Fix

- Added `ServerState::rebuild_message_index(&mut self)` as an explicit O(N) rebuild for callers that load state from disk.
- `apply_incremental` now transparently rebuilds the index on first use when `messages` is populated but `message_index` is stale. This triggers at most once per loaded state (the invariant holds after rebuild, so subsequent calls skip). Persisted clients self-heal without any API change on the caller side.

Materialize still builds the index incrementally, so the full-materialize path is unaffected and remains O(N) total.

## Test coverage

Added two regression tests in `crates/state/src/tests.rs`:

- **`deserialized_state_accepts_edit_delete_reaction_via_apply_incremental`** — Builds a state with three messages via `materialize`, round-trips it through `bincode`, verifies `message_index` is empty post-deserialize, applies one `EditMessage`, one `DeleteMessage`, and one `Reaction` via `apply_incremental`, and asserts each mutation took effect on the correct target.
- **`rebuild_message_index_restores_mapping`** — Exercises the new public method directly: clears the index by hand, rebuilds, asserts the hash→index map is correct.

Both tests fail without the fix and pass with it. The full `willow-state` suite (186 tests) passes.

## Test plan

- [x] `cargo test -p willow-state` passes (186 tests, includes the two new regression tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `just check-wasm` clean
- [x] `cargo test --workspace --exclude willow-worker` passes

Note: `just check` also runs `cargo test` across the full workspace, which currently fails to build `willow-worker` tests due to a pre-existing issue on `main` (`WorkerRoleInfo::Replay` gained a `pending_count` field but the test helper at `crates/worker/src/actors/network.rs:456` was not updated). That failure reproduces on unmodified `main` and is outside the scope of this fix; it should be addressed in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)