### PR TITLE
fix(agent): harden panic and silent-error paths

### DIFF
--- a/crates/agent/src/auth.rs
+++ b/crates/agent/src/auth.rs
@@ -88,7 +88,8 @@ mod tests {
         let dir = std::env::temp_dir().join("willow-auth-test");
         let _ = std::fs::create_dir_all(&dir);
         let path = dir.join("test-token");
-        let token = resolve_token(&None, Some(path.to_str().unwrap())).unwrap();
+        let path_str = path.to_string_lossy().into_owned();
+        let token = resolve_token(&None, Some(&path_str)).unwrap();
         let read_back = std::fs::read_to_string(&path).unwrap();
         assert_eq!(token, read_back);
         let _ = std::fs::remove_file(&path);

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -112,7 +112,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Connect to network if relay specified.
     if let Some(ref relay_url) = cli.relay {
-        let relay: RelayUrl = relay_url.parse().expect("invalid relay URL");
+        let relay: RelayUrl = relay_url
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid relay URL {relay_url:?}: {e}"))?;
         let iroh_config = IrohConfig {
             secret_key: identity.secret_key().clone(),
             relay_url: Some(relay),

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -31,8 +31,17 @@ fn parse_endpoint_ids(ids: &[String]) -> Result<Vec<EndpointId>, String> {
 }
 
 fn success_json(value: impl Serialize) -> Result<CallToolResult, ErrorData> {
-    let text = serde_json::to_string(&value).unwrap_or_else(|_| "{}".to_string());
-    Ok(CallToolResult::success(vec![Content::text(text)]))
+    match serde_json::to_string(&value) {
+        Ok(text) => Ok(CallToolResult::success(vec![Content::text(text)])),
+        Err(e) => {
+            tracing::warn!(error = %e, "tool serialization failed");
+            let err_body = serde_json::json!({
+                "error": format!("tool serialization failed: {e}")
+            })
+            .to_string();
+            Ok(CallToolResult::error(vec![Content::text(err_body)]))
+        }
+    }
 }
 
 fn error_text(msg: impl Into<String>) -> Result<CallToolResult, ErrorData> {
@@ -595,8 +604,13 @@ impl<N: Network> WillowToolRouter<N> {
                 let p: AuthorizeWorkersParams = parse_args(&args)?;
                 let eids = parse_endpoint_ids(&p.worker_peer_ids)
                     .map_err(|e| ErrorData::invalid_params(e, None))?;
-                self.client.authorize_workers(&eids).await.ok();
-                success_json(serde_json::json!({"success": true}))
+                match self.client.authorize_workers(&eids).await {
+                    Ok(()) => success_json(serde_json::json!({"success": true})),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "authorize_workers failed");
+                        error_text(format!("authorize_workers failed: {e}"))
+                    }
+                }
             }
 
             // ── Identity ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `main.rs:115` — replace `.expect(\"invalid relay URL\")` with `?` + anyhow error including offending URL
- `tools.rs` `success_json` — on serde_json failure, log `tracing::warn!` and return MCP error response instead of silent `\"{}\"`
- `tools.rs` `authorize_workers` handler — match Result, log on error, surface failure via `error_text`
- `auth.rs` test — `path.to_str().unwrap()` → `path.to_string_lossy().into_owned()`

## Test plan
- [x] `just check` — fmt, clippy (-D warnings), workspace tests, WASM all pass