### PR TITLE
obs(worker): log silent error paths in actors

### DIFF
--- a/crates/worker/src/actors/heartbeat.rs
+++ b/crates/worker/src/actors/heartbeat.rs
@@ -103,7 +103,9 @@ impl<T: TopicHandle + 'static> Handler<HeartbeatTick> for HeartbeatActor<T> {
             let msg = WorkerWireMessage::Announcement(announcement);
             let wire = willow_common::WireMessage::Worker(msg);
             if let Some(bytes) = willow_common::pack_wire(&wire, &identity) {
-                topic.broadcast(bytes::Bytes::from(bytes)).await.ok();
+                if let Err(err) = topic.broadcast(bytes::Bytes::from(bytes)).await {
+                    warn!(%err, %peer_id, "heartbeat announcement broadcast failed");
+                }
             }
         }
     }

--- a/crates/worker/src/actors/network.rs
+++ b/crates/worker/src/actors/network.rs
@@ -139,13 +139,22 @@ impl<E: TopicEvents + 'static, T: TopicHandle + 'static> Handler<GossipEventMsg>
                             // target_peer identifies the original requester so
                             // clients can filter responses addressed to them.
                             let reply = WorkerWireMessage::Response {
-                                request_id,
+                                request_id: request_id.clone(),
                                 target_peer: requester,
                                 payload: Box::new(response),
                             };
                             let wire = willow_common::WireMessage::Worker(reply);
                             if let Some(bytes) = willow_common::pack_wire(&wire, &identity) {
-                                reply_topic.broadcast(bytes::Bytes::from(bytes)).await.ok();
+                                if let Err(err) =
+                                    reply_topic.broadcast(bytes::Bytes::from(bytes)).await
+                                {
+                                    warn!(
+                                        %err,
+                                        %request_id,
+                                        %requester,
+                                        "worker reply broadcast failed"
+                                    );
+                                }
                             }
                         }
                     }
@@ -166,7 +175,14 @@ impl<E: TopicEvents + 'static, T: TopicHandle + 'static> Handler<GossipEventMsg>
                         match parse_server_message(&msg.content) {
                             ServerMessageAction::Events(events) => {
                                 for event in events {
-                                    state_addr.do_send(EventMsg(event)).ok();
+                                    let event_hash = event.hash;
+                                    if state_addr.do_send(EventMsg(event)).is_err() {
+                                        warn!(
+                                            %event_hash,
+                                            source = "workers-topic",
+                                            "worker event dropped: state mailbox full"
+                                        );
+                                    }
                                 }
                             }
                             ServerMessageAction::Ignore => {}
@@ -194,7 +210,14 @@ impl<E: TopicEvents + 'static, T: TopicHandle + 'static> Handler<ServerOpsEventM
                 match parse_server_message(&msg.content) {
                     ServerMessageAction::Events(events) => {
                         for event in events {
-                            state_addr.do_send(EventMsg(event)).ok();
+                            let event_hash = event.hash;
+                            if state_addr.do_send(EventMsg(event)).is_err() {
+                                warn!(
+                                    %event_hash,
+                                    source = "server-ops-topic",
+                                    "worker event dropped: state mailbox full"
+                                );
+                            }
                         }
                     }
                     ServerMessageAction::Ignore => {}

--- a/crates/worker/src/actors/sync.rs
+++ b/crates/worker/src/actors/sync.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use tracing::debug;
+use tracing::{debug, warn};
 use willow_actor::{Actor, Addr, Context, Handler, IntervalHandle, Message};
 use willow_network::TopicHandle;
 
@@ -75,14 +75,17 @@ impl<T: TopicHandle + 'static> Handler<SyncTick> for SyncActor<T> {
                 // it checks target_peer == local_peer_id (the receiver also
                 // has their own ID, which won't match) OR handles Sync
                 // requests specially.
+                let request_id = uuid::Uuid::new_v4().to_string();
                 let msg = WorkerWireMessage::Request {
-                    request_id: uuid::Uuid::new_v4().to_string(),
+                    request_id: request_id.clone(),
                     target_peer: peer_id,
                     payload: WorkerRequest::Sync { server_id, heads },
                 };
                 let wire = willow_common::WireMessage::Worker(msg);
                 if let Some(bytes) = willow_common::pack_wire(&wire, &identity) {
-                    topic.broadcast(bytes::Bytes::from(bytes)).await.ok();
+                    if let Err(err) = topic.broadcast(bytes::Bytes::from(bytes)).await {
+                        warn!(%err, %request_id, "sync request broadcast failed");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Five `.ok()` sites in worker actors dropped `Result` without logging. If an actor mailbox fills or a broadcast fails, events/announcements/responses vanished silently, looking like a network partition to peers.

Now each site logs at `warn!` level with relevant context.

- `heartbeat.rs` — announcement broadcast
- `network.rs` — reply broadcast, two `state_addr.do_send(EventMsg(...))` sites (workers + server-ops topics)
- `sync.rs` — sync request broadcast

`do_send` returns `Result<(), ()>` (unit error type), so those sites use `.is_err()` rather than binding the error. Broadcast errors are `anyhow::Error` and log with `%err` plus `peer_id` / `request_id` / `event_hash` context.

## Test plan
- [x] `cargo test -p willow-worker --lib` — 28 passed
- [x] `cargo clippy -p willow-worker --lib -- -D warnings` — clean