### PR TITLE
fix(storage): size truncation + LIMIT cap

### DIFF
--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -402,13 +402,23 @@ impl StorageEventStore {
     }
 
     /// Number of distinct servers tracked.
+    ///
+    /// Return type is capped at `u32` to match `WorkerRoleInfo::Storage.servers_tracked`.
+    /// A distinct-server count exceeding `u32::MAX` is astronomically unlikely and
+    /// is reported as `u32::MAX` with a warning.
     pub fn server_count(&self) -> anyhow::Result<u32> {
         let count: i64 =
             self.conn
                 .query_row("SELECT COUNT(DISTINCT server_id) FROM events", [], |row| {
                     row.get(0)
                 })?;
-        Ok(u32::try_from(count).unwrap_or(u32::MAX))
+        Ok(u32::try_from(count).unwrap_or_else(|_| {
+            tracing::warn!(
+                count,
+                "server_count exceeds u32::MAX; clamping (widen servers_tracked upstream)"
+            );
+            u32::MAX
+        }))
     }
 }
 
@@ -525,6 +535,30 @@ mod tests {
         assert_eq!(events[0].seq, 6);
         assert_eq!(events[1].seq, 5);
         assert_eq!(events[2].seq, 4);
+    }
+
+    #[test]
+    fn history_caps_caller_limit_to_sync_batch_limit() {
+        // Confirms history() silently caps `limit` at SYNC_BATCH_LIMIT so a
+        // malicious client cannot request up to u32::MAX events. With fewer
+        // rows stored than the cap, the return length matches the stored
+        // rows and `has_more` is false.
+        let store = StorageEventStore::open(":memory:").unwrap();
+        let (id, genesis) = setup_identity_and_genesis();
+
+        let mut prev = genesis.hash;
+        for seq in 2..=6 {
+            let e = make_message(&id, seq, prev, "general");
+            prev = e.hash;
+            store.store_event("srv-1", &e).unwrap();
+        }
+
+        let (events, has_more) = store
+            .history("srv-1", Some("general"), None, u32::MAX)
+            .unwrap();
+        assert_eq!(events.len(), 5);
+        assert!(!has_more);
+        assert!(events.len() <= StorageEventStore::SYNC_BATCH_LIMIT);
     }
 
     #[test]

--- a/crates/storage/src/store.rs
+++ b/crates/storage/src/store.rs
@@ -188,7 +188,8 @@ impl StorageEventStore {
         before: Option<&HeadsSummary>,
         limit: u32,
     ) -> anyhow::Result<(Vec<Event>, bool)> {
-        let fetch_limit = limit as usize + 1;
+        let capped = (limit as usize).min(Self::SYNC_BATCH_LIMIT);
+        let fetch_limit = capped + 1;
 
         // Build the query dynamically based on filters.
         let mut sql = String::from("SELECT event_data FROM events WHERE server_id = ?1");
@@ -271,8 +272,8 @@ impl StorageEventStore {
             })
             .collect();
 
-        let has_more = events.len() > limit as usize;
-        let events: Vec<Event> = events.into_iter().take(limit as usize).collect();
+        let has_more = events.len() > capped;
+        let events: Vec<Event> = events.into_iter().take(capped).collect();
 
         Ok((events, has_more))
     }
@@ -395,7 +396,9 @@ impl StorageEventStore {
         let page_size: i64 = self
             .conn
             .query_row("PRAGMA page_size", [], |row| row.get(0))?;
-        Ok((pages * page_size) as u64)
+        let pages = u64::try_from(pages).unwrap_or(0);
+        let page_size = u64::try_from(page_size).unwrap_or(0);
+        Ok(pages.saturating_mul(page_size))
     }
 
     /// Number of distinct servers tracked.
@@ -405,7 +408,7 @@ impl StorageEventStore {
                 .query_row("SELECT COUNT(DISTINCT server_id) FROM events", [], |row| {
                     row.get(0)
                 })?;
-        Ok(count as u32)
+        Ok(u32::try_from(count).unwrap_or(u32::MAX))
     }
 }
 


### PR DESCRIPTION
## Summary
Three hardening fixes in `crates/storage/src/store.rs`:

1. **`disk_usage_bytes`** — cast each pragma value (`pages`, `page_size`) to `u64` via `try_from`, then use `saturating_mul`. Previous `(pages * page_size) as u64` could overflow on large DBs before the cast.
2. **`server_count`** — use `u32::try_from(...).unwrap_or(u32::MAX)`. Keeps the u32 return type that `WorkerRoleInfo::Storage.servers_tracked` expects, but no longer wraps on a negative i64.
3. **`history`** — cap caller-supplied `limit` to `SYNC_BATCH_LIMIT`. Prevents a malicious client from requesting up to `u32::MAX` events.

## Test plan
- [x] `cargo test -p willow-storage` — 32 passed
- [x] `cargo clippy -p willow-storage --all-targets -- -D warnings` — clean