### PR TITLE
chore(tech-debt): remove dead code + tighten clippy CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             target
           key: clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: clippy-
-      - run: cargo clippy --workspace -- -D warnings
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
     name: Test

--- a/crates/client/src/base64.rs
+++ b/crates/client/src/base64.rs
@@ -1,10 +1,9 @@
 //! Minimal base64 encoding/decoding. Avoids pulling in an external crate
 //! for a simple operation used by storage (WASM localStorage) and invite codes.
 
-#[allow(clippy::manual_div_ceil)]
 pub fn encode(data: &[u8]) -> String {
     const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut result = String::with_capacity((data.len() + 2) / 3 * 4);
+    let mut result = String::with_capacity(data.len().div_ceil(3) * 4);
     for chunk in data.chunks(3) {
         let b0 = chunk[0] as u32;
         let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
@@ -38,8 +37,7 @@ pub fn decode(input: &str) -> Option<Vec<u8>> {
         }
     }
     let bytes = input.as_bytes();
-    #[allow(clippy::manual_is_multiple_of)]
-    if bytes.len() % 4 != 0 || bytes.is_empty() {
+    if !bytes.len().is_multiple_of(4) || bytes.is_empty() {
         return None;
     }
     let mut result = Vec::with_capacity(bytes.len() / 4 * 3);

--- a/crates/replay/src/role.rs
+++ b/crates/replay/src/role.rs
@@ -39,9 +39,6 @@ struct ServerData {
     state: ServerState,
     /// Buffer for events arriving before their chain predecessors.
     pending: PendingBuffer,
-    /// Max events per author before compaction (reserved for future use).
-    #[allow(dead_code)]
-    max_events_per_author: usize,
     /// Monotonic counter recording last access (for LRU eviction).
     last_access: u64,
 }
@@ -130,7 +127,6 @@ impl ReplayRole {
                     dag: EventDag::new(),
                     state: ServerState::new(server_id, server_id, author),
                     pending,
-                    max_events_per_author: max_per_author,
                     last_access: access_counter,
                 }
             });

--- a/crates/web/src/palette_recents.rs
+++ b/crates/web/src/palette_recents.rs
@@ -31,15 +31,6 @@ pub fn remember_enabled() -> bool {
         .unwrap_or(true)
 }
 
-/// Flip the remember-recents preference. Consumed by the settings UI
-/// (landing in settings-tweaks.md).
-#[allow(dead_code)]
-pub fn set_remember_enabled(v: bool) {
-    if let Some(s) = storage() {
-        let _ = s.set_item(TOGGLE_KEY, if v { "true" } else { "false" });
-    }
-}
-
 /// Load all recents (up to `MAX_RECENTS`). Returns empty when the
 /// remember-recents toggle is off or when localStorage is unavailable.
 pub fn load() -> Vec<Recent> {

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -9188,11 +9188,7 @@ mod phase_2a_message_row {
         // (no header). Uses the real MessageList predicate, not a
         // hand-rolled show_header flag.
         let now_ms = js_sys::Date::now() as u64;
-        let m0 = {
-            let mut m = make_msg("Mira", "one", now_ms);
-            m.author_peer_id = m.author_peer_id; // no-op, keep
-            m
-        };
+        let m0 = make_msg("Mira", "one", now_ms);
         let shared_author = m0.author_peer_id;
         let shared_name = m0.author_display_name.clone();
         let mut m1 = make_msg(&shared_name, "two", now_ms + 4 * 60 * 1000);

--- a/crates/worker/tests/integration.rs
+++ b/crates/worker/tests/integration.rs
@@ -896,16 +896,17 @@ async fn sync_actor_broadcasts_request_when_heads_nonempty() {
             _ => break false,
         };
         if let willow_network::GossipEvent::Received(msg) = event {
-            if let Some((willow_common::WireMessage::Worker(wire), _)) =
-                willow_common::unpack_wire(&msg.content)
+            if let Some((
+                willow_common::WireMessage::Worker(willow_common::WorkerWireMessage::Request {
+                    payload: willow_common::WorkerRequest::Sync { server_id, heads },
+                    ..
+                }),
+                _,
+            )) = willow_common::unpack_wire(&msg.content)
             {
-                if let willow_common::WorkerWireMessage::Request { payload, .. } = wire {
-                    if let willow_common::WorkerRequest::Sync { server_id, heads } = payload {
-                        assert_eq!(server_id, "srv-sync");
-                        assert_eq!(heads.heads.len(), 1, "heads should have the one author");
-                        break true;
-                    }
-                }
+                assert_eq!(server_id, "srv-sync");
+                assert_eq!(heads.heads.len(), 1, "heads should have the one author");
+                break true;
             }
         }
     };
@@ -1082,29 +1083,28 @@ async fn two_workers_sync_state_via_gossip() {
         };
 
         if let willow_network::GossipEvent::Received(msg) = event {
-            if let Some((willow_common::WireMessage::Worker(wire), _)) =
-                willow_common::unpack_wire(&msg.content)
-            {
-                if let willow_common::WorkerWireMessage::Response {
+            if let Some((
+                willow_common::WireMessage::Worker(willow_common::WorkerWireMessage::Response {
                     request_id: rid,
                     target_peer,
                     payload,
-                } = wire
-                {
-                    if rid == request_id && target_peer == requester_b_id {
-                        match *payload {
-                            willow_common::WorkerResponse::SyncBatch { events } => {
-                                assert_eq!(events.len(), 2, "Worker A should send genesis + msg1");
-                                let hashes: std::collections::HashSet<_> =
-                                    events.iter().map(|e| e.hash).collect();
-                                assert!(hashes.contains(&genesis.hash));
-                                assert!(hashes.contains(&msg1.hash));
-                                found_response = true;
-                                break;
-                            }
-                            other => {
-                                panic!("expected SyncBatch in response payload, got {:?}", other)
-                            }
+                }),
+                _,
+            )) = willow_common::unpack_wire(&msg.content)
+            {
+                if rid == request_id && target_peer == requester_b_id {
+                    match *payload {
+                        willow_common::WorkerResponse::SyncBatch { events } => {
+                            assert_eq!(events.len(), 2, "Worker A should send genesis + msg1");
+                            let hashes: std::collections::HashSet<_> =
+                                events.iter().map(|e| e.hash).collect();
+                            assert!(hashes.contains(&genesis.hash));
+                            assert!(hashes.contains(&msg1.hash));
+                            found_response = true;
+                            break;
+                        }
+                        other => {
+                            panic!("expected SyncBatch in response payload, got {:?}", other)
                         }
                     }
                 }

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ fmt-check:
 
 # Run clippy with warnings as errors
 clippy:
-    cargo clippy --workspace -- -D warnings
+    cargo clippy --workspace --all-targets -- -D warnings
 
 # Run all cargo tests (unit + integration, excludes browser)
 test:


### PR DESCRIPTION
## Summary

Audit-driven cleanup: delete dead code surfaced by an audit pass on
`main`, modernize a tiny util, fix test-file clippy warnings, and close
the CI gap that let them land.

- **Dead code**
  - `crates/replay/src/role.rs` — delete unused
    `ServerData.max_events_per_author` field (assigned but never read;
    the config value is captured in a local binding instead).
  - `crates/web/src/palette_recents.rs` — delete
    `set_remember_enabled` (no callers anywhere).

- **Modernize**
  - `crates/client/src/base64.rs` — use `div_ceil(3)` /
    `is_multiple_of(4)` (stable); drops two `clippy::manual_*` allows.

- **Test-only clippy fixes** (wouldn't fire under today's CI — see
  below)
  - `crates/worker/tests/integration.rs` — collapse three nested
    `if let`s the `collapsible_match` lint was flagging.
  - `crates/web/tests/browser.rs` — drop a
    `m.author_peer_id = m.author_peer_id` no-op self-assignment.

- **CI gap**
  - `.github/workflows/ci.yml` + `justfile` — run clippy with
    `--all-targets` so test-only warnings don't slip past review. The
    two fixes above would have been caught by CI with this change.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo check --target wasm32-unknown-unknown` (via `just check-wasm`)

## Scope notes

Deliberately avoided touching `crates/web/src/state.rs` and
`crates/client/src/storage.rs` — stale `#[allow(dead_code)]`
annotations and a dead `save_download` helper there also qualify for
deletion, but those files are under heavy modification in PRs #185,
#187, #188 and a cleanup edit would conflict. They're captured in a
follow-up audit note.

https://claude.ai/code/session_01JpAauE7enCc1t1HgsWsdN7