### PR TITLE
[#204] extract TYPING_INDICATOR_TTL_MS constant

### DIFF
--- a/crates/client/src/accessors.rs
+++ b/crates/client/src/accessors.rs
@@ -181,7 +181,8 @@ impl<N: willow_network::Network> ClientHandle<N> {
         let my_id = self.identity.endpoint_id();
         willow_actor::state::mutate(&self.network_meta_addr, move |n| {
             let now = crate::util::current_time_ms();
-            n.typing_peers.retain(|_, (_, ts)| now - *ts < 5000);
+            n.typing_peers
+                .retain(|_, (_, ts)| now - *ts < crate::TYPING_INDICATOR_TTL_MS);
             n.typing_peers
                 .iter()
                 .filter(|(pid, _)| *pid != &my_id)

--- a/crates/client/src/joining.rs
+++ b/crates/client/src/joining.rs
@@ -309,7 +309,8 @@ impl<N: willow_network::Network> ClientHandle<N> {
         let profiles = willow_actor::state::get(&self.profile_state_addr).await;
         willow_actor::state::mutate(&self.network_meta_addr, move |n| {
             let now = util::current_time_ms();
-            n.typing_peers.retain(|_, (_, ts)| now - *ts < 5000);
+            n.typing_peers
+                .retain(|_, (_, ts)| now - *ts < crate::TYPING_INDICATOR_TTL_MS);
             n.typing_peers
                 .iter()
                 .filter(|(pid, (ch, _))| ch == &channel && *pid != &my_id)

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -53,6 +53,9 @@ mod tests_trust_flow;
 #[path = "tests/multi_peer_sync.rs"]
 mod tests_multi_peer_sync;
 
+/// How long a typing indicator remains visible after the last typing event, in milliseconds.
+pub const TYPING_INDICATOR_TTL_MS: u64 = 5_000;
+
 // Re-export key types at crate root for convenience.
 pub use event_receiver::EventReceiver;
 pub use events::ClientEvent;


### PR DESCRIPTION
## Summary

- Extracts the hardcoded `5000` typing-indicator TTL duplicated in `joining.rs` and `accessors.rs` into a single public constant `TYPING_INDICATOR_TTL_MS` in `willow-client`.
- Prevents divergence if the TTL is ever updated.

Closes #204.

## Test plan

- [x] `cargo check -p willow-client`
- [x] `cargo test -p willow-client` (134 tests pass)
- [x] `cargo fmt --check`

https://claude.ai/code/session_01SMAPhyr9u7x4HNvKfmmGdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMAPhyr9u7x4HNvKfmmGdX)_