### PR TITLE
[#205] use MAX_CLIENT_PENDING at ManagedDag init sites

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -864,7 +864,11 @@ pub fn test_client() -> (
     // Create a ManagedDag seeded with genesis — DAG and state are
     // atomically initialized together.
     let mut dag_state = state_actors::DagState {
-        managed: willow_state::ManagedDag::new(&identity, "Test Server", 5000),
+        managed: willow_state::ManagedDag::new(
+            &identity,
+            "Test Server",
+            crate::state_actors::MAX_CLIENT_PENDING,
+        ),
         stashed: HashMap::new(),
     };
 
@@ -1604,7 +1608,9 @@ mod tests {
                 let events_for_b = a_events.clone();
                 willow_actor::state::mutate(&client_b.dag_addr, move |ds| {
                     // Reset to an empty DAG and replay A's events.
-                    ds.managed = willow_state::ManagedDag::empty(5000);
+                    ds.managed = willow_state::ManagedDag::empty(
+                        crate::state_actors::MAX_CLIENT_PENDING,
+                    );
                     for event in events_for_b {
                         ds.managed.insert_and_apply(event).ok();
                     }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1608,9 +1608,8 @@ mod tests {
                 let events_for_b = a_events.clone();
                 willow_actor::state::mutate(&client_b.dag_addr, move |ds| {
                     // Reset to an empty DAG and replay A's events.
-                    ds.managed = willow_state::ManagedDag::empty(
-                        crate::state_actors::MAX_CLIENT_PENDING,
-                    );
+                    ds.managed =
+                        willow_state::ManagedDag::empty(crate::state_actors::MAX_CLIENT_PENDING);
                     for event in events_for_b {
                         ds.managed.insert_and_apply(event).ok();
                     }

--- a/crates/client/src/servers.rs
+++ b/crates/client/src/servers.rs
@@ -27,7 +27,9 @@ impl<N: willow_network::Network> ClientHandle<N> {
             if let Some(restored) = ds.stashed.remove(&tid) {
                 ds.managed = restored;
             } else {
-                ds.managed = willow_state::ManagedDag::empty(5000);
+                ds.managed = willow_state::ManagedDag::empty(
+                    crate::state_actors::MAX_CLIENT_PENDING,
+                );
             }
             ds.managed.state().clone()
         })
@@ -117,7 +119,9 @@ impl<N: willow_network::Network> ClientHandle<N> {
             willow_actor::state::mutate(&self.dag_addr, move |ds| {
                 ds.stashed.insert(oid, ds.managed.clone());
                 // Reset managed to empty so seed_genesis creates fresh state.
-                ds.managed = willow_state::ManagedDag::empty(5000);
+                ds.managed = willow_state::ManagedDag::empty(
+                    crate::state_actors::MAX_CLIENT_PENDING,
+                );
             })
             .await;
         }

--- a/crates/client/src/servers.rs
+++ b/crates/client/src/servers.rs
@@ -27,9 +27,8 @@ impl<N: willow_network::Network> ClientHandle<N> {
             if let Some(restored) = ds.stashed.remove(&tid) {
                 ds.managed = restored;
             } else {
-                ds.managed = willow_state::ManagedDag::empty(
-                    crate::state_actors::MAX_CLIENT_PENDING,
-                );
+                ds.managed =
+                    willow_state::ManagedDag::empty(crate::state_actors::MAX_CLIENT_PENDING);
             }
             ds.managed.state().clone()
         })
@@ -119,9 +118,8 @@ impl<N: willow_network::Network> ClientHandle<N> {
             willow_actor::state::mutate(&self.dag_addr, move |ds| {
                 ds.stashed.insert(oid, ds.managed.clone());
                 // Reset managed to empty so seed_genesis creates fresh state.
-                ds.managed = willow_state::ManagedDag::empty(
-                    crate::state_actors::MAX_CLIENT_PENDING,
-                );
+                ds.managed =
+                    willow_state::ManagedDag::empty(crate::state_actors::MAX_CLIENT_PENDING);
             })
             .await;
         }

--- a/crates/client/src/state_actors.rs
+++ b/crates/client/src/state_actors.rs
@@ -195,7 +195,7 @@ pub struct VoiceState {
 /// Maximum number of events the client will buffer while waiting for
 /// missing predecessors. Prevents unbounded memory growth from malicious
 /// or misbehaving peers sending events with chain gaps.
-const MAX_CLIENT_PENDING: usize = 5_000;
+pub(crate) const MAX_CLIENT_PENDING: usize = 5_000;
 
 /// Combined EventDag + ServerState + PendingBuffer, held in a single
 /// StateActor via [`ManagedDag`](willow_state::ManagedDag).


### PR DESCRIPTION
## Summary

- `MAX_CLIENT_PENDING` was defined in `crates/client/src/state_actors.rs` but four `ManagedDag::new`/`empty` call sites hardcoded the literal `5000` instead.
- Promotes the constant to `pub(crate)` and routes the four call sites through it.
- Keeps client-side pending buffer sizing tunable in one place.

Closes #205.

## Test plan

- [x] `cargo check -p willow-client`
- [x] `cargo test -p willow-client` (134 tests pass)

https://claude.ai/code/session_01SMAPhyr9u7x4HNvKfmmGdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMAPhyr9u7x4HNvKfmmGdX)_