### PR TITLE
[#208] explicit TimerHandle::cancel() in Debounce/Throttle

### DIFF
--- a/crates/actor/src/debounce.rs
+++ b/crates/actor/src/debounce.rs
@@ -61,8 +61,10 @@ impl<M: Message<Result = ()> + Send + 'static> Handler<Enqueue<M>> for Debounce<
         ctx: &mut Context<Self>,
     ) -> impl Future<Output = ()> + Send {
         self.pending = Some(msg.0);
-        // Cancel existing timer
-        self.timer.take();
+        // Cancel existing timer explicitly
+        if let Some(t) = self.timer.take() {
+            t.cancel();
+        }
         // Start new timer
         self.timer = Some(ctx.run_after(self.delay, Flush));
         async {}
@@ -137,7 +139,10 @@ impl<M: Message<Result = ()> + Send + 'static> Handler<CooldownExpired> for Thro
         ctx: &mut Context<Self>,
     ) -> impl Future<Output = ()> + Send {
         self.cooling_down = false;
-        self._timer = None;
+        // Cancel existing timer explicitly
+        if let Some(t) = self._timer.take() {
+            t.cancel();
+        }
         if let Some(pending) = self.pending.take() {
             self.target.do_send(pending).ok();
             self.cooling_down = true;


### PR DESCRIPTION
## Summary

- Debounce and Throttle previously cancelled timers by dropping the `TimerHandle` via `self.timer.take();`. The cancellation worked only because `impl Drop for TimerHandle` stores `cancelled = true` on drop — this was implicit and fragile to future refactoring.
- Switches to the explicit `TimerHandle::cancel()` method (already defined on the type) so the intent is obvious at the call site.

Closes #208.

## Test plan

- [x] `cargo check -p willow-actor`
- [x] All 8 debounce/throttle tests pass (`debounce_single_message`, `debounce_rapid_messages`, `debounce_timer_reset`, `debounce_separate_bursts`, `throttle_immediate_first`, `throttle_rate_limited`, `throttle_pending_forwarded`, `throttle_only_latest_pending`).

https://claude.ai/code/session_01SMAPhyr9u7x4HNvKfmmGdX

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMAPhyr9u7x4HNvKfmmGdX)_