### PR TITLE
[#192] trim whitespace from resolved display names

### DIFF
--- a/crates/client/src/views.rs
+++ b/crates/client/src/views.rs
@@ -685,13 +685,13 @@ pub fn resolve_display_name(
     if let Some(profile) = event_state.profiles.get(peer_id) {
         let name = profile.display_name.trim();
         if !name.is_empty() {
-            return profile.display_name.clone();
+            return name.to_string();
         }
     }
     if let Some(name) = profiles.names.get(peer_id) {
         let trimmed = name.trim();
         if !trimmed.is_empty() {
-            return name.clone();
+            return trimmed.to_string();
         }
     }
     "unknown peer".to_string()
@@ -1087,6 +1087,31 @@ mod tests {
             view.messages[0].author_display_name, "unknown peer",
             "resolve_display_name must fall back to `unknown peer` when no profile is known"
         );
+    }
+
+    #[test]
+    fn resolve_display_name_trims_whitespace_from_profile_and_fallback() {
+        // A malicious peer can set a display name padded with whitespace
+        // (leading/trailing spaces, tabs, newlines). `resolve_display_name`
+        // must return the trimmed value so the UI cannot be visually
+        // spoofed with padded names that pass the emptiness check.
+        let owner = Identity::generate().endpoint_id();
+        let mallory = Identity::generate().endpoint_id();
+        let ghost = Identity::generate().endpoint_id();
+        let mut state = fresh_state(owner);
+        state.profiles.insert(
+            mallory,
+            Profile {
+                peer_id: mallory,
+                display_name: "  \t  Alice  \n  ".into(),
+            },
+        );
+
+        let mut profiles = ProfileState::default();
+        profiles.names.insert(ghost, "   Ghost\t".into());
+
+        assert_eq!(resolve_display_name(&state, &profiles, &mallory), "Alice");
+        assert_eq!(resolve_display_name(&state, &profiles, &ghost), "Ghost");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #192.

## Summary

- `resolve_display_name` checked emptiness on the trimmed value but returned the original untrimmed string from both branches, letting a peer propagate padded names like `"  \t  Alice  \n  "` into the UI (visually blank rows, disrupted layout, attribution spoofing).
- Return the trimmed value from both the server-profile path and the `ProfileState.names` fallback.
- Added a regression test exercising both branches with whitespace-padded inputs.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p willow-client` (135 passed, including the new `resolve_display_name_trims_whitespace_from_profile_and_fallback`)

https://claude.ai/code/session_01Afa7wVTmrPsqyvaSJxRnCW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Afa7wVTmrPsqyvaSJxRnCW)_