### PR TITLE
fix(agent): don't print bearer token to stderr

### DIFF
--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -151,7 +151,6 @@ async fn main() -> anyhow::Result<()> {
             server::serve_stdio(client).await?;
         }
         "http" => {
-            eprintln!("Bearer token: {token}");
             tracing::info!("starting MCP HTTP server on {}", cli.bind);
             server::serve_http(client, &cli.bind, Default::default(), token).await?;
         }


### PR DESCRIPTION
Removes the `eprintln!("Bearer token: {token}")` line in `crates/agent/src/main.rs` so the HTTP transport no longer leaks the MCP bearer token to stderr/logs.

Closes #228

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2qhqzCpeTdESRbEsEd71R)_