### PR TITLE
fix(web): a11y improvements — ConfirmDialog roles, input labels, pinch-zoom

### DIFF
--- a/crates/web/index.html
+++ b/crates/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="dark">
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="theme-color" content="#1a1a1e">

--- a/crates/web/src/components/channel_sidebar.rs
+++ b/crates/web/src/components/channel_sidebar.rs
@@ -323,6 +323,7 @@ pub fn ChannelSidebar(
                                             type="text"
                                             class="tree-slot__input"
                                             node_ref=name_input_ref
+                                            aria-label="Rename channel"
                                             placeholder="tree name"
                                             prop:value=move || new_name.get()
                                             on:input=move |ev| set_new_name.set(event_target_value(&ev))

--- a/crates/web/src/components/command_palette.rs
+++ b/crates/web/src/components/command_palette.rs
@@ -606,7 +606,7 @@ pub fn CommandPalette(
                     class="palette-input"
                     type="text"
                     placeholder="jump or search…"
-                    aria-label="command palette input"
+                    aria-label="Search commands"
                     aria-autocomplete="list"
                     aria-controls="palette-listbox"
                     aria-activedescendant=move || active_row_id.get()

--- a/crates/web/src/components/confirm_dialog.rs
+++ b/crates/web/src/components/confirm_dialog.rs
@@ -1,4 +1,5 @@
 use leptos::prelude::*;
+use wasm_bindgen::JsCast;
 
 /// Reusable modal confirmation dialog with Cancel / Confirm buttons.
 ///
@@ -35,6 +36,25 @@ pub fn ConfirmDialog(
         "btn btn-primary"
     };
 
+    let confirm_button_ref = NodeRef::<leptos::html::Button>::new();
+    let cancel_button_ref = NodeRef::<leptos::html::Button>::new();
+
+    // Auto-focus the confirm button when the dialog becomes visible so
+    // keyboard users are pulled into the modal and Escape/Tab work as
+    // expected per WAI-ARIA APG.
+    Effect::new(move |prev: Option<bool>| {
+        let is_visible = visible.get();
+        let was_visible = prev.unwrap_or(false);
+        if is_visible && !was_visible {
+            leptos::prelude::request_animation_frame(move || {
+                if let Some(el) = confirm_button_ref.get_untracked() {
+                    let _ = el.focus();
+                }
+            });
+        }
+        is_visible
+    });
+
     view! {
         {move || {
             if !visible.get() {
@@ -47,21 +67,59 @@ pub fn ConfirmDialog(
             Some(view! {
                 <div
                     class="confirm-overlay"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="confirm-dialog-title"
                     on:keydown=move |ev: web_sys::KeyboardEvent| {
                         if ev.key() == "Escape" {
                             on_cancel.run(());
+                            return;
+                        }
+                        if ev.key() == "Tab" {
+                            // Simple focus trap: wrap between confirm and
+                            // cancel buttons so focus stays inside the
+                            // dialog while it is open.
+                            let target = ev.target().and_then(|t| t.dyn_into::<web_sys::Element>().ok());
+                            let Some(target_el) = target else { return; };
+                            if ev.shift_key() {
+                                if let Some(cancel_el) = cancel_button_ref.get_untracked() {
+                                    let cancel_node: &web_sys::Element = &cancel_el;
+                                    if cancel_node.is_same_node(Some(&target_el)) {
+                                        if let Some(confirm_el) = confirm_button_ref.get_untracked() {
+                                            ev.prevent_default();
+                                            let _ = confirm_el.focus();
+                                        }
+                                    }
+                                }
+                            } else if let Some(confirm_el) = confirm_button_ref.get_untracked() {
+                                let confirm_node: &web_sys::Element = &confirm_el;
+                                if confirm_node.is_same_node(Some(&target_el)) {
+                                    if let Some(cancel_el) = cancel_button_ref.get_untracked() {
+                                        ev.prevent_default();
+                                        let _ = cancel_el.focus();
+                                    }
+                                }
+                            }
                         }
                     }
                     tabindex="-1"
                 >
                     <div class="confirm-dialog">
-                        <h3>{title}</h3>
+                        <h3 id="confirm-dialog-title">{title}</h3>
                         <p>{msg}</p>
                         <div class="confirm-actions">
-                            <button class="btn btn-secondary" on:click=move |_| on_cancel.run(())>
+                            <button
+                                class="btn btn-secondary"
+                                node_ref=cancel_button_ref
+                                on:click=move |_| on_cancel.run(())
+                            >
                                 {cancel_text}
                             </button>
-                            <button class=confirm_class on:click=move |_| on_confirm.run(())>
+                            <button
+                                class=confirm_class
+                                node_ref=confirm_button_ref
+                                on:click=move |_| on_confirm.run(())
+                            >
                                 {confirm_text}
                             </button>
                         </div>

--- a/crates/web/src/components/welcome.rs
+++ b/crates/web/src/components/welcome.rs
@@ -44,6 +44,7 @@ pub fn WelcomeScreen(on_done: impl Fn(()) + Send + Clone + 'static) -> impl Into
                                 class="welcome-name-input"
                                 type="text"
                                 autofocus
+                                aria-label="Your display name"
                                 placeholder="enter your name (optional)"
                                 prop:value=move || display_name.get()
                                 on:input=move |ev| set_display_name.set(event_target_value(&ev))


### PR DESCRIPTION
Closes #266
Closes #267
Closes #273

## Summary
- **#266 (GEN-04)**: Removed `maximum-scale=1.0, user-scalable=no` from the viewport meta so users can pinch-zoom on mobile.
- **#267 (GEN-06)**: Added `aria-label` to the welcome display-name input, channel rename input, and command-palette search input.
- **#273 (GEN-14)**: Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby` to `ConfirmDialog`; auto-focus the confirm button when the dialog opens; added a simple Tab/Shift-Tab focus trap between the confirm and cancel buttons.

## Test plan
- [ ] `cargo check -p willow-web` (native) passes locally
- [ ] `cargo fmt --check` clean
- [ ] `cargo clippy -p willow-web -- -D warnings` clean
- [ ] Manual: pinch-zoom works on mobile viewport
- [ ] Manual: screen reader announces "Your display name" / "Rename channel" / "Search commands"
- [ ] Manual: opening ConfirmDialog moves focus to confirm button; Tab cycles between buttons


---
_Generated by [Claude Code](https://claude.ai/code/session_01N2qhqzCpeTdESRbEsEd71R)_