### PR TITLE
fix(client): enforce CreateInvite check, use signer for JoinRequest, correct genesis_author

### DIFF
--- a/crates/client/src/joining.rs
+++ b/crates/client/src/joining.rs
@@ -5,6 +5,18 @@ impl<N: willow_network::Network> ClientHandle<N> {
         &self,
         recipient_peer_id: &willow_identity::EndpointId,
     ) -> anyhow::Result<String> {
+        // Enforce the CreateInvite permission up front so non-authorised
+        // peers cannot mint invites, matching the guard used by
+        // `create_join_link` (see issue #225 / SEC-A-02).
+        let pid = self.identity.endpoint_id();
+        let has_perm = willow_actor::state::select(&self.event_state_addr, move |es| {
+            es.has_permission(&pid, &willow_state::Permission::CreateInvite)
+        })
+        .await;
+        if !has_perm {
+            anyhow::bail!("missing CreateInvite permission");
+        }
+
         let pub_key = invite::endpoint_id_to_ed25519_public(recipient_peer_id);
 
         // Gather server info from registry.
@@ -35,10 +47,15 @@ impl<N: willow_network::Network> ClientHandle<N> {
             })
             .await;
 
-        // Get genesis author (first admin) from event_state.
+        // Use the authoritative `state.genesis_author` recorded at server
+        // creation rather than picking an arbitrary admin. Picking from
+        // `admins.iter().next()` is non-deterministic and wrong whenever
+        // additional admins have been promoted (see issue #241 / SEC-A-08).
+        // Fall back to the local peer id only for legacy states that were
+        // serialized before `genesis_author` existed.
         let my_id = self.identity.endpoint_id();
         let genesis_author = willow_actor::state::select(&self.event_state_addr, move |es| {
-            es.admins.iter().next().copied().unwrap_or(my_id)
+            es.genesis_author.unwrap_or(my_id)
         })
         .await;
 
@@ -318,5 +335,131 @@ impl<N: willow_network::Network> ClientHandle<N> {
                 .collect()
         })
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for the client-side auth guards on invite generation.
+    //!
+    //! These cover the fixes for SEC-A-02 (#225) and SEC-A-08 (#241):
+    //!   * `generate_invite` must refuse to run when the caller lacks the
+    //!     `CreateInvite` permission.
+    //!   * `generate_invite` must record the real `genesis_author` in the
+    //!     invite payload rather than an arbitrary admin.
+    use crate::test_client;
+    use willow_state::Permission;
+
+    /// #225 — callers without `CreateInvite` must be rejected.
+    ///
+    /// The owner of a server implicitly holds every permission, so we
+    /// first strip that status by overwriting `event_state.admins` and
+    /// `event_state.genesis_author` with an identity we do not control.
+    /// After that, the test client is a plain member and should not be
+    /// able to mint invites.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn generate_invite_requires_create_invite_permission() {
+        let (client, _rx) = test_client();
+
+        // Install a foreign genesis_author and admin set so the local
+        // identity no longer owns the server. Without this the caller is
+        // the implicit owner and `has_permission` always returns true.
+        let stranger = willow_identity::Identity::generate().endpoint_id();
+        willow_actor::state::mutate(&client.event_state_addr, move |es| {
+            es.genesis_author = Some(stranger);
+            es.admins.clear();
+            es.admins.insert(stranger);
+            es.peer_permissions.clear();
+        })
+        .await;
+
+        // Sanity check: the local peer really lacks CreateInvite now.
+        let local_pid = client.identity.endpoint_id();
+        let has_perm = willow_actor::state::select(&client.event_state_addr, move |es| {
+            es.has_permission(&local_pid, &Permission::CreateInvite)
+        })
+        .await;
+        assert!(
+            !has_perm,
+            "test setup failed: local peer should not hold CreateInvite"
+        );
+
+        // A synthetic recipient for whom we would generate the invite.
+        let bob = willow_identity::Identity::generate().endpoint_id();
+        let err = client
+            .generate_invite(&bob)
+            .await
+            .expect_err("generate_invite must refuse without CreateInvite");
+        assert!(
+            err.to_string().contains("CreateInvite"),
+            "error should name the missing permission, got: {err}"
+        );
+    }
+
+    /// #241 — the invite's `genesis_author` must be the authoritative
+    /// server owner recorded in state, not an arbitrarily-ordered admin.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn generate_invite_uses_state_genesis_author() {
+        let (client, _rx) = test_client();
+
+        // The local identity is the real genesis author on the test
+        // server. Promote a *second* peer to admin; then scramble the
+        // admin set so that `admins.iter().next()` would pick that peer
+        // rather than the real owner. A correct implementation reads
+        // `state.genesis_author` and so is unaffected by this ordering.
+        let owner_id = client.identity.endpoint_id();
+        let other_admin = willow_identity::Identity::generate().endpoint_id();
+        let fake_admin = willow_identity::Identity::generate().endpoint_id();
+        willow_actor::state::mutate(&client.event_state_addr, move |es| {
+            // Keep the real genesis_author untouched.
+            es.admins.clear();
+            // Insert admins such that `iter().next()` (BTreeSet
+            // ordering by EndpointId) returns a non-owner. We insert
+            // both; whichever sorts first will be picked by the buggy
+            // code path — neither is the real owner.
+            es.admins.insert(other_admin);
+            es.admins.insert(fake_admin);
+            // Grant the local peer the CreateInvite permission
+            // explicitly since they are no longer an admin by membership.
+            es.peer_permissions
+                .entry(owner_id)
+                .or_default()
+                .insert(Permission::CreateInvite);
+        })
+        .await;
+
+        // Confirm the buggy `admins.iter().next()` would have produced
+        // a non-owner — otherwise the test wouldn't actually catch #241.
+        let (would_be_wrong, real_owner) =
+            willow_actor::state::select(&client.event_state_addr, |es| {
+                (es.admins.iter().next().copied(), es.genesis_author)
+            })
+            .await;
+        assert_ne!(
+            would_be_wrong, real_owner,
+            "test setup failed: admins.iter().next() must differ from genesis_author",
+        );
+
+        let bob = willow_identity::Identity::generate().endpoint_id();
+        let code = client
+            .generate_invite(&bob)
+            .await
+            .expect("owner with CreateInvite must mint invites");
+
+        // Decode the invite and verify the embedded genesis_author is
+        // the real one, not the first-by-iteration admin.
+        let raw = crate::base64::decode(&code).expect("invite must base64-decode");
+        let payload: crate::invite::InvitePayload =
+            willow_transport::unpack(&raw).expect("invite must deserialize");
+        assert_eq!(
+            payload.genesis_author,
+            real_owner.expect("real_owner must be set"),
+            "invite must carry state.genesis_author, not admins.iter().next()"
+        );
+        assert_ne!(
+            Some(payload.genesis_author),
+            would_be_wrong,
+            "invite must not carry the arbitrary admin picked by ordering"
+        );
     }
 }

--- a/crates/client/src/listeners.rs
+++ b/crates/client/src/listeners.rs
@@ -376,6 +376,22 @@ async fn process_received_message<T: TopicHandle>(
             }
         }
         crate::ops::WireMessage::JoinRequest { link_id, peer_id } => {
+            // Security: the wire-supplied `peer_id` is attacker-controlled
+            // and must never be trusted as a grant target. The only
+            // authenticated peer identity we have is `signer`, which was
+            // verified against the envelope's Ed25519 signature by
+            // `unpack_wire`. Reject any request where the two disagree,
+            // matching the ProfileAnnounce spoof guard above. See issue
+            // #239 / SEC-A-03.
+            if peer_id != signer {
+                tracing::warn!(
+                    %peer_id,
+                    %signer,
+                    "rejecting JoinRequest: wire-supplied peer_id does not match verified signer"
+                );
+                return;
+            }
+            let _ = peer_id; // the verified `signer` is the grant target below
             let should_respond = {
                 let mut links = ctx.join_links.lock();
                 let valid = links
@@ -392,7 +408,9 @@ async fn process_received_message<T: TopicHandle>(
                 // Generate invite for the requesting peer using event_state + registry.
                 let server_registry = ctx.server_registry.clone();
                 let event_state = ctx.event_state.clone();
-                let peer_endpoint = peer_id;
+                // Use the verified signer as the grant target — never the
+                // attacker-supplied `peer_id` from the wire message.
+                let peer_endpoint = signer;
 
                 // Get server info from registry.
                 let reg_info = willow_actor::state::select(&server_registry, move |reg| {
@@ -420,7 +438,10 @@ async fn process_received_message<T: TopicHandle>(
                                     (topic, ch.name.clone())
                                 })
                                 .collect();
-                            let author = es.admins.iter().next().copied().unwrap_or(fallback_id);
+                            // Same correctness fix as in `generate_invite`
+                            // (issue #241): pick the authoritative genesis
+                            // author rather than an arbitrary admin.
+                            let author = es.genesis_author.unwrap_or(fallback_id);
                             (names, author)
                         })
                         .await;
@@ -439,7 +460,7 @@ async fn process_received_message<T: TopicHandle>(
                 };
                 if let Some(invite_data) = invite_result {
                     let msg = crate::ops::WireMessage::JoinResponse {
-                        target_peer: peer_id,
+                        target_peer: peer_endpoint,
                         invite_data,
                     };
                     if let Some(data) = crate::ops::pack_wire(&msg, &ctx.identity) {
@@ -452,7 +473,9 @@ async fn process_received_message<T: TopicHandle>(
                     // so all peers (including the new joiner) learn that
                     // the new member has send permission.
                     let identity = ctx.identity.clone();
-                    let granted_peer = peer_id;
+                    // Grant permission to the authenticated signer — never
+                    // the wire-supplied peer_id (issue #239 / SEC-A-03).
+                    let granted_peer = peer_endpoint;
                     let ts = crate::util::current_time_ms();
                     let grant_event = willow_actor::state::mutate(&ctx.dag, move |ds| {
                         ds.managed
@@ -538,5 +561,184 @@ async fn process_received_message<T: TopicHandle>(
         // Worker messages travel on the _willow_workers topic and are never
         // delivered to the client's server-ops listener.
         crate::ops::WireMessage::Worker(_) => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Listener tests for the JoinRequest signer guard (SEC-A-03 / #239).
+    use super::*;
+    use crate::test_client;
+    use std::sync::Arc;
+    use willow_network::Network;
+
+    /// A `JoinRequest` whose wire-supplied `peer_id` disagrees with the
+    /// Ed25519 `signer` must be rejected. Concretely: no `GrantPermission`
+    /// event should be emitted for either identity, and no `JoinResponse`
+    /// should be broadcast.
+    ///
+    /// Without the fix, the listener trusts `peer_id` from the wire and
+    /// hands the authoritative invite + `SendMessages` grant to whichever
+    /// identity the attacker names — even though the packet was signed by
+    /// someone else entirely.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn join_request_with_mismatched_peer_id_is_rejected() {
+        let (client, _rx) = test_client();
+
+        // Inject a join link so the listener would otherwise be willing
+        // to respond. Expires far in the future.
+        let link_id = "test-link-id".to_string();
+        {
+            let mut links = client.join_links.lock();
+            links.push(crate::ops::JoinLink {
+                link_id: link_id.clone(),
+                server_id: "unused".into(),
+                max_uses: 10,
+                used: 0,
+                active: true,
+                expires_at: None,
+                created_at: 0,
+            });
+        }
+
+        // Construct a MemNetwork + topic handle to satisfy the
+        // TopicHandle generic expected by process_received_message.
+        let hub = willow_network::mem::MemHub::new();
+        let net = willow_network::mem::MemNetwork::new(&hub);
+        let (topic_handle, _events) = net
+            .subscribe(willow_network::topic_id("unit-test-topic"), vec![])
+            .await
+            .expect("subscribe must succeed in test");
+
+        // Build a ListenerCtx from the ClientHandle.
+        let ctx = ListenerCtx {
+            event_state: client.event_state_addr.clone(),
+            chat_meta: client.chat_meta_addr.clone(),
+            profiles: client.profile_state_addr.clone(),
+            network: client.network_meta_addr.clone(),
+            voice: client.voice_state_addr.clone(),
+            persistence: client.persistence_addr.clone(),
+            persistence_enabled: false,
+            event_broker: client.event_broker.clone(),
+            identity: client.identity.clone(),
+            join_links: Arc::clone(&client.join_links),
+            dag: client.dag_addr.clone(),
+            server_registry: client.server_registry_addr.clone(),
+            on_neighbor_up: None,
+        };
+
+        // Mallory signs the packet, but claims it's from Bob. Neither
+        // identity is the inviter/client.
+        let mallory = willow_identity::Identity::generate();
+        let bob_id = willow_identity::Identity::generate().endpoint_id();
+        let msg = crate::ops::WireMessage::JoinRequest {
+            link_id: link_id.clone(),
+            peer_id: bob_id,
+        };
+        let bytes = crate::ops::pack_wire(&msg, &mallory).expect("pack_wire must succeed");
+
+        let sender = mallory.endpoint_id();
+        process_received_message(&bytes, sender, &ctx, &topic_handle).await;
+
+        // Give any actor tasks a moment to settle.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Neither Bob (the attacker-named target) nor Mallory (the real
+        // signer) should have been granted SendMessages — the listener
+        // must drop the packet entirely on signer/peer_id mismatch.
+        let mallory_id = mallory.endpoint_id();
+        let (bob_has, mallory_has) =
+            willow_actor::state::select(&client.event_state_addr, move |es| {
+                (
+                    es.has_permission(&bob_id, &willow_state::Permission::SendMessages),
+                    es.has_permission(&mallory_id, &willow_state::Permission::SendMessages),
+                )
+            })
+            .await;
+        assert!(
+            !bob_has,
+            "spoofed peer_id must not receive SendMessages grant"
+        );
+        assert!(
+            !mallory_has,
+            "signer must not receive SendMessages grant when peer_id mismatches"
+        );
+
+        // The join link's `used` counter must not have been incremented
+        // since the request was rejected before the link was consumed.
+        let used = {
+            let links = client.join_links.lock();
+            links
+                .iter()
+                .find(|l| l.link_id == link_id)
+                .map(|l| l.used)
+                .expect("link must still be present")
+        };
+        assert_eq!(used, 0, "rejected requests must not consume the join link");
+    }
+
+    /// When signer and wire peer_id agree, the listener grants
+    /// SendMessages to that verified peer. This is the positive
+    /// counterpart of the mismatch test above.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn join_request_with_matching_signer_grants_send_messages() {
+        let (client, _rx) = test_client();
+
+        let link_id = "match-link".to_string();
+        {
+            let mut links = client.join_links.lock();
+            links.push(crate::ops::JoinLink {
+                link_id: link_id.clone(),
+                server_id: "unused".into(),
+                max_uses: 10,
+                used: 0,
+                active: true,
+                expires_at: None,
+                created_at: 0,
+            });
+        }
+
+        let hub = willow_network::mem::MemHub::new();
+        let net = willow_network::mem::MemNetwork::new(&hub);
+        let (topic_handle, _events) = net
+            .subscribe(willow_network::topic_id("unit-test-topic-2"), vec![])
+            .await
+            .expect("subscribe must succeed");
+
+        let ctx = ListenerCtx {
+            event_state: client.event_state_addr.clone(),
+            chat_meta: client.chat_meta_addr.clone(),
+            profiles: client.profile_state_addr.clone(),
+            network: client.network_meta_addr.clone(),
+            voice: client.voice_state_addr.clone(),
+            persistence: client.persistence_addr.clone(),
+            persistence_enabled: false,
+            event_broker: client.event_broker.clone(),
+            identity: client.identity.clone(),
+            join_links: Arc::clone(&client.join_links),
+            dag: client.dag_addr.clone(),
+            server_registry: client.server_registry_addr.clone(),
+            on_neighbor_up: None,
+        };
+
+        let bob = willow_identity::Identity::generate();
+        let bob_id = bob.endpoint_id();
+        let msg = crate::ops::WireMessage::JoinRequest {
+            link_id: link_id.clone(),
+            peer_id: bob_id,
+        };
+        let bytes = crate::ops::pack_wire(&msg, &bob).expect("pack_wire must succeed");
+
+        process_received_message(&bytes, bob_id, &ctx, &topic_handle).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let bob_has = willow_actor::state::select(&client.event_state_addr, move |es| {
+            es.has_permission(&bob_id, &willow_state::Permission::SendMessages)
+        })
+        .await;
+        assert!(
+            bob_has,
+            "verified signer must be granted SendMessages via join link"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Three related client-side auth/signer findings from the recent audit, fixed together in `crates/client/`:

- Closes #225 (SEC-A-02) — `generate_invite` now rejects callers who lack `CreateInvite`, matching the existing guard on `create_join_link`.
- Closes #239 (SEC-A-03, JoinRequest portion) — the `JoinRequest` listener now drops packets whose wire-supplied `peer_id` disagrees with the verified Ed25519 `signer`, and always uses `signer` as the grant target / JoinResponse recipient. Attackers can no longer redirect the invite + `SendMessages` grant at an arbitrary identity.
- Closes #241 (SEC-A-08) — both `generate_invite` and the `JoinRequest` handler now read `state.genesis_author` instead of `admins.iter().next()`, so the invite carries the authoritative owner rather than a non-deterministic admin pick.

## Changes

- `crates/client/src/joining.rs` — `generate_invite`: added `CreateInvite` check up front; switched `genesis_author` to `es.genesis_author.unwrap_or(my_id)`.
- `crates/client/src/listeners.rs` — `JoinRequest` handler: drop on `peer_id != signer`; use `signer` as the grant target and as `JoinResponse.target_peer`; same `genesis_author` correction as above.

## Tests

Four new inline unit tests (all green locally):

- `joining::tests::generate_invite_requires_create_invite_permission` — non-admin caller gets an error naming `CreateInvite`.
- `joining::tests::generate_invite_uses_state_genesis_author` — sets up state where `admins.iter().next() != genesis_author`, then decodes the invite payload and asserts the real owner is carried.
- `listeners::tests::join_request_with_mismatched_peer_id_is_rejected` — Mallory-signed packet naming Bob yields no grant for either identity and does not consume the join link.
- `listeners::tests::join_request_with_matching_signer_grants_send_messages` — positive path still works.

## Test plan

- [x] `cargo check -p willow-client`
- [x] `cargo test -p willow-client` (139 passed)
- [x] `cargo clippy -p willow-client --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check -p willow-client --target wasm32-unknown-unknown`

https://claude.ai/code/session_01N2qhqzCpeTdESRbEsEd71R

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2qhqzCpeTdESRbEsEd71R)_