### PR TITLE
chore: enable superpowers and caveman plugins for project

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,17 @@
   "effortLevel": "high",
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
-    "code-simplifier@claude-plugins-official": true
+    "code-simplifier@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true,
+    "caveman@caveman": true
+  },
+  "extraKnownMarketplaces": {
+    "caveman": {
+      "source": {
+        "source": "github",
+        "repo": "JuliusBrussee/caveman"
+      },
+      "autoUpdate": false
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Enables the **superpowers** plugin (`@claude-plugins-official`) — provides brainstorming, TDD, systematic-debugging, writing-plans, executing-plans, code-review, **using-git-worktrees**, and other workflow skills.
- Enables the **caveman** plugin (`@caveman`) — terse-output modes plus `caveman-commit` / `caveman-review` helpers.
- Registers the caveman marketplace under `extraKnownMarketplaces` so teammates auto-resolve the source on first session (it lives outside `claude-plugins-official`).

The previously-enabled `frontend-design` and `code-simplifier` plugins are preserved.

## Test plan

- [ ] Open a fresh Claude Code session in this repo and confirm `superpowers:*` and `caveman:*` skills appear in the skill listing.
- [ ] Run `/caveman` and verify caveman mode toggles correctly.
- [ ] Trigger a superpowers skill (e.g. `superpowers:brainstorming`) and confirm it loads from the project plugin set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)