### PR TITLE
Add session start hook to invoke caveman skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,10 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/using-superpowers-session-start.sh\""
+          },
+          {
+            "type": "command",
+            "command": "echo '{\"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": \"Invoke the caveman skill before any other action in this session.\"}}'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Added a new command hook to the session start event that outputs context instructing the caveman skill to be invoked before any other action in the session.

## Key Changes
- Added a new command hook entry to the `SessionStart` event in `.claude/settings.json`
- The hook outputs JSON with `hookSpecificOutput` containing:
  - `hookEventName`: "SessionStart"
  - `additionalContext`: Instructions to invoke the caveman skill before any other session action

## Implementation Details
The new hook is appended to the existing `SessionStart` hooks array, ensuring it runs alongside the `using-superpowers-session-start.sh` script. The hook uses a simple `echo` command to output structured JSON that provides context about skill invocation priority for the session.

https://claude.ai/code/session_0164Tg6P1tpGqtVXK1Ferz58