### PR TITLE
Make vendored skills self-suppressing when plugins are enabled

### DIFF
--- a/.claude/hooks/caveman-session-start.sh
+++ b/.claude/hooks/caveman-session-start.sh
@@ -2,8 +2,10 @@
 # SessionStart hook — nudges Claude to invoke the caveman skill at the start
 # of every new/cleared/compacted session.
 #
-# Skips emission if the caveman plugin is already enabled at the user level
-# (so we don't double-prompt) or if WILLOW_SKIP_VENDORED_SKILLS=1.
+# The nudge is self-suppressing: if `caveman` is not in the available-skills
+# list (no plugin, no vendored copy), Claude is told to ignore the
+# instruction. If it is in the list, the source (plugin vs vendored) doesn't
+# matter — invoking the skill is idempotent.
 
 set -euo pipefail
 
@@ -18,20 +20,9 @@ if [ "${WILLOW_SKIP_VENDORED_SKILLS:-}" = "1" ]; then
     exit 0
 fi
 
-USER_SETTINGS="${HOME}/.claude/settings.json"
-if [ -f "$USER_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
-    if jq -e '
-        (.enabledPlugins // {})
-        | to_entries
-        | any(.[]; (.key | startswith("caveman@")) and .value == true)
-    ' "$USER_SETTINGS" >/dev/null 2>&1; then
-        exit 0
-    fi
-fi
-
 jq -n '{
   hookSpecificOutput: {
     hookEventName: "SessionStart",
-    additionalContext: "Invoke the caveman skill before any other action in this session."
+    additionalContext: "If a `caveman` skill appears in your available-skills list, invoke it before any other action in this session. If no such skill is available, ignore this instruction."
   }
 }'

--- a/.claude/hooks/caveman-session-start.sh
+++ b/.claude/hooks/caveman-session-start.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SessionStart hook — nudges Claude to invoke the caveman skill at the start
+# of every new/cleared/compacted session.
+#
+# Skips emission if the caveman plugin is already enabled at the user level
+# (so we don't double-prompt) or if WILLOW_SKIP_VENDORED_SKILLS=1.
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+SKILL_DIR="${PROJECT_DIR}/.claude/skills/caveman"
+
+if [ ! -d "$SKILL_DIR" ]; then
+    exit 0
+fi
+
+if [ "${WILLOW_SKIP_VENDORED_SKILLS:-}" = "1" ]; then
+    exit 0
+fi
+
+USER_SETTINGS="${HOME}/.claude/settings.json"
+if [ -f "$USER_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+    if jq -e '
+        (.enabledPlugins // {})
+        | to_entries
+        | any(.[]; (.key | startswith("caveman@")) and .value == true)
+    ' "$USER_SETTINGS" >/dev/null 2>&1; then
+        exit 0
+    fi
+fi
+
+jq -n '{
+  hookSpecificOutput: {
+    hookEventName: "SessionStart",
+    additionalContext: "Invoke the caveman skill before any other action in this session."
+  }
+}'

--- a/.claude/hooks/using-superpowers-session-start.sh
+++ b/.claude/hooks/using-superpowers-session-start.sh
@@ -14,6 +14,23 @@ if [ ! -f "$SKILL_PATH" ]; then
     exit 0
 fi
 
+# Skip vendored preload if user already has the plugin enabled at the user
+# level, or if they explicitly opt out via env var.
+if [ "${WILLOW_SKIP_VENDORED_SKILLS:-}" = "1" ]; then
+    exit 0
+fi
+
+USER_SETTINGS="${HOME}/.claude/settings.json"
+if [ -f "$USER_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
+    if jq -e '
+        (.enabledPlugins // {})
+        | to_entries
+        | any(.[]; (.key | startswith("superpowers@")) and .value == true)
+    ' "$USER_SETTINGS" >/dev/null 2>&1; then
+        exit 0
+    fi
+fi
+
 skill_content="$(cat "$SKILL_PATH")"
 
 context="$(printf '<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your '\''superpowers:using-superpowers'\'' skill - your introduction to using skills. For all other skills, use the '\''Skill'\'' tool:**\n\n%s\n</EXTREMELY_IMPORTANT>' "$skill_content")"

--- a/.claude/hooks/using-superpowers-session-start.sh
+++ b/.claude/hooks/using-superpowers-session-start.sh
@@ -4,6 +4,12 @@
 #
 # Vendored from github.com/obra/superpowers (hooks/session-start), simplified
 # for the Claude Code runtime only and pointed at the in-repo skill copy.
+#
+# The emitted block is self-suppressing: if `superpowers:using-superpowers`
+# already appears in the available-skills list (because the user has the
+# plugin enabled at the user/CLI level), Claude is instructed to treat the
+# block as a no-op. This avoids brittle config-path detection and works
+# across Claude Code, Copilot CLI, Gemini CLI, etc.
 
 set -euo pipefail
 
@@ -14,26 +20,15 @@ if [ ! -f "$SKILL_PATH" ]; then
     exit 0
 fi
 
-# Skip vendored preload if user already has the plugin enabled at the user
-# level, or if they explicitly opt out via env var.
 if [ "${WILLOW_SKIP_VENDORED_SKILLS:-}" = "1" ]; then
     exit 0
 fi
 
-USER_SETTINGS="${HOME}/.claude/settings.json"
-if [ -f "$USER_SETTINGS" ] && command -v jq >/dev/null 2>&1; then
-    if jq -e '
-        (.enabledPlugins // {})
-        | to_entries
-        | any(.[]; (.key | startswith("superpowers@")) and .value == true)
-    ' "$USER_SETTINGS" >/dev/null 2>&1; then
-        exit 0
-    fi
-fi
-
 skill_content="$(cat "$SKILL_PATH")"
 
-context="$(printf '<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your '\''superpowers:using-superpowers'\'' skill - your introduction to using skills. For all other skills, use the '\''Skill'\'' tool:**\n\n%s\n</EXTREMELY_IMPORTANT>' "$skill_content")"
+preamble="If \`superpowers:using-superpowers\` already appears in your available-skills list, treat this entire <EXTREMELY_IMPORTANT> block as a no-op — the plugin version is authoritative. Otherwise, the block below is the vendored fallback copy of that skill; treat it as primed meta-skill content."
+
+context="$(printf '%s\n\n<EXTREMELY_IMPORTANT>\nYou have superpowers.\n\n**Below is the full content of your '\''superpowers:using-superpowers'\'' skill - your introduction to using skills. For all other skills, use the '\''Skill'\'' tool:**\n\n%s\n</EXTREMELY_IMPORTANT>' "$preamble" "$skill_content")"
 
 jq -n --arg ctx "$context" '{
   hookSpecificOutput: {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -26,7 +26,7 @@
           },
           {
             "type": "command",
-            "command": "echo '{\"hookSpecificOutput\": {\"hookEventName\": \"SessionStart\", \"additionalContext\": \"Invoke the caveman skill before any other action in this session.\"}}'"
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/caveman-session-start.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
Refactored the session-start hooks to be self-suppressing when their corresponding plugins are already enabled, eliminating brittle configuration detection and improving compatibility across different Claude environments.

## Key Changes
- **New caveman hook**: Created `.claude/hooks/caveman-session-start.sh` that conditionally invokes the caveman skill only if it's available, with graceful fallback if the skill doesn't exist or if vendored skills are disabled
- **Enhanced superpowers hook**: Updated `.claude/hooks/using-superpowers-session-start.sh` to:
  - Add a preamble that instructs Claude to treat the block as a no-op if the plugin version is already available
  - Support the `WILLOW_SKIP_VENDORED_SKILLS` environment variable for explicit opt-out
  - Improve documentation explaining the self-suppressing behavior
- **Updated settings**: Migrated caveman hook from inline echo command to bash script invocation for consistency and maintainability

## Implementation Details
Both hooks now follow the same pattern:
1. Check if the skill directory/file exists (graceful degradation)
2. Respect the `WILLOW_SKIP_VENDORED_SKILLS` environment variable
3. Emit context that instructs Claude to ignore the vendored version if the plugin version is already in the available-skills list

This approach avoids fragile path detection and works consistently across Claude Code, Copilot CLI, Gemini CLI, and other environments where the plugin might be enabled at the user or CLI level.

https://claude.ai/code/session_01TaGkMfKXAFiUTHdBGPt46A