### PR TITLE
chore: add rust-toolchain.toml (closes #353)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Pin Rust toolchain to match CI (stable + rustfmt/clippy + wasm32 target).
Ensures contributors get a reproducible local environment matching CI.

Closes #353
Refs #300

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWdbBYuYhstPWaKYCaYAK4)_