### PR TITLE
chore: use workspace edition in 4 crates (closes #315)

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "willow-common"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 willow-state = { path = "../state" }

--- a/crates/replay/Cargo.toml
+++ b/crates/replay/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "willow-replay"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [[bin]]
 name = "willow-replay"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "willow-storage"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [[bin]]
 name = "willow-storage"

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "willow-worker"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 willow-actor = { path = "../actor" }


### PR DESCRIPTION
Replace hard-coded `edition = "2021"` with `edition.workspace = true` in `common`, `replay`, `storage`, and `worker` crates so edition is centrally managed via `[workspace.package]`.

Closes #315
Refs #300

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWdbBYuYhstPWaKYCaYAK4)_