### PR TITLE
chore(agent): drop unused willow-actor dep (closes #338)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5977,7 +5977,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "willow-actor",
  "willow-client",
  "willow-identity",
  "willow-network",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 willow-client = { path = "../client" }
 willow-identity = { path = "../identity" }
 willow-network = { path = "../network" }
-willow-actor = { path = "../actor" }
 willow-state = { path = "../state" }
 
 rmcp = { version = "1.3", features = ["server", "transport-io", "transport-streamable-http-server"] }


### PR DESCRIPTION
willow-agent declared willow-actor as a dependency but had zero references in src/. Drop the unused dep to keep the crate graph clean.

Closes #338
Refs #300

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWdbBYuYhstPWaKYCaYAK4)_