### PR TITLE
ci: run e2e on pushes to main and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,29 @@ jobs:
           restore-keys: wasm-
       - run: cargo check --target wasm32-unknown-unknown --workspace --exclude willow-relay --exclude willow-worker --exclude willow-replay --exclude willow-storage --exclude willow-agent
 
+  browser:
+    name: Browser tests (wasm-pack + Firefox)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: browser-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: browser-
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@787505cde8a44ea468a00478fe52baf23b15bccd # v2.9.4
+        with:
+          tool: wasm-pack
+      - run: wasm-pack test --headless --firefox crates/web
+
   audit:
     name: cargo-audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,22 @@ jobs:
             target
           key: clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: clippy-
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - id: clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tee /tmp/clippy.log
+      - name: Surface clippy failure
+        if: failure() && steps.clippy.conclusion == 'failure'
+        run: |
+          {
+            echo "## Clippy failed"
+            echo
+            echo '<details><summary>last 200 lines</summary>'
+            echo
+            echo '```'
+            tail -n 200 /tmp/clippy.log || echo "(no log captured)"
+            echo '```'
+            echo
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   test:
     name: Test
@@ -57,7 +72,22 @@ jobs:
             target
           key: test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: test-
-      - run: cargo test --workspace
+      - id: test
+        run: cargo test --workspace 2>&1 | tee /tmp/test.log
+      - name: Surface test failure
+        if: failure() && steps.test.conclusion == 'failure'
+        run: |
+          {
+            echo "## Tests failed"
+            echo
+            echo '<details><summary>last 300 lines</summary>'
+            echo
+            echo '```'
+            tail -n 300 /tmp/test.log || echo "(no log captured)"
+            echo '```'
+            echo
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   wasm:
     name: WASM Check
@@ -99,7 +129,22 @@ jobs:
         uses: taiki-e/install-action@787505cde8a44ea468a00478fe52baf23b15bccd # v2.9.4
         with:
           tool: wasm-pack
-      - run: wasm-pack test --headless --firefox crates/web
+      - id: browser
+        run: wasm-pack test --headless --firefox crates/web 2>&1 | tee /tmp/browser.log
+      - name: Surface browser-test failure
+        if: failure() && steps.browser.conclusion == 'failure'
+        run: |
+          {
+            echo "## Browser tests failed"
+            echo
+            echo '<details><summary>last 300 lines</summary>'
+            echo
+            echo '```'
+            tail -n 300 /tmp/browser.log || echo "(no log captured)"
+            echo '```'
+            echo
+            echo '</details>'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   audit:
     name: cargo-audit

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,4 +41,30 @@ jobs:
           tool: just
 
       - name: Run full E2E flow (setup + tests + teardown)
-        run: just test-e2e-full
+        id: e2e
+        run: just test-e2e-full 2>&1 | tee /tmp/e2e.log
+      - name: Surface E2E failure
+        if: failure() && steps.e2e.conclusion == 'failure'
+        run: |
+          {
+            echo "## Playwright E2E failed"
+            echo
+            echo '<details><summary>just / playwright output (last 300 lines)</summary>'
+            echo
+            echo '```'
+            tail -n 300 /tmp/e2e.log || echo "(no log captured)"
+            echo '```'
+            echo
+            echo '</details>'
+            for f in .dev/logs/relay.log .dev/logs/replay.log .dev/logs/storage.log .dev/logs/web.log; do
+              [ -f "$f" ] || continue
+              echo
+              echo "<details><summary>$f (last 100 lines)</summary>"
+              echo
+              echo '```'
+              tail -n 100 "$f"
+              echo '```'
+              echo
+              echo '</details>'
+            done
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,10 +1,11 @@
 name: E2E
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
-  schedule:
-    # Weekly smoke run — catches drift without gating PRs on a flaky suite.
-    - cron: '0 12 * * 1'
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,9 +15,6 @@ jobs:
     name: Playwright E2E
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Manual / scheduled only: the full stack run takes 15+ min and the
-    # multi-peer suite still has known flakes. Promote to `pull_request`
-    # once the suite is stable.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
The suite is stable enough now to gate PRs on. Drops the weekly cron
since per-PR runs subsume it; keeps workflow_dispatch for manual reruns.