### PR TITLE
perf(search): share Posting via Arc across token buckets (#346)

### DIFF
--- a/crates/client/src/search/execute.rs
+++ b/crates/client/src/search/execute.rs
@@ -6,6 +6,8 @@
 //! timestamp-desc order with matched byte-ranges ready for the
 //! highlight renderer.
 
+use std::sync::Arc;
+
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 
@@ -81,7 +83,7 @@ pub fn execute(index: &SearchIndex, query: &SearchQuery, scope: &SearchScope) ->
 /// Candidate set: posting-lists for every token + first-word of each
 /// phrase. Falls back to every posting when the query has no tokens
 /// (pure operator-only queries like `has:link`).
-fn candidate_postings(index: &SearchIndex, query: &SearchQuery) -> Vec<Posting> {
+fn candidate_postings(index: &SearchIndex, query: &SearchQuery) -> Vec<Arc<Posting>> {
     let mut lookup_tokens: Vec<String> = query.tokens.clone();
     for ph in &query.phrases {
         if let Some(first) = ph.split_whitespace().next() {
@@ -89,7 +91,7 @@ fn candidate_postings(index: &SearchIndex, query: &SearchQuery) -> Vec<Posting> 
         }
     }
 
-    let mut candidates: Vec<Posting> = Vec::new();
+    let mut candidates: Vec<Arc<Posting>> = Vec::new();
     for t in &lookup_tokens {
         if let Some(slice) = index.postings_for(t) {
             candidates.extend(slice.iter().cloned());

--- a/crates/client/src/search/index.rs
+++ b/crates/client/src/search/index.rs
@@ -12,6 +12,7 @@
 //! all.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use willow_identity::EndpointId;
 
@@ -91,11 +92,15 @@ impl From<IndexableMessage> for Posting {
 
 /// The inverted index itself. Not `Clone` — wrap it in an
 /// `Arc<Mutex<_>>` in the handle layer.
+///
+/// Postings are stored as `Arc<Posting>` so a single message that
+/// matches N tokens occupies one allocation plus N pointer-sized
+/// references — not N deep clones of every field.
 #[derive(Debug, Default)]
 pub struct SearchIndex {
     /// token -> ordered list of postings (insertion order; executor
     /// re-sorts by timestamp-desc).
-    pub(crate) postings: HashMap<String, Vec<Posting>>,
+    pub(crate) postings: HashMap<String, Vec<Arc<Posting>>>,
     /// `message_id -> tokens` so [`Self::remove_message`] can unthread
     /// every posting list the message sits in without a full walk.
     pub(crate) by_msg: HashMap<String, Vec<String>>,
@@ -131,13 +136,13 @@ impl SearchIndex {
         }
 
         let id = m.message_id.clone();
-        let posting: Posting = m.into();
+        let posting = Arc::new(Posting::from(m));
         let tokens: Vec<String> = token_set.into_iter().collect();
         for t in &tokens {
             self.postings
                 .entry(t.clone())
                 .or_default()
-                .push(posting.clone());
+                .push(Arc::clone(&posting));
         }
         self.by_msg.insert(id, tokens);
     }
@@ -189,16 +194,16 @@ impl SearchIndex {
 
     /// Read-only view of one token's postings (empty if absent). Used
     /// by [`super::execute::execute`].
-    pub fn postings_for(&self, token: &str) -> Option<&[Posting]> {
+    pub fn postings_for(&self, token: &str) -> Option<&[Arc<Posting>]> {
         self.postings.get(token).map(|v| v.as_slice())
     }
 
     /// Read-only iterator over every posting once (dedup by id).
     /// Used by [`super::execute::execute`] when the query has no tokens
     /// or phrases but still carries filters (e.g. `has:link` alone).
-    pub fn all_postings(&self) -> Vec<&Posting> {
+    pub fn all_postings(&self) -> Vec<&Arc<Posting>> {
         let mut seen: HashSet<&str> = HashSet::new();
-        let mut out: Vec<&Posting> = Vec::new();
+        let mut out: Vec<&Arc<Posting>> = Vec::new();
         for list in self.postings.values() {
             for p in list {
                 if seen.insert(p.message_id.as_str()) {

--- a/crates/client/src/search/tests.rs
+++ b/crates/client/src/search/tests.rs
@@ -700,6 +700,26 @@ mod index_tests {
         idx.insert(mk("m1", "hello world", 100, "general"));
         assert_eq!(idx.all_postings().len(), 1);
     }
+
+    #[test]
+    fn postings_share_one_allocation_across_tokens() {
+        // A message that lands under N tokens must reference one
+        // shared `Posting` allocation, not N deep clones. Pointer
+        // equality between the entries in two different token lists
+        // proves the `Arc` sharing — without it, every token would
+        // own its own deep copy of the message body + ids.
+        let mut idx = SearchIndex::new();
+        idx.insert(mk("m1", "hello world", 100, "general"));
+
+        let hello = idx.postings_for("hello").expect("hello bucket");
+        let world = idx.postings_for("world").expect("world bucket");
+        assert_eq!(hello.len(), 1);
+        assert_eq!(world.len(), 1);
+        assert!(
+            std::sync::Arc::ptr_eq(&hello[0], &world[0]),
+            "postings under different tokens must share one Arc allocation",
+        );
+    }
 }
 
 mod tokenize_tests {


### PR DESCRIPTION
## Summary

Fixes [#346](https://github.com/intendednull/willow/issues/346) — `SearchIndex::insert` was deep-cloning the entire `Posting` once per token. A 50-token message stored 50 copies of every field (body String, ids, author strings), so memory and allocation cost grew roughly quadratically with body length, amplifying full-rebuild cost.

- Wrap `Posting` in `Arc` inside the index: one allocation per message, pointer-sized clones per token bucket.
- `postings_for` / `all_postings` now return `&[Arc<Posting>]` / `Vec<&Arc<Posting>>`. `Posting` is module-private — no external consumers needed updating.
- Executor closures rely on `Arc<Posting>` deref coercion to `&Posting`, so filter/map bodies are unchanged beyond signatures.

## Test plan

- [x] `cargo test -p willow-client` — 269 tests pass, including the new `postings_share_one_allocation_across_tokens` (pointer-equality assertion across two token buckets pins the optimization).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo check --target wasm32-unknown-unknown -p willow-client` clean.
- [x] Verify smell `rg "or_default\(\)\.push\(posting\.clone" crates/client/src/search` returns no matches.

Note: a pre-existing flaky test in `willow-actor` (`ask_dead_actor_returns_closed`, `pool_worker_dies`) intermittently fails under workspace-parallel scheduling but passes when `-p willow-actor` is run alone. Unrelated to this change.

Closes #346.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1yC23eBg9AdFtx7dG1SFo)_