### PR TITLE
docs: drop willow-channel from README/CLAUDE.md + EventKind drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,7 +324,7 @@ events. The `willow-state` crate is pure — zero I/O, zero networking.
 
 - **Event**: carries unique ID, parent state hash, author PeerId,
   timestamp hint, and an `EventKind` mutation variant.
-- **EventKind**: 17 variants covering server structure, roles,
+- **EventKind**: variants covering server structure, roles,
   fine-grained permissions, chat, identity, and encryption.
 - **ServerState**: complete shared state derivable from event replay.
   Computes a `StateHash` (SHA-256) for divergence detection.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ accounts, no middlemen. End-to-end encrypted by default.
 | `willow-identity` | Ed25519 identity, message signing, profiles |
 | `willow-messaging` | Chat messages, HLC ordering, message store |
 | `willow-crypto` | E2E encryption (ChaCha20-Poly1305, X25519) |
-| `willow-channel` | Servers, channels, roles, permissions |
 | `willow-network` | iroh-based P2P networking (native + WASM) |
 | `willow-actor` | Lightweight actor framework (dual-target native + WASM) |
 | `willow-common` | Shared wire protocol types (WireMessage, worker types) |
@@ -86,7 +85,7 @@ event log *is* the data.
 - **`ServerState`** is the materialized view — rebuilt deterministically by
   topologically sorting all events and replaying them through `materialize()`.
   Peers converge to identical state when they have the same DAG.
-- **22 `EventKind` variants** cover server structure (create/delete/rename
+- **`EventKind` variants** cover server structure (create/delete/rename
   channels and roles), chat (messages, edits, deletes, reactions, pins),
   permissions (grant/revoke), identity (profiles), encryption (key rotation),
   and governance (proposals and votes).


### PR DESCRIPTION
- closes #255
- README.md:51 — drop `willow-channel` row (crate removed)
- README.md:89 — "22 EventKind variants" → non-numeric "EventKind variants"
- CLAUDE.md:327 — "17 variants" → non-numeric "variants"

before: README listed deleted `willow-channel` crate; both docs cited stale variant counts (17, 22) while actual is ~24.
after: removed crate row dropped; numeric counts replaced with prose so the docs do not drift again as variants are added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvXynFPgSaqWTBo65iMnD9)_