### PR TITLE
fix(worker): gate test_config() behind test-utils feature

### DIFF
--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -19,6 +19,9 @@ clap = { version = "4", features = ["derive"] }
 anyhow = { workspace = true }
 uuid = { workspace = true }
 
+[features]
+test-utils = []
+
 [dev-dependencies]
 willow-network = { path = "../network", features = ["test-utils"] }
 async-trait = { workspace = true }

--- a/crates/worker/src/config.rs
+++ b/crates/worker/src/config.rs
@@ -15,6 +15,7 @@ pub struct WorkerConfig {
     pub allocation: AllocationStrategy,
 }
 
+#[cfg(any(test, feature = "test-utils"))]
 impl WorkerConfig {
     /// Create a config for testing.
     pub fn test_config() -> Self {


### PR DESCRIPTION
## file:line
`crates/worker/src/config.rs:20` — `WorkerConfig::test_config()`

## fix sketch
- Wrap `impl WorkerConfig { test_config() }` with `#[cfg(any(test, feature = "test-utils"))]` (matches the convention from `crates/network/src/mem.rs`).
- Add `[features] test-utils = []` to `crates/worker/Cargo.toml`.
- Sole call site lives inside the same file's `#[cfg(test)] mod tests`, so no production callers needed updating.

## why (security)
`test_config()` was unconditionally `pub`, leaking the hardcoded `/tmp/test-worker.key` path string into any release binary that depends on `willow-worker`. Gating it removes the test scaffolding from non-test builds.

closes #331

## verification
- [x] `cargo check -p willow-worker` (default features)
- [x] `cargo check -p willow-worker --features test-utils`
- [x] `cargo test -p willow-worker --no-run`
- [x] `cargo fmt -p willow-worker`
- [x] `rg -n 'test_config\(\)' crates/` — only the def + the in-file `#[cfg(test)]` test

https://claude.ai/code/session_01KvXynFPgSaqWTBo65iMnD9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KvXynFPgSaqWTBo65iMnD9)_