### PR TITLE
fix: correct CLAUDE.md dep graph, spec drift (ARCH-01, ARCH-04, ARCH-10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ project/.obsidian/
 web/pkg/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.claude/worktrees/
 
 # Playwright
 node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,9 +335,8 @@ an event is created — rejected events never enter the DAG.
 ```
 willow-web → willow-client  → willow-state
                             → willow-network (iroh, iroh-gossip, iroh-blobs)
-           → willow-crypto  → willow-identity → willow-transport
-           → willow-messaging → willow-identity
-                              (defines SealedContent used by willow-crypto)
+           → willow-crypto  → willow-messaging → willow-identity → willow-transport
+                              (re-exports Content, SealedContent from willow-messaging)
 
 willow-replay  → willow-worker → willow-actor
 willow-storage → willow-worker → willow-actor

--- a/docs/specs/2026-04-12-state-authority-and-mutations.md
+++ b/docs/specs/2026-04-12-state-authority-and-mutations.md
@@ -76,7 +76,7 @@ cases where a remote event is rejected:
 | **Governance (vote)** | `Propose`, `Vote` | `is_admin()` — only admins may propose or vote. Actions auto-apply when vote threshold is met. |
 | **Admin-only** | `GrantPermission`, `RevokePermission`, `RenameServer`, `SetServerDescription` | `is_admin()` — any single admin can execute these directly. |
 | **Permission-gated** | `Message`, `EditMessage`, `DeleteMessage`, `Reaction` → `SendMessages`; `CreateChannel`, `DeleteChannel`, `RenameChannel`, `RotateChannelKey` → `ManageChannels`; `CreateRole`, `DeleteRole`, `SetPermission`, `AssignRole` → `ManageRoles` | `has_permission()` — admins pass implicitly; non-admins need an explicit grant. |
-| **Unrestricted** | `SetProfile`, `PinMessage`, `UnpinMessage` | No check — any member can execute. |
+| **Unrestricted** | `SetProfile`, `UpdateProfile`, `PinMessage`, `UnpinMessage`, `MuteChannel`, `MuteGrove` | No check — any member can execute. |
 | **Genesis** | `CreateServer` | No-op on replay; the genesis author becomes the sole initial admin. |
 
 Admin status is tracked in `ServerState.admins` and is **not** a variant
@@ -103,7 +103,9 @@ comment so reviewers notice when a new variant is missing:
 - `RenameServer`, `SetServerDescription` — admin-only, checked in the
   admin block
 - `SetProfile` — intentionally unrestricted
+- `UpdateProfile` — intentionally unrestricted (any member; self-authorship enforced structurally)
 - `PinMessage`, `UnpinMessage` — intentionally unrestricted
+- `MuteChannel`, `MuteGrove` — per-identity preference, never gated
 
 If a variant is not in this list and not in a `required_permission()`
 arm, it is a bug.

--- a/docs/specs/2026-04-13-test-architecture.md
+++ b/docs/specs/2026-04-13-test-architecture.md
@@ -1,7 +1,7 @@
 # Test Architecture Specification — Willow
 
 **Date**: 2026-04-13
-**Status**: Canonical
+**Status**: Superseded by [docs/specs/2026-04-21-e2e-test-architecture-design.md](2026-04-21-e2e-test-architecture-design.md)
 
 ---
 


### PR DESCRIPTION
Fix 3 doc/spec issues from audit.

**#333 ARCH-01** — CLAUDE.md dep graph show crypto→messaging. Reality reversed. Fix arrow.
**#335 ARCH-04** — state-authority spec missing UpdateProfile/MuteChannel/MuteGrove in unrestricted list. Add them.
**#339 ARCH-10** — older test-arch spec still claim Canonical. Mark Superseded.

Closes #333, closes #335, closes #339

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzWjHTaoQ8EJ64foWr3Zv4)_