### PR TITLE
fix: gate test_config behind cfg(test), guard profile keydown listener

### DIFF
--- a/crates/web/src/profile/controller.rs
+++ b/crates/web/src/profile/controller.rs
@@ -46,7 +46,7 @@ pub fn use_profile_controller() -> (
     let write = use_context::<crate::state::AppWriteSignals>().expect("AppWriteSignals in context");
     let read_sig = app_state.profile.open;
     let write_sig = write.profile.set_open;
-    install_listeners_once(write_sig);
+    install_listeners_once(read_sig, write_sig);
     (read_sig, write_sig)
 }
 
@@ -55,7 +55,10 @@ pub fn use_profile_controller() -> (
 /// Idempotent — the helper tags `<body data-profile-bus="mounted">`
 /// so repeat calls are no-ops. In practice the root `<App>` calls
 /// [`use_profile_controller`] once, which calls this helper once.
-fn install_listeners_once(set_open: WriteSignal<Option<ProfileState>>) {
+fn install_listeners_once(
+    open: ReadSignal<Option<ProfileState>>,
+    set_open: WriteSignal<Option<ProfileState>>,
+) {
     let Some(win) = web_sys::window() else { return };
     let body = match win.document().and_then(|d| d.body()) {
         Some(b) => b,
@@ -110,10 +113,10 @@ fn install_listeners_once(set_open: WriteSignal<Option<ProfileState>>) {
         .ok();
     on_close.forget();
 
-    // ESCAPE — close on Escape anywhere.
+    // ESCAPE — close on Escape, but only when a profile is actually open.
     let on_esc = Closure::<dyn FnMut(web_sys::Event)>::new(move |ev: web_sys::Event| {
         if let Ok(ke) = ev.dyn_into::<web_sys::KeyboardEvent>() {
-            if ke.key() == "Escape" {
+            if ke.key() == "Escape" && open.with(Option::is_some) {
                 set_open.set(None);
             }
         }

--- a/crates/worker/src/config.rs
+++ b/crates/worker/src/config.rs
@@ -17,6 +17,7 @@ pub struct WorkerConfig {
 
 impl WorkerConfig {
     /// Create a config for testing.
+    #[cfg(test)]
     pub fn test_config() -> Self {
         Self {
             identity_path: "/tmp/test-worker.key".to_string(),


### PR DESCRIPTION
Two small fixes from audit.

**#331 TD-13** — test_config() live in prod module. Gate with #[cfg(test)]. Test artifact not reachable from release builds.
**#347 GEN-04** — profile keydown listener fire Escape even when no profile open. Guard with is_some check. Prevents racing other Esc handlers.

Closes #331, closes #347

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzWjHTaoQ8EJ64foWr3Zv4)_