### PR TITLE
chore: drop stale dead_code allows + dead helper

### DIFF
--- a/crates/client/src/storage.rs
+++ b/crates/client/src/storage.rs
@@ -229,17 +229,6 @@ pub fn load_events(server_id: &str) -> Vec<willow_state::Event> {
 // Vec<Event> in memory. Removed as part of compat.rs deletion.
 // See SqliteDagStore above for the live DAG persistence path.
 
-/// Save a downloaded file to the downloads directory. Returns the path.
-#[cfg(not(target_arch = "wasm32"))]
-#[allow(dead_code)]
-pub fn save_download(filename: &str, data: &[u8]) -> Option<std::path::PathBuf> {
-    let dir = dirs::download_dir().unwrap_or_else(|| data_dir().join("downloads"));
-    std::fs::create_dir_all(&dir).ok();
-    let path = dir.join(filename);
-    std::fs::write(&path, data).ok()?;
-    Some(path)
-}
-
 // ---- Native implementation --------------------------------------------------
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/web/src/state.rs
+++ b/crates/web/src/state.rs
@@ -274,7 +274,6 @@ pub struct UiState {
     pub show_call_page: ReadSignal<bool>,
     pub show_palette: ReadSignal<bool>,
     pub call_layout: ReadSignal<CallLayout>,
-    #[allow(dead_code)]
     pub settings_tab: ReadSignal<SettingsTab>,
     pub join_token: ReadSignal<Option<ParsedJoinToken>>,
     /// "", "connecting", or "denied:<reason>".
@@ -287,7 +286,6 @@ pub struct VoiceState {
     pub voice_muted: ReadSignal<bool>,
     pub voice_deafened: ReadSignal<bool>,
     /// Participants per voice channel.
-    #[allow(dead_code)]
     pub voice_participants_map: ReadSignal<HashMap<String, Vec<String>>>,
     pub voice_channel_name: ReadSignal<String>,
     pub video_source: ReadSignal<Option<VideoSource>>,


### PR DESCRIPTION
## Why
Stale `#[allow(dead_code)]` from old in-flight work. Fields now read. Helper unused.

## Changes
- `web/state.rs`: drop allow on `settings_tab` (read in app.rs, written 4 places).
- `web/state.rs`: drop allow on `voice_participants_map` (read in event_processing.rs, app.rs, call_page.rs, channel_sidebar.rs).
- `client/storage.rs`: delete `save_download` fn (zero callers anywhere).

## Verify
`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo check --target wasm32-unknown-unknown` all clean.

Closes #196

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPZ84wqFzniQ1FL4mvztJS)_