### PR TITLE
test(agent): cover bearer token const-time compare

### DIFF
--- a/crates/agent/src/server.rs
+++ b/crates/agent/src/server.rs
@@ -287,4 +287,38 @@ mod tests {
         ));
         assert_eq!(info.server_info.name, "willow-agent");
     }
+
+    #[test]
+    fn tokens_eq_ct_accepts_correct_token() {
+        let token = "s3cret-bearer-token";
+        assert!(tokens_eq_ct(token.as_bytes(), token.as_bytes()));
+    }
+
+    #[test]
+    fn tokens_eq_ct_rejects_wrong_token_same_length() {
+        let expected = "s3cret-bearer-token";
+        let provided = "X3cret-bearer-token";
+        assert_eq!(provided.len(), expected.len());
+        assert!(!tokens_eq_ct(provided.as_bytes(), expected.as_bytes()));
+    }
+
+    #[test]
+    fn tokens_eq_ct_rejects_shorter_token() {
+        let expected = "s3cret-bearer-token";
+        let provided = "s3cret-bearer";
+        assert!(!tokens_eq_ct(provided.as_bytes(), expected.as_bytes()));
+    }
+
+    #[test]
+    fn tokens_eq_ct_rejects_longer_token() {
+        let expected = "s3cret-bearer-token";
+        let provided = "s3cret-bearer-token-extra";
+        assert!(!tokens_eq_ct(provided.as_bytes(), expected.as_bytes()));
+    }
+
+    #[test]
+    fn tokens_eq_ct_rejects_empty_against_nonempty() {
+        let expected = "s3cret-bearer-token";
+        assert!(!tokens_eq_ct(b"", expected.as_bytes()));
+    }
 }


### PR DESCRIPTION
## Why
Bearer compare already const-time (13c7dc6, audit/agent-sec). But no test lock behavior. Future refactor could revert silently. #304 still open.

## Fix
Add unit tests for `tokens_eq_ct`:
- right token pass
- wrong same-len reject
- short reject
- long reject
- empty reject

No timing assertion (test correctness, not const-time property).

## Verify
- `just check` clean (fmt, clippy, test, wasm). Zero warnings.
- All 5 new `tokens_eq_ct_*` tests pass.
- `subtle = "2"` already in `crates/agent/Cargo.toml`.

Closes #304

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPZ84wqFzniQ1FL4mvztJS)_