### PR TITLE
ci(deploy): pin trunk version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,9 @@ jobs:
           restore-keys: deploy-
 
       - name: Install trunk
-        run: cargo install trunk --locked
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.9.4 trunk
+        with:
+          tool: trunk@0.21.14
 
       - name: Install sshpass
         run: sudo apt-get update && sudo apt-get install -y sshpass


### PR DESCRIPTION
## Why

deploy step ran `cargo install trunk --locked`. no version. each deploy grab latest from crates.io. bad release ship to prod unattended. supply chain weak link (combine w/ #227 sshpass, worse).

## Fix

swap to `taiki-e/install-action` at pinned sha (`cf525cb33f51aca27cd6fa02034117ab963ff9f1` = v2.9.4). same pattern + same sha as `e2e.yml` use for `just`. now consistent across workflows. pin trunk to `0.21.14` (latest stable).

bonus: faster too — install-action grab prebuilt binary, no cargo compile.

## Verify

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` parses clean
- [x] diff = 3 lines, no unrelated change
- [ ] next deploy run on main install trunk 0.21.14 from action

Closes #319

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnwK1dP6rnrsbLxtg92zfF)_