### PR TITLE
ci(audit): ignore unmaintained transitive advisories (#316/#317/#318)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,4 +164,7 @@ jobs:
             --ignore RUSTSEC-2026-0099 `# rustls-webpki URI-constraint  (#223)` \
             --ignore RUSTSEC-2026-0104 `# rustls-webpki CRL panic       (#223)` \
             --ignore RUSTSEC-2026-0097 `# rand unsoundness              (#246)` \
-            --ignore RUSTSEC-2025-0141 `# bincode 1.x unmaintained      (#247)`
+            --ignore RUSTSEC-2025-0141 `# bincode 1.x unmaintained      (#247)` \
+            --ignore RUSTSEC-2024-0436 `# paste unmaintained, via leptos+iroh (#316)` \
+            --ignore RUSTSEC-2024-0370 `# proc-macro-error unmaintained, via iroh-blobs->genawaiter (#317)` \
+            --ignore RUSTSEC-2023-0089 `# atomic-polyfill unmaintained, via iroh->postcard->heapless (#318)`


### PR DESCRIPTION
## Why

Three RUSTSEC unmaintained advisories trip CI audit gate. All transitive, no path from our code:

- `RUSTSEC-2024-0436` — `paste 1.0.15` archived Oct 2024 (#316)
- `RUSTSEC-2024-0370` — `proc-macro-error 0.4.12` unmaintained, drags syn 1.x (#317)
- `RUSTSEC-2023-0089` — `atomic-polyfill 1.0.3` replaced by portable-atomic (#318)

Upstream chains:

```
paste 1.0.15
  - leptos 0.7.8 (tachys, leptos_dom, leptos_server, reactive_stores, either_of)
  - iroh 0.98.1 (netwatch -> netlink-packet-core)

proc-macro-error 0.4.12
  - iroh-blobs 0.100.0 -> bao-tree -> genawaiter -> genawaiter-proc-macro

atomic-polyfill 1.0.3
  - iroh 0.98.1 (postcard -> heapless), iroh-blobs, iroh-gossip, iroh-relay, irpc
```

No trivial single-dep bump fixes any of these — iroh + leptos ecosystems both pin upstreams that haven't migrated. Bumping iroh/leptos = deep risk, separate work.

## Fix

Add `--ignore RUSTSEC-XXXX-XXXX` to existing `cargo audit` step in `.github/workflows/ci.yml`. Matches existing style (inline `#` comment with tracking issue ref). Issues #316/#317/#318 stay open as tracking issues — not closed by this PR — until upstream fixes land or we bump iroh/leptos.

## Verify

Local before:

```
warning: 3 allowed warnings found
  paste            RUSTSEC-2024-0436
  proc-macro-error RUSTSEC-2024-0370
  atomic-polyfill  RUSTSEC-2023-0089
```

Local after (same flags as CI):

```
Scanning Cargo.lock for vulnerabilities (639 crate dependencies)
exit 0
```

Tradeoff: ignoring vs upgrading. Upgrading rejected — iroh/leptos pin transitives, blast radius too large for this scope. Tracking issues capture follow-up.

Refs #316
Refs #317
Refs #318

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnwK1dP6rnrsbLxtg92zfF)_