### PR TITLE
ci: pin trunk install in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,9 @@ jobs:
           restore-keys: deploy-
 
       - name: Install trunk
-        run: cargo install trunk --locked
+        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.9.4
+        with:
+          tool: trunk
 
       - name: Install sshpass
         run: sudo apt-get update && sudo apt-get install -y sshpass


### PR DESCRIPTION
## Why
deploy.yml `cargo install trunk --locked` no version pin. Each deploy pull latest trunk from crates.io. Bad release slip in -> prod WASM busted. Combine with #227 = supply chain risk.

## Fix
Swap to `taiki-e/install-action` at SHA `cf525cb33f51aca27cd6fa02034117ab963ff9f1` (v2.9.4). Same SHA e2e.yml use. Action fetch prebuilt trunk binary, faster + reproducible. Action self pinned by SHA, trunk version resolved by action -> bumps tracked one place.

Reject runner-up `cargo install trunk --version X.Y.Z --locked`: still rebuild from source every deploy, slower, no match e2e.yml pattern. Action route cleaner.

## Verify
- YAML parse: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` -> OK.
- Diff minimal: only `.github/workflows/deploy.yml`, 3 insert / 1 delete.

Closes #319

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPZ84wqFzniQ1FL4mvztJS)_