### PR TITLE
fix(relay): log shutdown errors instead of swallowing

### DIFF
--- a/crates/relay/src/main.rs
+++ b/crates/relay/src/main.rs
@@ -231,7 +231,9 @@ async fn main() -> Result<()> {
     }
 
     // Network is moved into the listener task, so we just shut down the relay.
-    relay_server.shutdown().await.ok();
+    if let Err(e) = relay_server.shutdown().await {
+        tracing::warn!(%e, "relay server shutdown failed");
+    }
     info!("shut down complete");
     Ok(())
 }


### PR DESCRIPTION
## Why

`relay_server.shutdown().await.ok()` swallowed errors. I/O fail, already-closed socket, anything — invisible. No log, no signal. Bad for observability.

## Fix

Replace `.ok()` with `if let Err(e)` + `tracing::warn!(%e, ...)`. Shutdown still non-fatal — relay process exits regardless — but failure now surfaces in logs. Matches existing `tracing::error!(%e, ...)` style nearby (lines 227-228).

Swept relay crate for `.shutdown().await.ok()` and `.ok();` — only one site found. No other instances in scope.

## Verify

- `cargo fmt --check -p willow-relay` clean
- `cargo clippy -p willow-relay --all-targets -- -D warnings` clean
- `cargo test -p willow-relay` 17 tests pass

Closes #159

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnwK1dP6rnrsbLxtg92zfF)_