### PR TITLE
fix(web): use once_into_js for per-touch timers (no leak)

### DIFF
--- a/crates/web/src/components/add_friend.rs
+++ b/crates/web/src/components/add_friend.rs
@@ -72,14 +72,17 @@ pub(crate) fn announce(msg: &str) {
     region.set_text_content(Some(""));
     let msg = msg.to_string();
     let region_clone = region.clone();
-    let cb = wasm_bindgen::closure::Closure::<dyn FnMut()>::new(move || {
+    // One-shot 20ms timer fires per `announce()` call (per trust
+    // action). `once_into_js` hands the closure to JS so GC reclaims
+    // it after the callback runs — `.forget()` would leak per
+    // announcement (issue #193).
+    let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
         region_clone.set_text_content(Some(&msg));
     });
     if let Some(win) = web_sys::window() {
-        win.set_timeout_with_callback_and_timeout_and_arguments_0(cb.as_ref().unchecked_ref(), 20)
+        win.set_timeout_with_callback_and_timeout_and_arguments_0(cb.unchecked_ref(), 20)
             .ok();
     }
-    cb.forget();
 }
 
 /// Root-mounted compare-fingerprints dialog. Renders when the

--- a/crates/web/src/components/grove_rail.rs
+++ b/crates/web/src/components/grove_rail.rs
@@ -209,7 +209,14 @@ pub fn GroveRail(
                                 let cx = touch.client_x() as f64;
                                 let cy = touch.client_y() as f64;
                                 if let Some(window) = web_sys::window() {
-                                    let cb = wasm_bindgen::closure::Closure::once(move || {
+                                    // `once_into_js` hands the closure
+                                    // to JS so it is reclaimed by GC
+                                    // after fire (or after
+                                    // `clear_timeout_with_handle` on
+                                    // touchend / touchmove). `.forget()`
+                                    // would leak one closure per
+                                    // touchstart (issue #193).
+                                    let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
                                         set_menu_server_id.set(Some(id_for_timer));
                                         set_menu_x.set(cx);
                                         set_menu_y.set(cy);
@@ -228,13 +235,12 @@ pub fn GroveRail(
                                     });
                                     if let Ok(timer_id) =
                                         window.set_timeout_with_callback_and_timeout_and_arguments_0(
-                                            cb.as_ref().unchecked_ref(),
+                                            cb.unchecked_ref(),
                                             500,
                                         )
                                     {
                                         lp.set(timer_id);
                                     }
-                                    cb.forget();
                                 }
                             }
                         };

--- a/crates/web/src/components/long_press.rs
+++ b/crates/web/src/components/long_press.rs
@@ -43,7 +43,11 @@ pub fn LongPressAvatar(
         set_ring.set(Some(false));
         let set_ring_for_timer = set_ring;
         let on_trigger_inner = on_trigger;
-        let cb = wasm_bindgen::closure::Closure::<dyn FnMut()>::new(move || {
+        // `once_into_js` transfers ownership to JS so the closure is
+        // reclaimed by GC after fire (or after `clear_timeout_with_handle`
+        // in `cancel`). `Closure::once(...).forget()` would leak one
+        // closure per pointerdown / touchstart (issue #193).
+        let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
             set_ring_for_timer.set(Some(true));
             // Light haptic + fire the callback. Headless browsers
             // (wasm-bindgen-test) lack `navigator.vibrate`, so
@@ -56,14 +60,12 @@ pub fn LongPressAvatar(
             on_trigger_inner.get_value().run(());
         });
         if let Some(win) = web_sys::window() {
-            if let Ok(handle) = win.set_timeout_with_callback_and_timeout_and_arguments_0(
-                cb.as_ref().unchecked_ref(),
-                HOLD_MS,
-            ) {
+            if let Ok(handle) = win
+                .set_timeout_with_callback_and_timeout_and_arguments_0(cb.unchecked_ref(), HOLD_MS)
+            {
                 timer.set_value(Some(handle));
             }
         }
-        cb.forget();
     };
 
     let cancel = move || {
@@ -80,17 +82,16 @@ pub fn LongPressAvatar(
     Effect::new(move |_| {
         if let Some(true) = ring.get() {
             let set_ring_off = set_ring;
-            let cb = wasm_bindgen::closure::Closure::<dyn FnMut()>::new(move || {
+            // One-shot fade-off timer. `once_into_js` lets JS reclaim
+            // the closure after fire — this Effect re-runs on every
+            // arm, so `forget()` would leak per long-press (issue #193).
+            let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
                 set_ring_off.set(None);
             });
             if let Some(win) = web_sys::window() {
-                win.set_timeout_with_callback_and_timeout_and_arguments_0(
-                    cb.as_ref().unchecked_ref(),
-                    180,
-                )
-                .ok();
+                win.set_timeout_with_callback_and_timeout_and_arguments_0(cb.unchecked_ref(), 180)
+                    .ok();
             }
-            cb.forget();
         }
     });
 

--- a/crates/web/src/components/message.rs
+++ b/crates/web/src/components/message.rs
@@ -510,10 +510,14 @@ pub fn MessageView(
             is_dragging.set(true);
         }
         set_long_press_active.set(true);
-        // Start 500ms timer via web_sys.
+        // Start 500ms timer via web_sys. Use `once_into_js` so the
+        // closure transfers ownership to JS — once the timer fires (or
+        // `clear_timeout_with_handle` discards it on the cancel paths
+        // below), the JS GC reclaims it. `Closure::once(...).forget()`
+        // would leak per touchstart on mobile (issue #193).
         if let Some(window) = web_sys::window() {
             let open_sheet = set_show_sheet_open.clone();
-            let cb = wasm_bindgen::closure::Closure::once(move || {
+            let cb = wasm_bindgen::closure::Closure::once_into_js(move || {
                 set_long_press_active.set(false);
                 open_sheet();
                 // Haptic feedback. Headless test browsers lack
@@ -525,13 +529,11 @@ pub fn MessageView(
                     }
                 }
             });
-            if let Ok(id) = window.set_timeout_with_callback_and_timeout_and_arguments_0(
-                cb.as_ref().unchecked_ref(),
-                500,
-            ) {
+            if let Ok(id) = window
+                .set_timeout_with_callback_and_timeout_and_arguments_0(cb.unchecked_ref(), 500)
+            {
                 lp_start.set(id);
             }
-            cb.forget();
         }
     };
 

--- a/crates/web/src/components/reconnection_toast.rs
+++ b/crates/web/src/components/reconnection_toast.rs
@@ -69,15 +69,18 @@ pub fn ReconnectionToast() -> impl IntoView {
             // before scheduling a fresh one.
             clear_timeout(timeout_handle.get_value());
             let vis = visible;
-            let cb = wasm_bindgen::closure::Closure::<dyn FnMut()>::new(move || vis.set(false));
+            // One-shot auto-hide timer; this Effect re-runs on every
+            // reconnect so `forget()` would leak per reconnection
+            // (issue #193). `once_into_js` hands the closure to JS
+            // for GC after fire / `clear_timeout_with_handle` above.
+            let cb = wasm_bindgen::closure::Closure::once_into_js(move || vis.set(false));
             let handle = web_sys::window().and_then(|win| {
                 win.set_timeout_with_callback_and_timeout_and_arguments_0(
-                    cb.as_ref().unchecked_ref(),
+                    cb.unchecked_ref(),
                     AUTO_HIDE_MS,
                 )
                 .ok()
             });
-            cb.forget();
             timeout_handle.set_value(handle);
         }
     });

--- a/crates/web/src/keybindings.rs
+++ b/crates/web/src/keybindings.rs
@@ -119,7 +119,11 @@ fn close_top_of_stack(state: AppState, write: AppWriteSignals) -> bool {
 /// timeout so Leptos has mounted the surface if we just opened it.
 fn focus_search_input() {
     if let Some(w) = web_sys::window() {
-        let cb = Closure::<dyn FnMut()>::new(move || {
+        // One-shot zero-timeout focus push fires every time the search
+        // surface opens. `once_into_js` lets JS GC reclaim the closure
+        // after fire — `.forget()` would leak per search-open
+        // (issue #193).
+        let cb = Closure::once_into_js(move || {
             if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
                 if let Some(el) = doc.query_selector(".search-input").ok().flatten() {
                     if let Ok(html) = el.dyn_into::<web_sys::HtmlElement>() {
@@ -128,9 +132,7 @@ fn focus_search_input() {
                 }
             }
         });
-        let _ =
-            w.set_timeout_with_callback_and_timeout_and_arguments_0(cb.as_ref().unchecked_ref(), 0);
-        cb.forget();
+        let _ = w.set_timeout_with_callback_and_timeout_and_arguments_0(cb.unchecked_ref(), 0);
     }
 }
 


### PR DESCRIPTION
## Why

`Closure::once(...).forget()` leaks the wasm-bindgen closure shim in the WASM heap once per fire. four long-press timers + three other per-event one-shot timers all re-run on every gesture / Effect tick. on mobile, every touchstart on a message bubble / grove tile / avatar leaks one closure — accumulates over hours. issue #193, severity low.

## Fix

swap to `Closure::once_into_js`. transfers ownership to JS, GC reclaims after timer fires (or after `clear_timeout_with_handle` on cancel path). already the established pattern in `audio.rs:79`, `app.rs:272`, `components/toast.rs:282`. all sites here are one-shot `setTimeout`; cancel paths key off the timer id, not the closure handle, so nothing breaks.

sites swept:

- `crates/web/src/components/message.rs` — touch long-press 500ms timer (issue cite)
- `crates/web/src/components/long_press.rs` — pointer / touch long-press 350ms timer (issue cite)
- `crates/web/src/components/long_press.rs` — Effect-driven 180ms ring fade (issue cite)
- `crates/web/src/components/grove_rail.rs` — touch long-press 500ms timer (issue cite)
- `crates/web/src/components/add_friend.rs` — `announce()` 20ms SR-replay timer (per trust action)
- `crates/web/src/keybindings.rs` — `focus_search_input` 0ms timer (per search-open)
- `crates/web/src/components/reconnection_toast.rs` — auto-hide timer (per reconnection)

left as-is — page-lifetime listeners that intentionally outlive any single event:

- `app.rs` visibilitychange / willow-push / hashchange (window-mounted for app lifetime)
- `keybindings.rs:85` global keydown listener
- `mobile_shell.rs` pointerdown / pointerup gesture binder
- `profile/controller.rs` profile open / close / Esc window listeners
- `voice.rs` ICE / track / negotiation handlers (peer-connection lifetime, comments say so)
- `file_share.rs` FileReader callback (FileReader-lifetime, comment says so)
- `audio.rs:98` chime play() promise rejection handler
- `call_page.rs` MediaStream handlers (already managed via `closures.update_value(...)`)
- `bottom_sheet.rs` / `grove_drawer.rs` Escape listeners (component-mount-lifetime; remove-listener refactor is separate scope)

runner-up rejected: `Rc<RefCell<Option<Closure>>>` cleared on cancel. correct, but heavier — the timer id alone already lets cancel paths abort, and `once_into_js` matches existing patterns in this crate. only worth the extra plumbing if a closure must be cancellable AND the existing call site can drop it deterministically; neither holds here.

## Verify

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo check -p willow-web --target wasm32-unknown-unknown` clean
- [x] `cargo test -p willow-web --lib` 72 passed
- [ ] no new test — per-touch GC reclamation isn't observable from wasm-pack (no API for heap-pressure assertions); existing browser tests continue to exercise the long-press / search-focus / announce / reconnect paths and would catch any cancel-path regression. relying on compile gates + reviewer eyes for the lifetime change.

Closes #193

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnwK1dP6rnrsbLxtg92zfF)_