### PR TITLE
fix(web): validate kind on service-worker postMessage

### DIFF
--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -293,29 +293,18 @@ pub fn App() -> impl IntoView {
 
     // Wire the service-worker bridge — the `willow-push` window event
     // fires whenever the SW forwards a focused-client push payload.
-    // Reads the payload out of `window.__willowLastPush` (stashed by
-    // `main.rs::wire_service_worker_bridge`) and routes it through the
-    // Notifier.
+    // Pulls the validated payload from `service_worker_bridge` (a
+    // module-local cell, not a global window property — issue #244)
+    // and routes it through the Notifier.
     {
         use wasm_bindgen::closure::Closure;
         use wasm_bindgen::JsCast;
         let notifier = notifier.clone();
         let closure = Closure::<dyn Fn(web_sys::Event)>::new(move |_ev: web_sys::Event| {
-            let Some(window) = web_sys::window() else {
+            let Some(payload) = crate::service_worker_bridge::take_last_push() else {
                 return;
             };
-            let payload = js_sys::Reflect::get(
-                &window,
-                &wasm_bindgen::JsValue::from_str("__willowLastPush"),
-            )
-            .ok();
-            let Some(payload) = payload else {
-                return;
-            };
-            let cat = js_sys::Reflect::get(&payload, &"cat".into())
-                .ok()
-                .and_then(|v| v.as_string())
-                .unwrap_or_else(|| "msg".to_string());
+            let cat = payload.cat;
             let cat_enum = match cat.as_str() {
                 "mention" => crate::notifications::Category::Mention,
                 "letter" => crate::notifications::Category::Letter,
@@ -333,8 +322,10 @@ pub fn App() -> impl IntoView {
             });
         });
         if let Some(window) = web_sys::window() {
-            let _ = window
-                .add_event_listener_with_callback("willow-push", closure.as_ref().unchecked_ref());
+            let _ = window.add_event_listener_with_callback(
+                crate::service_worker_bridge::PUSH_EVENT,
+                closure.as_ref().unchecked_ref(),
+            );
         }
         closure.forget();
     }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -17,6 +17,7 @@ pub mod keybindings;
 pub mod notifications;
 pub mod palette_recents;
 pub mod profile;
+pub mod service_worker_bridge;
 pub mod state;
 pub mod state_bridge;
 pub mod trust_store;

--- a/crates/web/src/main.rs
+++ b/crates/web/src/main.rs
@@ -1,4 +1,4 @@
-use willow_web::app;
+use willow_web::{app, service_worker_bridge};
 
 fn main() {
     console_error_panic_hook::set_once();
@@ -20,44 +20,13 @@ fn main() {
 
     // Wire navigator.serviceWorker.onmessage so pushes forwarded by the
     // service worker (focused-client path) reach the in-app Notifier.
-    // The payload is `{ kind: "willow-push", cat, ref }`. When the app
-    // is focused the SW forwards here instead of calling
-    // `registration.showNotification` — per the privacy contract the
-    // in-app toast is the visible surface when we already have DOM.
-    wire_service_worker_bridge();
+    // The bridge validates the `kind` discriminator before accepting
+    // (issue #244) and stashes payloads in a module-local cell rather
+    // than on the global `window`. When the app is focused the SW
+    // forwards here instead of calling `registration.showNotification`
+    // — per the privacy contract the in-app toast is the visible
+    // surface when we already have DOM.
+    service_worker_bridge::install();
 
     leptos::mount::mount_to_body(app::App);
-}
-
-/// Install the `navigator.serviceWorker.onmessage` listener that
-/// stashes the most recent push payload on `window.__willowLastPush`
-/// and dispatches a plain `willow-push` Event on the window so the
-/// Leptos app can poll the property when the event fires. Using a
-/// custom-event-free path sidesteps a `web-sys` feature dependency.
-fn wire_service_worker_bridge() {
-    use wasm_bindgen::closure::Closure;
-    use wasm_bindgen::JsCast;
-
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-
-    let sw = window.navigator().service_worker();
-    let window_for_dispatch = window.clone();
-    let onmessage =
-        Closure::<dyn Fn(web_sys::MessageEvent)>::new(move |ev: web_sys::MessageEvent| {
-            // Stash the payload on `window.__willowLastPush` so the
-            // in-app Notifier handler can read it after the event
-            // fires.
-            let _ = js_sys::Reflect::set(
-                &window_for_dispatch,
-                &wasm_bindgen::JsValue::from_str("__willowLastPush"),
-                &ev.data(),
-            );
-            if let Ok(evt) = web_sys::Event::new("willow-push") {
-                let _ = window_for_dispatch.dispatch_event(&evt);
-            }
-        });
-    let _ = sw.add_event_listener_with_callback("message", onmessage.as_ref().unchecked_ref());
-    onmessage.forget();
 }

--- a/crates/web/src/service_worker_bridge.rs
+++ b/crates/web/src/service_worker_bridge.rs
@@ -1,0 +1,133 @@
+//! Service-worker `postMessage` bridge.
+//!
+//! `sw.js` forwards push payloads to focused clients via
+//! `client.postMessage({ kind, cat, ref })`. The boundary is untrusted
+//! by default — anything with a handle to the `ServiceWorker` (or, in
+//! future, a `MessageChannel` peer) can call `postMessage`. The bridge
+//! enforces two defenses:
+//!
+//! 1. **Kind discriminator.** `ev.data.kind` must equal one of the
+//!    constants below. Messages without a recognized kind are dropped
+//!    silently (no logging — this is hot-path on every push).
+//! 2. **No global window stash.** The previous implementation parked
+//!    the payload on `window.__willowLastPush`, where any script in
+//!    the page could read it. We now keep the payload in a
+//!    module-local `RefCell` (single-threaded WASM, see
+//!    `CLAUDE.md` State Management table — "WASM single-threaded
+//!    interior mutability").
+//!
+//! After validation, the bridge stashes the payload and dispatches a
+//! plain `willow-push` window event. The Leptos handler in `app.rs`
+//! listens for that event and pulls the payload via
+//! [`take_last_push`].
+//!
+//! The custom-event-free path (plain `Event`, not `CustomEvent`)
+//! sidesteps a `web-sys` feature dependency — see the original
+//! comment in `main.rs`.
+
+use std::cell::RefCell;
+
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
+
+/// `kind` value the SW sets on a forwarded push payload.
+pub const PUSH_KIND: &str = "willow-push";
+
+/// `kind` value the SW sets on a notification-click forward.
+pub const NOTIFICATION_CLICK_KIND: &str = "willow-notification-click";
+
+/// Window event name dispatched after a push payload is accepted.
+pub const PUSH_EVENT: &str = "willow-push";
+
+/// Validated payload stashed for the Leptos reader.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PushPayload {
+    /// Always equals one of [`PUSH_KIND`] / [`NOTIFICATION_CLICK_KIND`].
+    pub kind: String,
+    /// Notification category (e.g. `"msg"`, `"mention"`).
+    pub cat: String,
+    /// Optional opaque reference (channel id, message id, …).
+    pub reference: Option<String>,
+}
+
+thread_local! {
+    /// Last validated payload received from the SW. Replaced — not
+    /// queued — on each push, mirroring the prior single-slot
+    /// behavior. WASM is single-threaded so a plain `RefCell` is
+    /// sufficient (see `CLAUDE.md` State Management table).
+    static LAST_PUSH: RefCell<Option<PushPayload>> = const { RefCell::new(None) };
+}
+
+/// Pull and clear the last validated push payload, if any.
+///
+/// Returns `None` when no payload has arrived since the previous
+/// call. Intended for the Leptos `willow-push` listener.
+pub fn take_last_push() -> Option<PushPayload> {
+    LAST_PUSH.with(|cell| cell.borrow_mut().take())
+}
+
+/// Validate a raw `MessageEvent.data` value and return a
+/// [`PushPayload`] iff it carries a recognized `kind`.
+///
+/// Pulled out of the closure for direct unit-test coverage — driving
+/// the full SW path in a headless browser is not feasible.
+pub fn validate_payload(data: &wasm_bindgen::JsValue) -> Option<PushPayload> {
+    if !data.is_object() {
+        return None;
+    }
+    let kind = js_sys::Reflect::get(data, &"kind".into())
+        .ok()
+        .and_then(|v| v.as_string())?;
+    if kind != PUSH_KIND && kind != NOTIFICATION_CLICK_KIND {
+        return None;
+    }
+    let cat = js_sys::Reflect::get(data, &"cat".into())
+        .ok()
+        .and_then(|v| v.as_string())
+        .unwrap_or_else(|| "msg".to_string());
+    let reference = js_sys::Reflect::get(data, &"ref".into())
+        .ok()
+        .and_then(|v| v.as_string());
+    Some(PushPayload {
+        kind,
+        cat,
+        reference,
+    })
+}
+
+/// Install the `navigator.serviceWorker.onmessage` listener.
+///
+/// Validates each incoming `MessageEvent` against [`validate_payload`],
+/// stashes the result in the module-local cell, and dispatches a
+/// `willow-push` window event so the in-app Notifier can react.
+///
+/// Idempotent only at the call-site level — calling twice attaches two
+/// listeners. Production calls it exactly once from `main.rs`.
+pub fn install() {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let sw = window.navigator().service_worker();
+    let window_for_dispatch = window.clone();
+    let onmessage =
+        Closure::<dyn Fn(web_sys::MessageEvent)>::new(move |ev: web_sys::MessageEvent| {
+            let Some(payload) = validate_payload(&ev.data()) else {
+                return;
+            };
+            store_and_dispatch(&window_for_dispatch, payload);
+        });
+    let _ = sw.add_event_listener_with_callback("message", onmessage.as_ref().unchecked_ref());
+    onmessage.forget();
+}
+
+/// Stash `payload` and fire the `willow-push` window event.
+///
+/// Split out so browser tests can drive the post-validation path
+/// without faking a `ServiceWorker` (which is unavailable under
+/// `wasm-pack test`).
+pub fn store_and_dispatch(window: &web_sys::Window, payload: PushPayload) {
+    LAST_PUSH.with(|cell| *cell.borrow_mut() = Some(payload));
+    if let Ok(evt) = web_sys::Event::new(PUSH_EVENT) {
+        let _ = window.dispatch_event(&evt);
+    }
+}

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -11927,3 +11927,142 @@ mod phase_2d_ephemeral_channels {
         assert_eq!(input.value(), "90", "must clamp at 90-day cap");
     }
 }
+
+// ── Service-worker postMessage validation (issue #244) ──────────────────────
+//
+// `validate_payload` is the kind-discriminator gate. We test it
+// directly because driving a real `ServiceWorker` under wasm-pack is
+// infeasible — and the gate is the load-bearing piece. The
+// `store_and_dispatch` helper is exercised separately to confirm a
+// validated payload reaches `take_last_push` and fires the
+// `willow-push` window event.
+mod service_worker_bridge {
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_test::*;
+    use willow_web::service_worker_bridge::{
+        store_and_dispatch, take_last_push, validate_payload, PushPayload, NOTIFICATION_CLICK_KIND,
+        PUSH_EVENT, PUSH_KIND,
+    };
+
+    /// Build a JS `{ kind, cat, ref }` object for `MessageEvent.data`.
+    fn make_data(kind: Option<&str>, cat: Option<&str>, reference: Option<&str>) -> JsValue {
+        let obj = js_sys::Object::new();
+        if let Some(k) = kind {
+            js_sys::Reflect::set(&obj, &"kind".into(), &k.into()).unwrap();
+        }
+        if let Some(c) = cat {
+            js_sys::Reflect::set(&obj, &"cat".into(), &c.into()).unwrap();
+        }
+        if let Some(r) = reference {
+            js_sys::Reflect::set(&obj, &"ref".into(), &r.into()).unwrap();
+        }
+        obj.into()
+    }
+
+    #[wasm_bindgen_test]
+    fn validate_accepts_well_formed_push() {
+        let data = make_data(Some(PUSH_KIND), Some("mention"), Some("ch:42"));
+        let payload = validate_payload(&data).expect("valid push must pass");
+        assert_eq!(
+            payload,
+            PushPayload {
+                kind: PUSH_KIND.to_string(),
+                cat: "mention".to_string(),
+                reference: Some("ch:42".to_string()),
+            }
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn validate_accepts_notification_click_kind() {
+        // Both kinds the SW posts must clear the gate so a future
+        // reader can subscribe without a second validator.
+        let data = make_data(Some(NOTIFICATION_CLICK_KIND), Some("msg"), None);
+        let payload = validate_payload(&data).expect("notification-click must pass");
+        assert_eq!(payload.kind, NOTIFICATION_CLICK_KIND);
+    }
+
+    #[wasm_bindgen_test]
+    fn validate_drops_payload_missing_kind() {
+        // The whole point of issue #244 — no `kind`, no admission.
+        let data = make_data(None, Some("msg"), Some("anything"));
+        assert!(
+            validate_payload(&data).is_none(),
+            "missing kind must be rejected"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn validate_drops_payload_with_wrong_kind() {
+        let data = make_data(Some("attacker-kind"), Some("msg"), None);
+        assert!(
+            validate_payload(&data).is_none(),
+            "unknown kind must be rejected"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn validate_drops_non_object_payload() {
+        // postMessage(string) etc. — the SW never sends these but a
+        // hostile sender might.
+        assert!(validate_payload(&JsValue::from_str("willow-push")).is_none());
+        assert!(validate_payload(&JsValue::from_f64(42.0)).is_none());
+        assert!(validate_payload(&JsValue::NULL).is_none());
+        assert!(validate_payload(&JsValue::UNDEFINED).is_none());
+    }
+
+    #[wasm_bindgen_test]
+    fn validate_defaults_missing_cat_to_msg() {
+        let data = make_data(Some(PUSH_KIND), None, None);
+        let payload = validate_payload(&data).expect("kind alone is enough");
+        assert_eq!(payload.cat, "msg");
+        assert!(payload.reference.is_none());
+    }
+
+    #[wasm_bindgen_test]
+    async fn store_and_dispatch_round_trips_through_window_event() {
+        use wasm_bindgen::closure::Closure;
+
+        // Drain any leftover payload from prior tests in the same
+        // browser document so this case starts from a known state.
+        let _ = take_last_push();
+
+        let window = web_sys::window().expect("window exists");
+        let fired = Rc::new(Cell::new(false));
+        let fired_for_cb = fired.clone();
+        let cb = Closure::<dyn Fn(web_sys::Event)>::new(move |_| {
+            fired_for_cb.set(true);
+        });
+        window
+            .add_event_listener_with_callback(PUSH_EVENT, cb.as_ref().unchecked_ref())
+            .unwrap();
+
+        let payload = PushPayload {
+            kind: PUSH_KIND.to_string(),
+            cat: "mention".to_string(),
+            reference: Some("msg:abc".to_string()),
+        };
+        store_and_dispatch(&window, payload.clone());
+
+        // Synchronous dispatch_event: the listener has already run.
+        assert!(fired.get(), "willow-push event must fire");
+        assert_eq!(
+            take_last_push(),
+            Some(payload),
+            "validated payload must be retrievable"
+        );
+        assert!(
+            take_last_push().is_none(),
+            "take_last_push must drain the slot"
+        );
+
+        window
+            .remove_event_listener_with_callback(PUSH_EVENT, cb.as_ref().unchecked_ref())
+            .unwrap();
+        drop(cb);
+    }
+}


### PR DESCRIPTION
## Why

`navigator.serviceWorker.onmessage` accepted whatever `ev.data` it got. payload landed on `window.__willowLastPush` — readable by any script in the page. no `kind` check before dispatching the in-app Notifier. defense-in-depth gap (SEC-W-06).

## Fix

new `service_worker_bridge` module owns the SW boundary:

- gate on `kind in {willow-push, willow-notification-click}` — anything else dropped silently. constants shared between writer (`install`) + reader (`app.rs`) so both ends agree in one place.
- payload stashed in module-local `thread_local! RefCell<Option<PushPayload>>` (CLAUDE.md WASM single-thread rule), not on `window`. `__willowLastPush` write removed entirely — web is single-page, no second reader to keep alive.
- `validate_payload` + `store_and_dispatch` split out so browser tests can drive the post-validation path without faking a `ServiceWorker` (unavailable under wasm-pack).

## Verify

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo check -p willow-web --target wasm32-unknown-unknown`
- [x] `cargo test -p willow-web --lib`
- [x] new wasm-pack tests cover: well-formed push accepted; notification-click accepted; missing kind dropped; wrong kind dropped; non-object dropped; round-trip fires `willow-push` event + drains slot

Closes #244

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnwK1dP6rnrsbLxtg92zfF)_