### PR TITLE
auto-fix batch 2026-04-27-122744

### DIFF
--- a/.claude/skills/resolving-issues/SKILL.md
+++ b/.claude/skills/resolving-issues/SKILL.md
@@ -30,17 +30,18 @@ All sub-fixes land on one master branch per session. Master PR is opened **only 
 3. Track resolved issues locally during the run (commit subjects + a working list in coordinator memory or a scratch file). Assemble the final PR body at end-of-run from this list.
 
 ### Master PR open (end of run)
-1. After all sub-PRs merge, all skill edits applied, and Lessons Learned drafted, open the PR — **non-draft, ready for review**.
+1. After all sub-PRs merge (or get parked as follow-up issues — see below), all skill edits applied, and Lessons Learned drafted, open the PR — **non-draft, ready for review**.
 2. Title: `auto-fix batch YYYY-MM-DD-HHMMSS`. Base: `main`. Apply label `auto-fix-batch`.
-3. PR body: running list of `Fixes #N` lines (one per resolved issue) + `## Skill Evolution` (if skill commits landed) + `## Lessons Learned` section.
-4. **Never open the master PR as a draft.** Open as ready or not at all. If something is unfinished, leave the branch un-PR'd and surface what's left so the human can decide.
+3. PR body: running list of `Fixes #N` lines (one per resolved issue) + `## Skill Evolution` (if skill commits landed) + `## Lessons Learned` section + `## Parked` (if any issues hit a blocker mid-run; cite the follow-up issue per row).
+4. **Always open the master PR with what landed**, even if some attempted issues hit blockers. The PR ships the wins; blockers move to follow-up issues so the next scheduled run picks them up automatically. Never open as draft. If literally nothing landed (zero merged sub-PRs), don't open a PR at all — close the branch out.
+5. **No in-session continuation.** Don't leave a session "to be resumed" — the human must not have to chase a session. The issue queue is the durable handoff.
 
 ### Sub-PR rules
 - Sub-PR base = master branch, NOT `main`.
 - Sub-PR body references issue (`Refs #N`) — no `Fixes` keyword. `Fixes` lives only on master PR (assembled at end of run) so issues close when master PR merges.
 - **Sub-PR base ≠ main means GH Actions workflows scoped to `pull_request: branches: [main]` won't fire.** Implementer treats local `just check` green (fmt + clippy + test + wasm) as the merge gate; do not park sub-PR open waiting for CI that won't run. Master PR (base=main, opened end-of-run) runs full CI before human merge — the load-bearing gate.
 - Implementer watches CI on sub-PR ONLY when CI actually runs (rare; usually requires PR base = main). CI green → merge sub-PR into master branch. No CI run → local `just check` green is the gate, then merge.
-- CI red after one fix attempt → convert sub-PR to draft + caveman question. Move on.
+- CI red after one fix attempt → file follow-up issue (caveman body, link blocker), close sub-PR. Move on. Do NOT leave it as a draft for someone to resume — the next scheduled run picks up the follow-up issue automatically.
 
 ## Core Loop
 
@@ -78,8 +79,8 @@ Fresh agent per issue, scoped to one issue + master branch ref. Steps:
 7. `just check` green locally before pushing.
 8. Push branch. Open sub-PR with master branch as base.
 9. **Merge gate:** if sub-PR CI runs (rare — only when workflow `branches: [main]` filter matches), wait for green. If CI doesn't run (sub-PR base ≠ main is the common case), local `just check` green from step 7 IS the gate. Merge with `mcp__github__merge_pull_request` `merge_method: squash`.
-10. CI red after one fix attempt OR local `just check` red → mark sub-PR as draft + caveman question in body. Return control to coordinator.
-11. Tear down worktree on merge.
+10. CI red after one fix attempt OR local `just check` red OR mid-fix block → **file a follow-up GH issue** (caveman body, link the original issue + cite the blocker), then **close the sub-PR** (don't leave it as a draft for someone to resume). The next scheduled run will see the follow-up issue in the queue and pick it up. Return control to coordinator.
+11. Tear down worktree on merge OR on close-after-blocker.
 
 ## Lessons Learned
 
@@ -118,8 +119,9 @@ Never defer skill edits to a follow-up — they ship with the run that surfaced 
 
 ### Autonomy
 - Best judgment. No hand-holding.
-- Mid-fix block? Implementer parks work as draft sub-PR + caveman question, moves on.
+- Mid-fix block? Implementer files a follow-up GH issue (caveman body, link original + cite blocker), closes the sub-PR, moves on. The follow-up issue is the durable handoff for the next scheduled run — don't leave a draft sub-PR for someone to chase.
 - Noop fine. Ship nothing > ship junk.
+- **No in-session continuation.** Sessions don't get resumed. If something doesn't fit in this run, file an issue.
 
 ## Setup
 
@@ -131,5 +133,6 @@ Never defer skill edits to a follow-up — they ship with the run that surfaced 
 - `just check` green before sub-PR opened.
 - Tests at lowest tier covering behavior (see `CLAUDE.md`).
 - Sub-PR merges into master branch only after merge gate passes (see ### Sub-PR rules — local `just check` is the gate when CI doesn't run, sub-PR CI is the gate when it does).
-- Master PR opened only at end of run, **non-draft**. Master PR runs full CI when opened — the actual quality net for the run.
-- If anything's unfinished or you're unsure, leave the branch un-PR'd. Never open the master PR as a draft.
+- Master PR opened only at end of run, **non-draft**, with whatever sub-PRs landed. Master PR runs full CI when opened — the actual quality net for the run.
+- Anything blocked → follow-up issue, sub-PR closed, next scheduled run picks it up. Never open the master PR as draft. Only skip opening the PR entirely if literally zero sub-PRs landed.
+- No in-session continuation. The issue queue is the durable handoff.

--- a/.claude/skills/resolving-issues/SKILL.md
+++ b/.claude/skills/resolving-issues/SKILL.md
@@ -25,13 +25,14 @@ All sub-fixes land in one master PR per session. Human reviews master PR holisti
 
 ### Master PR setup
 1. Always create fresh master PR per session. Never reuse an open one.
-2. Branch off latest `main`: `auto-fix/batch-YYYY-MM-DD-HHMMSS` (timestamp = unique per session). Push. Open **draft** PR titled `auto-fix batch YYYY-MM-DD-HHMMSS` targeting `main`. Apply label `auto-fix-batch`.
+2. Branch off latest `main`: `auto-fix/batch-YYYY-MM-DD-HHMMSS` (timestamp = unique per session). Empty session-open commit (`git commit --allow-empty -m "chore: open auto-fix batch ..."`) so the draft PR can be opened before any sub-PR lands. Push. Open **draft** PR titled `auto-fix batch YYYY-MM-DD-HHMMSS` targeting `main`. Apply label `auto-fix-batch`.
 3. Master PR body = running list of `Fixes #N` lines, one per resolved issue. Update after each sub-PR merge.
 
 ### Sub-PR rules
 - Sub-PR base = master PR branch, NOT `main`.
 - Sub-PR body references issue (`Refs #N`) — no `Fixes` keyword. `Fixes` lives only on master PR so issues close on master merge.
-- Implementer watches CI on sub-PR. CI green → merge sub-PR into master PR branch.
+- **Sub-PR base ≠ main means GH Actions workflows scoped to `pull_request: branches: [main]` won't fire.** Implementer treats local `just check` green (fmt + clippy + test + wasm) as the merge gate; do not park sub-PR open waiting for CI that won't run. Master PR (base=main) re-runs full CI on every merge — the load-bearing gate.
+- Implementer watches CI on sub-PR ONLY when CI actually runs (rare; usually requires PR base = main). CI green → merge sub-PR into master PR branch. No CI run → local `just check` green is the gate, then merge.
 - CI red after one fix attempt → convert sub-PR to draft + caveman question. Move on.
 
 ## Core Loop
@@ -58,21 +59,25 @@ Fresh agent per issue, scoped to one issue + master PR branch ref. Steps:
 2. **Research (optional, parallel OK):** spawn research subagents for codebase grep, related-file reads, spec lookups. Synthesize before coding.
 3. Open worktree branched off master PR branch. Branch name: `auto-fix/issue-N-short-slug`.
 4. Apply fix. Add tests at lowest tier covering behavior (see `CLAUDE.md`).
-5. `just check` green locally before pushing.
-6. Push branch. Open sub-PR with master PR branch as base.
-7. Watch CI. Flake → re-run. Real failure → one fix attempt.
-8. CI green → merge sub-PR into master PR branch. Tear down worktree.
-9. CI still red → mark sub-PR as draft + caveman question in body. Return control to coordinator.
+5. **Scope-creep guard:** if root-cause fix touches > 5 files OR > 200 LOC, return to coordinator with a brainstorm note before pushing. Coordinator decides: split, defer, or proceed. Don't unilaterally balloon a small-scope ticket.
+6. `just check` green locally before pushing.
+7. Push branch. Open sub-PR with master PR branch as base.
+8. **Merge gate:** if sub-PR CI runs (rare — only when workflow `branches: [main]` filter matches), wait for green. If CI doesn't run (sub-PR base ≠ main is the common case), local `just check` green from step 6 IS the gate. Merge with `mcp__github__merge_pull_request` `merge_method: squash`.
+9. CI red after one fix attempt OR local `just check` red → mark sub-PR as draft + caveman question in body. Return control to coordinator.
+10. Tear down worktree on merge.
 
 ## Lessons Learned
 
-End of run, append `## Lessons Learned` section to master PR body with caveman bullets: what worked, what didn't, concrete suggested edits to this skill file. Human (or follow-up routine) edits `.claude/skills/resolving-issues/SKILL.md` directly to incorporate.
+End of run, append `## Lessons Learned` section to master PR body with caveman bullets: what worked, what didn't, concrete suggested edits to this skill file.
+
+**Apply the skill edits in the same master PR.** Don't defer to a follow-up — coordinator commits the edits to `.claude/skills/resolving-issues/SKILL.md` on the master PR branch directly so the run lands one self-contained PR (fixes + skill evolution). Editing the skill is meta-work, exempt from the "coordinator never codes" rule.
 
 ## Rules
 
 ### Coordinator never codes
 - Read, dispatch, monitor. Implementers touch files.
 - One worktree per issue. Sequential between issues. Tear down after merge or draft-park.
+- **Exception:** the master PR's own session-open commit + Lessons Learned skill edits (see ## Lessons Learned). Coordinator commits these directly to the master PR branch.
 
 ### Sequential between issues
 - One issue at a time. No parallel implementers.
@@ -106,5 +111,6 @@ End of run, append `## Lessons Learned` section to master PR body with caveman b
 
 - `just check` green before sub-PR opened.
 - Tests at lowest tier covering behavior (see `CLAUDE.md`).
-- Sub-PR merges into master PR only after CI green.
+- Sub-PR merges into master PR only after merge gate passes (see ### Sub-PR rules — local `just check` is the gate when CI doesn't run, sub-PR CI is the gate when it does).
+- Master PR (base=main) runs full CI on every merge — that's the actual quality net for the run.
 - Master PR stays draft for entire orchestrator run. Human marks ready when satisfied.

--- a/.claude/skills/resolving-issues/SKILL.md
+++ b/.claude/skills/resolving-issues/SKILL.md
@@ -18,21 +18,28 @@ You = coordinator. Implementer subagents = workers. Read, dispatch, monitor. Nev
 - **REQUIRED:** `superpowers:using-git-worktrees` — isolate each implementer.
 - **REQUIRED:** `caveman` — all GH comms.
 - **REQUIRED for implementers:** `superpowers:test-driven-development`, `superpowers:verification-before-completion`, `superpowers:dispatching-parallel-agents` (for research subagents).
+- **REQUIRED for implementers when complexity gate trips (see Implementer Agent step 3):** `superpowers:brainstorming` (run automated, single-actor — never ask the human; runs are unattended), `superpowers:writing-plans` (drop a plan file when the brainstorm lands a multi-step plan).
 
-## Master PR Pattern
+## Master Branch Pattern
 
-All sub-fixes land in one master PR per session. Human reviews master PR holistically + merges → all linked issues auto-close.
+All sub-fixes land on one master branch per session. Master PR is opened **only at the end** of the run, **ready (not draft)**, so the human can't accidentally merge incomplete work mid-flight.
 
-### Master PR setup
-1. Always create fresh master PR per session. Never reuse an open one.
-2. Branch off latest `main`: `auto-fix/batch-YYYY-MM-DD-HHMMSS` (timestamp = unique per session). Empty session-open commit (`git commit --allow-empty -m "chore: open auto-fix batch ..."`) so the draft PR can be opened before any sub-PR lands. Push. Open **draft** PR titled `auto-fix batch YYYY-MM-DD-HHMMSS` targeting `main`. Apply label `auto-fix-batch`.
-3. Master PR body = running list of `Fixes #N` lines, one per resolved issue. Update after each sub-PR merge.
+### Master branch setup (start of run)
+1. Always create fresh master branch per session. Never reuse an open one.
+2. Branch off latest `main`: `auto-fix/batch-YYYY-MM-DD-HHMMSS` (timestamp = unique per session). Empty session-open commit (`git commit --allow-empty -m "chore: open auto-fix batch ..."`) so the branch is non-empty + sub-PRs have a stable base. Push branch. **Do NOT open a PR yet.**
+3. Track resolved issues locally during the run (commit subjects + a working list in coordinator memory or a scratch file). Assemble the final PR body at end-of-run from this list.
+
+### Master PR open (end of run)
+1. After all sub-PRs merge, all skill edits applied, and Lessons Learned drafted, open the PR — **non-draft, ready for review**.
+2. Title: `auto-fix batch YYYY-MM-DD-HHMMSS`. Base: `main`. Apply label `auto-fix-batch`.
+3. PR body: running list of `Fixes #N` lines (one per resolved issue) + `## Skill Evolution` (if skill commits landed) + `## Lessons Learned` section.
+4. **Never open the master PR as a draft.** Open as ready or not at all. If something is unfinished, leave the branch un-PR'd and surface what's left so the human can decide.
 
 ### Sub-PR rules
-- Sub-PR base = master PR branch, NOT `main`.
-- Sub-PR body references issue (`Refs #N`) — no `Fixes` keyword. `Fixes` lives only on master PR so issues close on master merge.
-- **Sub-PR base ≠ main means GH Actions workflows scoped to `pull_request: branches: [main]` won't fire.** Implementer treats local `just check` green (fmt + clippy + test + wasm) as the merge gate; do not park sub-PR open waiting for CI that won't run. Master PR (base=main) re-runs full CI on every merge — the load-bearing gate.
-- Implementer watches CI on sub-PR ONLY when CI actually runs (rare; usually requires PR base = main). CI green → merge sub-PR into master PR branch. No CI run → local `just check` green is the gate, then merge.
+- Sub-PR base = master branch, NOT `main`.
+- Sub-PR body references issue (`Refs #N`) — no `Fixes` keyword. `Fixes` lives only on master PR (assembled at end of run) so issues close when master PR merges.
+- **Sub-PR base ≠ main means GH Actions workflows scoped to `pull_request: branches: [main]` won't fire.** Implementer treats local `just check` green (fmt + clippy + test + wasm) as the merge gate; do not park sub-PR open waiting for CI that won't run. Master PR (base=main, opened end-of-run) runs full CI before human merge — the load-bearing gate.
+- Implementer watches CI on sub-PR ONLY when CI actually runs (rare; usually requires PR base = main). CI green → merge sub-PR into master branch. No CI run → local `just check` green is the gate, then merge.
 - CI red after one fix attempt → convert sub-PR to draft + caveman question. Move on.
 
 ## Core Loop
@@ -40,44 +47,56 @@ All sub-fixes land in one master PR per session. Human reviews master PR holisti
 1. Read open issues + open PRs. Skip anything in flight.
 2. Pick small-scope fixes. `general-audit` issues = top priority.
 3. Skip big features + major refactors. Out of scope.
-4. No in-scope issues? Noop. Skip the rest. No master PR opened.
-5. Create fresh master PR for this session.
+4. No in-scope issues? Noop. Skip the rest. No master branch created, no PR opened.
+5. Create fresh master branch for this session (push, no PR yet — see ### Master branch setup).
 6. Per issue, sequential, max 10 per run:
    - Spawn fresh implementer agent.
-   - Implementer: worktree off master PR branch → research subagents if needed → fix → tests → sub-PR into master PR → watch CI → merge on green.
-   - On merge, append `Fixes #N` to master PR body.
+   - Implementer: worktree off master branch → research subagents if needed → fix → tests → sub-PR into master branch → merge gate → squash-merge.
+   - Track `Fixes #N` for final PR body assembly.
    - Tear down worktree.
    - Next issue.
 7. Implementer finds related rot? File follow-up issue.
-8. Run done? Append Lessons Learned section to master PR body. Leave master PR as draft. Human marks ready when satisfied.
+8. Apply Lessons Learned skill edits to `.claude/skills/resolving-issues/SKILL.md`, commit on master branch, push.
+9. Open the master PR — **ready (not draft)** — with full body (`Fixes #N` list + `## Skill Evolution` + `## Lessons Learned`). Master PR runs full CI; human merges when satisfied. If anything's unfinished, leave the branch un-PR'd instead of opening a draft.
 
 ## Implementer Agent
 
-Fresh agent per issue, scoped to one issue + master PR branch ref. Steps:
+Fresh agent per issue, scoped to one issue + master branch ref. Steps:
 
 1. Read the issue. Decide if more context needed.
 2. **Research (optional, parallel OK):** spawn research subagents for codebase grep, related-file reads, spec lookups. Synthesize before coding.
-3. Open worktree branched off master PR branch. Branch name: `auto-fix/issue-N-short-slug`.
-4. Apply fix. Add tests at lowest tier covering behavior (see `CLAUDE.md`).
-5. **Scope-creep guard:** if root-cause fix touches > 5 files OR > 200 LOC, return to coordinator with a brainstorm note before pushing. Coordinator decides: split, defer, or proceed. Don't unilaterally balloon a small-scope ticket.
-6. `just check` green locally before pushing.
-7. Push branch. Open sub-PR with master PR branch as base.
-8. **Merge gate:** if sub-PR CI runs (rare — only when workflow `branches: [main]` filter matches), wait for green. If CI doesn't run (sub-PR base ≠ main is the common case), local `just check` green from step 6 IS the gate. Merge with `mcp__github__merge_pull_request` `merge_method: squash`.
-9. CI red after one fix attempt OR local `just check` red → mark sub-PR as draft + caveman question in body. Return control to coordinator.
-10. Tear down worktree on merge.
+3. **Complexity gate — automated brainstorm + plan when warranted:**
+   - **Trigger any of:** issue spans > 1 crate, fix touches state machine / wire format / migration paths, ≥ 2 reasonable approaches exist, root cause not obvious from issue text, fix likely > 5 files OR > 200 LOC, "it depends" question on scope.
+   - **Skip when:** issue is a one-liner / config swap / typo / clearly mechanical (single rg-pattern site) / has explicit "Suggested fix" the implementer can follow verbatim.
+   - **If triggered, run automated:**
+     1. Invoke `superpowers:brainstorming` self-driven — implementer plays both roles (exploration + decision). Do NOT ask the human anything; the run is unattended. Output: a written brief naming the chosen approach, the runner-up, and why rejected. Cap at 5 minutes / a few tool calls.
+     2. If the brainstorm surfaces a multi-step plan, invoke `superpowers:writing-plans` to drop a `docs/plans/YYYY-MM-DD-<issue-N>-<slug>.md` on the worktree branch. Otherwise skip — small fixes don't need a plan file.
+   - Fold the brainstorm + plan into the sub-PR body so the human can review the reasoning, not just the code.
+4. Open worktree branched off master branch. Branch name: `auto-fix/issue-N-short-slug`.
+5. Apply fix. Add tests at lowest tier covering behavior (see `CLAUDE.md`).
+6. **Scope-creep guard:** if root-cause fix touches > 5 files OR > 200 LOC AND brainstorm in step 3 didn't already approve that scope, return to coordinator with a brainstorm note before pushing. Coordinator decides: split, defer, or proceed. Don't unilaterally balloon a small-scope ticket.
+7. `just check` green locally before pushing.
+8. Push branch. Open sub-PR with master branch as base.
+9. **Merge gate:** if sub-PR CI runs (rare — only when workflow `branches: [main]` filter matches), wait for green. If CI doesn't run (sub-PR base ≠ main is the common case), local `just check` green from step 7 IS the gate. Merge with `mcp__github__merge_pull_request` `merge_method: squash`.
+10. CI red after one fix attempt OR local `just check` red → mark sub-PR as draft + caveman question in body. Return control to coordinator.
+11. Tear down worktree on merge.
 
 ## Lessons Learned
 
-End of run, append `## Lessons Learned` section to master PR body with caveman bullets: what worked, what didn't, concrete suggested edits to this skill file.
+End of run, before opening the master PR:
 
-**Apply the skill edits in the same master PR.** Don't defer to a follow-up — coordinator commits the edits to `.claude/skills/resolving-issues/SKILL.md` on the master PR branch directly so the run lands one self-contained PR (fixes + skill evolution). Editing the skill is meta-work, exempt from the "coordinator never codes" rule.
+1. Draft `## Lessons Learned` content with caveman bullets: what worked, what didn't, concrete suggested edits to this skill file.
+2. **Apply the skill edits to `.claude/skills/resolving-issues/SKILL.md` on the master branch.** Commit + push. Editing the skill is meta-work, exempt from the "coordinator never codes" rule.
+3. Then open the master PR (ready, not draft) with body containing `Fixes #N` list + `## Skill Evolution` (referencing the skill commit) + `## Lessons Learned`.
+
+Never defer skill edits to a follow-up — they ship with the run that surfaced them, in the same PR.
 
 ## Rules
 
 ### Coordinator never codes
 - Read, dispatch, monitor. Implementers touch files.
 - One worktree per issue. Sequential between issues. Tear down after merge or draft-park.
-- **Exception:** the master PR's own session-open commit + Lessons Learned skill edits (see ## Lessons Learned). Coordinator commits these directly to the master PR branch.
+- **Exception:** the master branch's own session-open commit + Lessons Learned skill edits (see ## Lessons Learned). Coordinator commits these directly to the master branch.
 
 ### Sequential between issues
 - One issue at a time. No parallel implementers.
@@ -86,7 +105,7 @@ End of run, append `## Lessons Learned` section to master PR body with caveman b
 
 ### Fresh agent per issue
 - New implementer each issue. No state leak.
-- Each implementer gets only its issue + master PR branch ref.
+- Each implementer gets only its issue + master branch ref.
 
 ### Scope filter
 - Fixes + small-scope only.
@@ -105,12 +124,12 @@ End of run, append `## Lessons Learned` section to master PR body with caveman b
 ## Setup
 
 - Pre-worktree: `git stash` or `git restore` main dir; `.claude/worktrees/` in `.gitignore`.
-- Worktree per issue, branched off master PR branch. Tear down after sub-PR merges or parks as draft.
+- Worktree per issue, branched off master branch. Tear down after sub-PR merges or parks as draft.
 
 ## Quality
 
 - `just check` green before sub-PR opened.
 - Tests at lowest tier covering behavior (see `CLAUDE.md`).
-- Sub-PR merges into master PR only after merge gate passes (see ### Sub-PR rules — local `just check` is the gate when CI doesn't run, sub-PR CI is the gate when it does).
-- Master PR (base=main) runs full CI on every merge — that's the actual quality net for the run.
-- Master PR stays draft for entire orchestrator run. Human marks ready when satisfied.
+- Sub-PR merges into master branch only after merge gate passes (see ### Sub-PR rules — local `just check` is the gate when CI doesn't run, sub-PR CI is the gate when it does).
+- Master PR opened only at end of run, **non-draft**. Master PR runs full CI when opened — the actual quality net for the run.
+- If anything's unfinished or you're unsure, leave the branch un-PR'd. Never open the master PR as a draft.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6226,6 +6226,7 @@ dependencies = [
  "bincode",
  "iroh-base",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
  "tracing",
  "willow-identity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6208,6 +6208,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -6237,6 +6238,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "clap",
+ "dirs",
  "rusqlite",
  "serde",
  "tempfile",

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -549,9 +549,18 @@ impl<N: Network> WillowToolRouter<N> {
             }
             "set_permission" => {
                 let p: SetPermissionParams = parse_args(&args)?;
+                let perm = willow_state::Permission::from_name(&p.permission).ok_or_else(|| {
+                    ErrorData::invalid_params(
+                        format!(
+                            "unknown permission '{}'; valid: SyncProvider, ManageChannels, ManageRoles, SendMessages, CreateInvite",
+                            p.permission
+                        ),
+                        None,
+                    )
+                })?;
                 match self
                     .client
-                    .set_permission(&p.role_id, &p.permission, p.granted)
+                    .set_permission(&p.role_id, perm, p.granted)
                     .await
                 {
                     Ok(()) => success_json(serde_json::json!({"success": true})),

--- a/crates/client/src/actions.rs
+++ b/crates/client/src/actions.rs
@@ -196,11 +196,10 @@ impl<N: willow_network::Network> ClientHandle<N> {
     pub async fn set_permission(
         &self,
         role_id: &str,
-        permission: &str,
+        permission: willow_state::Permission,
         granted: bool,
     ) -> anyhow::Result<()> {
         let role_id = role_id.to_string();
-        let permission = permission.to_string();
         let event = self
             .mutation_handle
             .build_event(willow_state::EventKind::SetPermission {

--- a/crates/client/src/search/index.rs
+++ b/crates/client/src/search/index.rs
@@ -16,6 +16,59 @@ use std::sync::Arc;
 
 use willow_identity::EndpointId;
 
+use crate::state::DisplayMessage;
+
+/// File extensions that classify a body / attachment as an image for
+/// the `has:image` operator. Mirrors the web UI's `IMAGE_EXTENSIONS`
+/// list in `crates/web/src/components/message.rs` — keep in sync if
+/// either one grows.
+const IMAGE_EXTENSIONS: &[&str] = &[
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".ico",
+];
+
+/// Strip an inline-file body of the form `[file:NAME:BASE64]` and
+/// return `NAME`. Returns `None` for plain bodies.
+///
+/// The web UI sends inline file attachments via this body shape (see
+/// `crates/client/src/actions.rs::share_file_inline`), so the indexer
+/// classifies attachments by sniffing the body without needing a
+/// separate attachments field on `DisplayMessage`.
+fn inline_file_name(body: &str) -> Option<&str> {
+    let inner = body.strip_prefix("[file:")?.strip_suffix(']')?;
+    let colon = inner.find(':')?;
+    Some(&inner[..colon])
+}
+
+/// True if `name` ends with an image-file extension (case-insensitive).
+fn is_image_name(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    IMAGE_EXTENSIONS.iter().any(|ext| lower.ends_with(ext))
+}
+
+/// True if `body` contains a URL whose path ends in an image
+/// extension. Cheap scan — proper URL parsing happens in the message
+/// row renderer; this mirror only needs to be precise enough for the
+/// `has:image` operator.
+fn body_has_image_url(body: &str) -> bool {
+    for prefix in ["http://", "https://"] {
+        let mut rest = body;
+        while let Some(idx) = rest.find(prefix) {
+            let url_start = idx;
+            let after = &rest[url_start..];
+            let url_end = after
+                .find(|c: char| c.is_whitespace() || c == '>' || c == ')' || c == ']')
+                .unwrap_or(after.len());
+            let url = &after[..url_end];
+            let path = url.split('?').next().unwrap_or(url);
+            if is_image_name(path) {
+                return true;
+            }
+            rest = &after[url_end..];
+        }
+    }
+    false
+}
+
 /// One message ready to be indexed.
 ///
 /// All the metadata the executor needs to apply scope + operator
@@ -49,6 +102,58 @@ pub struct IndexableMessage {
     pub has_file: bool,
     /// `has:link` operator target (body contains a URL).
     pub has_link: bool,
+}
+
+impl IndexableMessage {
+    /// Build an [`IndexableMessage`] from a [`DisplayMessage`], with
+    /// the operator-flag fields (`has_image`, `has_file`, `has_link`)
+    /// derived from the body so the search executor's `has:image` /
+    /// `has:file` / `has:link` filters actually match.
+    ///
+    /// Per `docs/specs/2026-04-19-ui-design/local-search.md` §Operators:
+    /// the index is the source of truth for `has:` filtering.
+    /// Classification rules:
+    ///
+    /// - Inline `[file:NAME:b64]` bodies (sent by
+    ///   `share_file_inline`) → `has_image` if `NAME` has an image
+    ///   extension, else `has_file`.
+    /// - Bare URLs whose path ends in an image extension →
+    ///   `has_image` (`https://example.com/cat.jpg`).
+    /// - Any `http://` or `https://` substring → `has_link`.
+    ///
+    /// `letter_id` is plumbed through verbatim — the caller resolves
+    /// it from the active letter context (or passes `None` for
+    /// grove-channel messages). See issue #355 for the missing
+    /// plumbing context.
+    pub fn from_display_message(
+        m: &DisplayMessage,
+        channel_name: &str,
+        grove_id: Option<String>,
+        letter_id: Option<String>,
+    ) -> Self {
+        let inline_name = inline_file_name(&m.body);
+        let has_inline_image = inline_name.is_some_and(is_image_name);
+        let has_inline_file = inline_name.is_some() && !has_inline_image;
+        let has_image = has_inline_image || body_has_image_url(&m.body);
+        let has_file = has_inline_file;
+        let has_link = m.body.contains("http://") || m.body.contains("https://");
+
+        Self {
+            message_id: m.id.clone(),
+            channel_id: m.channel_id.clone(),
+            channel_name: channel_name.to_string(),
+            grove_id,
+            letter_id,
+            author_peer_id: m.author_peer_id,
+            author_handle: m.author_display_name.to_lowercase(),
+            author_display_name: m.author_display_name.clone(),
+            timestamp_ms: m.timestamp_ms,
+            body: m.body.clone(),
+            has_image,
+            has_file,
+            has_link,
+        }
+    }
 }
 
 /// One row stored in the inverted index. Cheaply cloned into

--- a/crates/client/src/search/tests.rs
+++ b/crates/client/src/search/tests.rs
@@ -940,3 +940,102 @@ mod query_tests {
         assert_eq!(q.raw, "Hello");
     }
 }
+
+mod from_display_message_tests {
+    //! `IndexableMessage::from_display_message` derives the operator
+    //! flags (`has_image`, `has_file`, `has_link`) from a
+    //! [`DisplayMessage`]. Per `docs/specs/2026-04-19-ui-design/local-search.md`
+    //! §Operators, the index must populate these so `has:image` /
+    //! `has:file` / `has:link` queries actually match — see issue
+    //! #355.
+    use super::super::index::IndexableMessage;
+    use crate::state::{DisplayMessage, QueueNote};
+    use std::collections::HashMap;
+    use willow_identity::Identity;
+
+    fn dm(id: &str, body: &str) -> DisplayMessage {
+        DisplayMessage {
+            id: id.into(),
+            channel_id: "c1".into(),
+            author_peer_id: Identity::generate().endpoint_id(),
+            author_display_name: "Mira".into(),
+            body: body.into(),
+            is_local: false,
+            timestamp_ms: 100,
+            reactions: HashMap::new(),
+            edited: false,
+            deleted: false,
+            reply_to: None,
+            reply_preview: None,
+            mentions: Vec::new(),
+            pinned: false,
+            whisper: false,
+            queue_note: QueueNote::None,
+        }
+    }
+
+    #[test]
+    fn inline_image_attachment_sets_has_image() {
+        // `[file:NAME:b64]` where NAME has an image extension renders
+        // inline as an image embed in the web UI; the index must
+        // mirror that classification so `has:image` matches.
+        let body = format!(
+            "[file:photo.png:{}]",
+            crate::base64::encode(b"\x89PNG\r\n\x1a\n")
+        );
+        let m = dm("m1", &body);
+        let ix = IndexableMessage::from_display_message(&m, "general", None, None);
+        assert!(ix.has_image, "image attachment must set has_image");
+        assert!(!ix.has_file, "image attachment must not set has_file");
+    }
+
+    #[test]
+    fn inline_non_image_attachment_sets_has_file() {
+        let body = format!("[file:notes.txt:{}]", crate::base64::encode(b"hello"));
+        let m = dm("m2", &body);
+        let ix = IndexableMessage::from_display_message(&m, "general", None, None);
+        assert!(ix.has_file, "non-image attachment must set has_file");
+        assert!(!ix.has_image, "non-image attachment must not set has_image");
+    }
+
+    #[test]
+    fn image_url_in_body_sets_has_image() {
+        // Bare URL pointing at an image extension also lights up
+        // `has:image` — mirrors the UI's `is_image_url` rule.
+        let m = dm("m3", "look at https://example.com/cat.jpg");
+        let ix = IndexableMessage::from_display_message(&m, "general", None, None);
+        assert!(ix.has_image, "image URL must set has_image");
+        assert!(ix.has_link, "URL must set has_link");
+    }
+
+    #[test]
+    fn plain_url_sets_has_link_only() {
+        let m = dm("m4", "see https://willow.im/docs");
+        let ix = IndexableMessage::from_display_message(&m, "general", None, None);
+        assert!(ix.has_link);
+        assert!(!ix.has_image);
+        assert!(!ix.has_file);
+    }
+
+    #[test]
+    fn plain_text_sets_no_flags() {
+        let m = dm("m5", "hello world");
+        let ix = IndexableMessage::from_display_message(&m, "general", None, None);
+        assert!(!ix.has_image);
+        assert!(!ix.has_file);
+        assert!(!ix.has_link);
+    }
+
+    #[test]
+    fn grove_and_letter_id_passed_through() {
+        let m = dm("m6", "hi");
+        let ix = IndexableMessage::from_display_message(
+            &m,
+            "general",
+            Some("g0".into()),
+            Some("L1".into()),
+        );
+        assert_eq!(ix.grove_id.as_deref(), Some("g0"));
+        assert_eq!(ix.letter_id.as_deref(), Some("L1"));
+    }
+}

--- a/crates/client/src/views.rs
+++ b/crates/client/src/views.rs
@@ -299,6 +299,9 @@ pub struct RolesView {
 pub struct RoleEntry {
     pub id: String,
     pub name: String,
+    /// Permission names (string form) in stable, deduplicated order.
+    /// Surfaced as strings so UI / accessor consumers stay format-stable
+    /// even as the underlying [`willow_state::Permission`] enum grows.
     pub permissions: Vec<String>,
 }
 
@@ -786,7 +789,7 @@ pub fn compute_roles_view(events: &Arc<willow_state::ServerState>) -> RolesView 
         .map(|role| RoleEntry {
             id: role.id.clone(),
             name: role.name.clone(),
-            permissions: role.permissions.iter().cloned().collect(),
+            permissions: role.permissions.iter().map(|p| format!("{p:?}")).collect(),
         })
         .collect();
     roles.sort_by(|a, b| a.name.cmp(&b.name));

--- a/crates/replay/Cargo.toml
+++ b/crates/replay/Cargo.toml
@@ -13,6 +13,7 @@ willow-state = { path = "../state" }
 willow-identity = { path = "../identity" }
 willow-network = { path = "../network" }
 clap = { version = "4", features = ["derive"] }
+dirs = "6"
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/replay/src/main.rs
+++ b/crates/replay/src/main.rs
@@ -2,14 +2,28 @@
 
 pub mod role;
 
+use std::path::PathBuf;
+
 use clap::Parser;
 use role::{ReplayConfig, ReplayRole};
+
+/// Compute the platform-aware default path for the replay identity key.
+///
+/// Prefers the user's config dir (e.g. `$XDG_CONFIG_HOME/willow/replay.key`
+/// on Linux, `~/Library/Application Support/willow/replay.key` on macOS),
+/// falling back to `/etc/willow/replay.key` when no config dir is available
+/// (matches the historical Linux deployment path used by the Docker images).
+fn default_replay_key() -> PathBuf {
+    dirs::config_dir()
+        .map(|d| d.join("willow").join("replay.key"))
+        .unwrap_or_else(|| PathBuf::from("/etc/willow/replay.key"))
+}
 
 #[derive(Parser)]
 #[command(name = "willow-replay", about = "Willow replay worker node")]
 struct Cli {
     /// Path to the Ed25519 identity keypair file.
-    #[arg(long, default_value = "/etc/willow/replay.key")]
+    #[arg(long, default_value_t = default_replay_key().display().to_string())]
     identity_path: String,
 
     /// Iroh relay URL to connect through.
@@ -92,4 +106,28 @@ async fn main() -> anyhow::Result<()> {
     };
 
     willow_worker::runtime::run(Box::new(role), config, network).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn default_replay_key_targets_willow_subdir() {
+        let p = default_replay_key();
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("replay.key"));
+        let parent = p.parent().expect("default path has parent");
+        assert_eq!(
+            parent.file_name().and_then(|s| s.to_str()),
+            Some("willow"),
+            "expected willow/ as parent dir, got {parent:?}"
+        );
+        assert!(p.is_absolute(), "default path must be absolute, got {p:?}");
+        // Sanity: path contains at least the `willow/replay.key` tail.
+        assert!(
+            p.ends_with(Path::new("willow/replay.key")),
+            "expected path to end with willow/replay.key, got {p:?}"
+        );
+    }
 }

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -12,3 +12,6 @@ iroh-base = { workspace = true, features = ["key"] }
 serde = { workspace = true }
 sha2 = "0.10"
 willow-identity = { path = "../identity" }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/state/src/event.rs
+++ b/crates/state/src/event.rs
@@ -4,7 +4,7 @@
 //! containing an [`EventKind`]. Events are content-addressed — their
 //! identity is their SHA-256 hash.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use willow_identity::{EndpointId, Identity, Signature};
 
 use crate::hash::EventHash;
@@ -17,7 +17,7 @@ use crate::hash::EventHash;
 /// [`ProposedAction`] and the vote path. This structural separation makes
 /// it impossible for any peer to grant admin via a direct
 /// [`EventKind::GrantPermission`] event.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub enum Permission {
     /// Can sync/provide full history to other peers.
     SyncProvider,
@@ -30,6 +30,124 @@ pub enum Permission {
     SendMessages,
     /// Can create invites.
     CreateInvite,
+    /// Sentinel for permission names that an unknown / future client
+    /// emitted. Reached only via the back-compat string-form deserialize
+    /// path (e.g. an MCP tool boundary or a legacy JSON snapshot).
+    /// `apply_event` treats this sentinel as a no-op so the event still
+    /// joins the DAG — preserving signatures + hash linkage — without
+    /// mutating any role's permission set.
+    ///
+    /// Hidden from generated docs; never emitted by Willow itself.
+    #[doc(hidden)]
+    #[serde(skip)]
+    __UnknownLegacy,
+}
+
+impl Permission {
+    /// Try to parse a permission name from its string form.
+    ///
+    /// Returns `None` for unknown names. Used by the agent MCP tool
+    /// boundary, which rejects unknown permissions before they enter
+    /// the DAG.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "SyncProvider" => Some(Self::SyncProvider),
+            "ManageChannels" => Some(Self::ManageChannels),
+            "ManageRoles" => Some(Self::ManageRoles),
+            "SendMessages" => Some(Self::SendMessages),
+            "CreateInvite" => Some(Self::CreateInvite),
+            _ => None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Permission {
+    /// Custom deserialize that accepts both the enum form (default for
+    /// any format — bincode emits a u32 discriminant, JSON emits the
+    /// variant name) and tolerates unknown variant names by mapping
+    /// them to the [`Permission::__UnknownLegacy`] sentinel.
+    ///
+    /// This lets a peer running an older or rogue client that broadcast
+    /// an unrecognised permission name still have its event join the
+    /// DAG; `apply_event` then silently drops the unknown perm so the
+    /// role's permission set is never polluted.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PermissionVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for PermissionVisitor {
+            type Value = Permission;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a Permission variant")
+            }
+
+            // String form (JSON, MCP boundary, legacy snapshots).
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Permission, E> {
+                Ok(Permission::from_name(v).unwrap_or_else(|| {
+                    tracing::warn!(
+                        permission = %v,
+                        "unknown permission name; mapping to __UnknownLegacy",
+                    );
+                    Permission::__UnknownLegacy
+                }))
+            }
+
+            // Owned-string variant — same handling.
+            fn visit_string<E: serde::de::Error>(self, v: String) -> Result<Permission, E> {
+                self.visit_str(&v)
+            }
+
+            // Bincode encodes a unit-variant enum as the discriminant
+            // index via `deserialize_enum`, which routes through this
+            // method. Forward to the standard derived parser.
+            fn visit_enum<A>(self, data: A) -> Result<Permission, A::Error>
+            where
+                A: serde::de::EnumAccess<'de>,
+            {
+                use serde::de::VariantAccess;
+                #[derive(Deserialize)]
+                enum Tag {
+                    SyncProvider,
+                    ManageChannels,
+                    ManageRoles,
+                    SendMessages,
+                    CreateInvite,
+                }
+                let (tag, variant) = data.variant::<Tag>()?;
+                variant.unit_variant()?;
+                Ok(match tag {
+                    Tag::SyncProvider => Permission::SyncProvider,
+                    Tag::ManageChannels => Permission::ManageChannels,
+                    Tag::ManageRoles => Permission::ManageRoles,
+                    Tag::SendMessages => Permission::SendMessages,
+                    Tag::CreateInvite => Permission::CreateInvite,
+                })
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            // JSON-style formats encode unit variants as strings; route
+            // through the visitor so unknown names hit the sentinel.
+            deserializer.deserialize_any(PermissionVisitor)
+        } else {
+            // Bincode-style formats encode unit variants as discriminant
+            // indices; route through the enum visitor.
+            deserializer.deserialize_enum(
+                "Permission",
+                &[
+                    "SyncProvider",
+                    "ManageChannels",
+                    "ManageRoles",
+                    "SendMessages",
+                    "CreateInvite",
+                ],
+                PermissionVisitor,
+            )
+        }
+    }
 }
 
 // ───── Governance types ────────────────────────────────────────────────────
@@ -125,7 +243,7 @@ pub enum EventKind {
     /// Set or clear a permission on a role.
     SetPermission {
         role_id: String,
-        permission: String,
+        permission: Permission,
         granted: bool,
     },
     /// Assign a role to a member.

--- a/crates/state/src/materialize.rs
+++ b/crates/state/src/materialize.rs
@@ -418,9 +418,20 @@ fn apply_mutation(state: &mut ServerState, event: &Event) -> ApplyResult {
             permission,
             granted,
         } => {
+            // Drop the unknown-legacy sentinel produced by the
+            // back-compat deserialize path so a rogue / future client
+            // can never inject an unrecognised permission name into a
+            // role's permission set.
+            if matches!(permission, Permission::__UnknownLegacy) {
+                tracing::warn!(
+                    role_id = %role_id,
+                    "SetPermission with unknown legacy permission; dropping",
+                );
+                return ApplyResult::Applied;
+            }
             if let Some(role) = state.roles.get_mut(role_id) {
                 if *granted {
-                    role.permissions.insert(permission.clone());
+                    role.permissions.insert(*permission);
                 } else {
                     role.permissions.remove(permission);
                 }

--- a/crates/state/src/tests.rs
+++ b/crates/state/src/tests.rs
@@ -446,7 +446,7 @@ fn set_permission_on_nonexistent_role_is_noop() {
         &admin,
         EventKind::SetPermission {
             role_id: "nonexistent".to_string(),
-            permission: "SendMessages".to_string(),
+            permission: Permission::SendMessages,
             granted: true,
         },
     );
@@ -856,7 +856,7 @@ fn has_permission_ignores_role_based_permissions() {
         &admin,
         EventKind::SetPermission {
             role_id: "r-1".to_string(),
-            permission: "SendMessages".to_string(),
+            permission: Permission::SendMessages,
             granted: true,
         },
     );
@@ -4374,5 +4374,140 @@ fn derive_ephemeral_state_bands() {
     assert_eq!(
         derive_ephemeral_state(None, threshold, 200),
         EphemeralState::Archived
+    );
+}
+
+// ───── SetPermission typed permission round-trip ─────────────────────────
+
+/// Emit `SetPermission` with a typed `Permission` enum value, serialize
+/// via the wire format (`willow-transport` = bincode), deserialize, apply
+/// to a fresh DAG, and assert the role's permission set contains the
+/// typed permission.
+#[test]
+fn set_permission_with_typed_permission_round_trips() {
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::CreateRole {
+            name: "mod".into(),
+            role_id: "r-1".into(),
+        },
+    );
+    let set_event = do_emit(
+        &mut dag,
+        &admin,
+        EventKind::SetPermission {
+            role_id: "r-1".into(),
+            permission: Permission::ManageChannels,
+            granted: true,
+        },
+    );
+
+    // Wire-round-trip the event through bincode (the format used by
+    // `willow-transport` and the storage layer) and re-apply.
+    let bytes = bincode::serialize(&set_event).unwrap();
+    let decoded: Event = bincode::deserialize(&bytes).unwrap();
+    match &decoded.kind {
+        EventKind::SetPermission { permission, .. } => {
+            assert_eq!(*permission, Permission::ManageChannels);
+        }
+        other => panic!("expected SetPermission, got {other:?}"),
+    }
+
+    let state = materialize(&dag);
+    let role = state.roles.get("r-1").expect("role created");
+    assert!(role.permissions.contains(&Permission::ManageChannels));
+}
+
+/// Synthesize a JSON document carrying the legacy `permission: "<name>"`
+/// string form (the shape MCP / agent boundary accepts) and assert the
+/// custom deserializer maps it to the typed `Permission::ManageChannels`.
+#[test]
+fn set_permission_legacy_string_form_still_loads() {
+    let json = serde_json::json!({
+        "SetPermission": {
+            "role_id": "r-1",
+            "permission": "ManageChannels",
+            "granted": true,
+        }
+    });
+    let kind: EventKind = serde_json::from_value(json).expect("legacy string form must load");
+    match kind {
+        EventKind::SetPermission { permission, .. } => {
+            assert_eq!(permission, Permission::ManageChannels);
+        }
+        other => panic!("expected SetPermission, got {other:?}"),
+    }
+}
+
+/// Unknown legacy permission strings deserialize successfully (so the
+/// event still enters the DAG and the chain is not broken) but apply as
+/// a no-op — the unknown name is dropped.
+#[test]
+fn set_permission_legacy_unknown_string_drops_silently() {
+    let json = serde_json::json!({
+        "SetPermission": {
+            "role_id": "r-1",
+            "permission": "FrobnicateWidgets",
+            "granted": true,
+        }
+    });
+    let kind: EventKind =
+        serde_json::from_value(json).expect("unknown legacy string must deserialize, not fail");
+    match kind {
+        EventKind::SetPermission { permission, .. } => {
+            // Unknown name is mapped to the sentinel that apply_event drops.
+            assert_eq!(permission, Permission::__UnknownLegacy);
+        }
+        other => panic!("expected SetPermission, got {other:?}"),
+    }
+
+    // Apply path: synthesize the post-deserialize event in memory (the
+    // sentinel never crosses the wire — it only exists after a custom
+    // deserialize from an unrecognised string form). Bypass `do_emit`
+    // (which signs + bincodes the kind) and feed the event directly to
+    // `apply_incremental`, mirroring what would happen if a JSON
+    // snapshot containing the unknown name were replayed into state.
+    use crate::materialize::apply_incremental;
+
+    let admin = Identity::generate();
+    let mut dag = test_dag(&admin);
+    do_emit(
+        &mut dag,
+        &admin,
+        EventKind::CreateRole {
+            name: "mod".into(),
+            role_id: "r-1".into(),
+        },
+    );
+    let mut state = materialize(&dag);
+
+    // Fabricate an event whose kind carries the sentinel; we reuse a
+    // valid hash from the genesis chain since `apply_event` does not
+    // re-verify signatures and we only care about the apply branch.
+    let signable = EventKind::SetPermission {
+        role_id: "r-1".into(),
+        permission: Permission::__UnknownLegacy,
+        granted: true,
+    };
+    let synthetic = Event {
+        hash: EventHash::from_bytes(b"synthetic-unknown-legacy"),
+        author: admin.endpoint_id(),
+        seq: 99,
+        prev: EventHash::ZERO,
+        deps: vec![],
+        kind: signable,
+        sig: willow_identity::Signature::from_bytes(&[0u8; 64]),
+        timestamp_hint_ms: 0,
+    };
+    let _ = apply_incremental(&mut state, &synthetic);
+
+    let role = state.roles.get("r-1").expect("role created");
+    assert!(
+        role.permissions.is_empty(),
+        "unknown legacy permission must apply as a no-op"
     );
 }

--- a/crates/state/src/types.rs
+++ b/crates/state/src/types.rs
@@ -57,8 +57,8 @@ pub struct Role {
     pub id: String,
     /// Human-readable name (e.g. "Moderator").
     pub name: String,
-    /// The set of permission strings this role grants.
-    pub permissions: BTreeSet<String>,
+    /// The set of typed permissions this role grants.
+    pub permissions: BTreeSet<crate::event::Permission>,
 }
 
 /// A peer's membership record within a server.

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -15,6 +15,7 @@ willow-network = { path = "../network" }
 willow-common = { path = "../common" }
 rusqlite = { version = "0.31", features = ["bundled"] }
 clap = { version = "4", features = ["derive"] }
+dirs = "6"
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/storage/src/main.rs
+++ b/crates/storage/src/main.rs
@@ -3,15 +3,39 @@
 pub mod role;
 pub mod store;
 
+use std::path::PathBuf;
+
 use clap::Parser;
 use role::StorageRole;
 use store::StorageEventStore;
+
+/// Compute the platform-aware default path for the storage identity key.
+///
+/// Prefers the user's config dir (e.g. `$XDG_CONFIG_HOME/willow/storage.key`
+/// on Linux), falling back to `/etc/willow/storage.key` when no config dir
+/// is available (matches the historical Linux deployment path).
+fn default_storage_key() -> PathBuf {
+    dirs::config_dir()
+        .map(|d| d.join("willow").join("storage.key"))
+        .unwrap_or_else(|| PathBuf::from("/etc/willow/storage.key"))
+}
+
+/// Compute the platform-aware default path for the storage SQLite database.
+///
+/// Prefers the user's data dir (e.g. `$XDG_DATA_HOME/willow/storage.db` on
+/// Linux), falling back to `/var/lib/willow/storage.db` when no data dir is
+/// available (matches the historical Linux deployment path).
+fn default_storage_db() -> PathBuf {
+    dirs::data_dir()
+        .map(|d| d.join("willow").join("storage.db"))
+        .unwrap_or_else(|| PathBuf::from("/var/lib/willow/storage.db"))
+}
 
 #[derive(Parser)]
 #[command(name = "willow-storage", about = "Willow storage worker node")]
 struct Cli {
     /// Path to the Ed25519 identity keypair file.
-    #[arg(long, default_value = "/etc/willow/storage.key")]
+    #[arg(long, default_value_t = default_storage_key().display().to_string())]
     identity_path: String,
 
     /// Iroh relay URL to connect through.
@@ -19,7 +43,7 @@ struct Cli {
     relay_url: Option<String>,
 
     /// Path to SQLite database.
-    #[arg(long, default_value = "/var/lib/willow/storage.db")]
+    #[arg(long, default_value_t = default_storage_db().display().to_string())]
     db_path: String,
 
     /// Active sync interval in seconds.
@@ -88,4 +112,44 @@ async fn main() -> anyhow::Result<()> {
     };
 
     willow_worker::runtime::run(Box::new(role), config, network).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn default_storage_key_targets_willow_subdir() {
+        let p = default_storage_key();
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("storage.key"));
+        let parent = p.parent().expect("default path has parent");
+        assert_eq!(
+            parent.file_name().and_then(|s| s.to_str()),
+            Some("willow"),
+            "expected willow/ as parent dir, got {parent:?}"
+        );
+        assert!(p.is_absolute(), "default path must be absolute, got {p:?}");
+        assert!(
+            p.ends_with(Path::new("willow/storage.key")),
+            "expected path to end with willow/storage.key, got {p:?}"
+        );
+    }
+
+    #[test]
+    fn default_storage_db_targets_willow_subdir() {
+        let p = default_storage_db();
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("storage.db"));
+        let parent = p.parent().expect("default path has parent");
+        assert_eq!(
+            parent.file_name().and_then(|s| s.to_str()),
+            Some("willow"),
+            "expected willow/ as parent dir, got {parent:?}"
+        );
+        assert!(p.is_absolute(), "default path must be absolute, got {p:?}");
+        assert!(
+            p.ends_with(Path::new("willow/storage.db")),
+            "expected path to end with willow/storage.db, got {p:?}"
+        );
+    }
 }

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -379,33 +379,26 @@ pub fn App() -> impl IntoView {
             let grove_id = active_server_sig.get();
             let local_peer = peer_id_sig.get();
 
+            // `IndexableMessage::from_display_message` derives the
+            // `has_image` / `has_file` / `has_link` operator flags
+            // from the body so `has:image` / `has:file` / `has:link`
+            // queries actually match. `letter_id` stays `None` here —
+            // the active-letter signal isn't yet wired into this
+            // effect; tracked as a follow-up to issue #355.
+            let grove = if grove_id.is_empty() {
+                None
+            } else {
+                Some(grove_id.clone())
+            };
             let indexable: Vec<willow_client::IndexableMessage> = msgs
                 .into_iter()
                 .map(|m| {
-                    let author_peer_id = m.author_peer_id;
-                    // Lightweight link detection — `has:link` operator
-                    // key. Proper URL parsing lives in message-row
-                    // rendering; this is the cheap version.
-                    let has_link = m.body.contains("http://") || m.body.contains("https://");
-                    willow_client::IndexableMessage {
-                        message_id: m.id,
-                        channel_id: m.channel_id.clone(),
-                        channel_name: current_ch.clone(),
-                        grove_id: if grove_id.is_empty() {
-                            None
-                        } else {
-                            Some(grove_id.clone())
-                        },
-                        letter_id: None,
-                        author_peer_id,
-                        author_handle: m.author_display_name.to_lowercase(),
-                        author_display_name: m.author_display_name,
-                        timestamp_ms: m.timestamp_ms,
-                        body: m.body,
-                        has_image: false,
-                        has_file: false,
-                        has_link,
-                    }
+                    willow_client::IndexableMessage::from_display_message(
+                        &m,
+                        &current_ch,
+                        grove.clone(),
+                        None,
+                    )
                 })
                 .collect();
             // Ignore local peer binding to avoid unused_variables clippy

--- a/crates/web/src/components/roles.rs
+++ b/crates/web/src/components/roles.rs
@@ -198,7 +198,14 @@ pub fn RoleManager(
                                                         let rid = rid_t.clone();
                                                         let perm = perm_toggle.clone();
                                                         wasm_bindgen_futures::spawn_local(async move {
-                                                            let _ = h.set_permission(&rid, &perm, granted).await;
+                                                            // Names come from PERMISSION_NAMES which is
+                                                            // kept in sync with willow_state::Permission;
+                                                            // an unparsed name is a bug, not user input.
+                                                            if let Some(parsed) =
+                                                                willow_state::Permission::from_name(&perm)
+                                                            {
+                                                                let _ = h.set_permission(&rid, parsed, granted).await;
+                                                            }
                                                         });
                                                     }
                                                 />

--- a/crates/web/src/components/search/input.rs
+++ b/crates/web/src/components/search/input.rs
@@ -14,9 +14,14 @@
 //!   target. The active row is also announced via
 //!   `aria-activedescendant`, which points at the row's
 //!   `id="search-row-{message_id}"` per WAI-ARIA listbox guidance.
+//! - `Enter` activates the highlighted row (the row at `active_index`
+//!   in flat in-display order) — same path as clicking the row. When
+//!   there are no results to highlight, `Enter` falls back to the
+//!   recents-push submit so empty / zero-hit queries still get
+//!   remembered.
 
 use leptos::prelude::*;
-use willow_client::SearchScope;
+use willow_client::{SearchResult, SearchScope};
 
 use crate::state::{AppState, AppWriteSignals};
 
@@ -34,9 +39,17 @@ fn placeholder_for(scope: &SearchScope) -> &'static str {
 #[component]
 pub fn SearchInput(
     /// Fired with the current query text when the user presses Enter
-    /// (used for recents push).
+    /// AND there is no row to activate (zero results — recents push
+    /// fallback so the "submit query for later recall" affordance still
+    /// works on misses).
     #[prop(into)]
     on_submit: Callback<String>,
+    /// Fired when Enter activates the highlighted result row (the row
+    /// at `SearchUiState::active_index` in flat in-display order). The
+    /// caller navigates to the row's native container — same path as
+    /// clicking the row.
+    #[prop(into)]
+    on_select: Callback<SearchResult>,
 ) -> impl IntoView {
     let state = use_context::<AppState>().expect("AppState");
     let write = use_context::<AppWriteSignals>().expect("AppWriteSignals");
@@ -75,7 +88,21 @@ pub fn SearchInput(
         }
         "Enter" => {
             ev.prevent_default();
-            on_submit.run(state.search.query.get_untracked());
+            // Enter activates the highlighted row when results exist —
+            // matches the click path. Falls back to the recents-push
+            // submit only when there is no row to activate (e.g. zero
+            // results, query just typed, etc.). Per #406, routing Enter
+            // unconditionally to `on_submit` is the bug we're fixing.
+            let flat = super::results::flat_ordered(
+                &state.search.results.get_untracked(),
+                &state.search.scope.get_untracked(),
+            );
+            let i = state.search.active_index.get_untracked();
+            if let Some(row) = flat.get(i) {
+                on_select.run(row.clone());
+            } else {
+                on_submit.run(state.search.query.get_untracked());
+            }
         }
         "ArrowDown" => {
             let n = result_count();

--- a/crates/web/src/components/search/surface.rs
+++ b/crates/web/src/components/search/surface.rs
@@ -147,7 +147,7 @@ pub fn SearchSurface(
 
     view! {
         <div class="search-surface">
-            <SearchInput on_submit=on_submit />
+            <SearchInput on_submit=on_submit on_select=on_select_result />
             <ScopeChip focused_channel=focused_channel />
             {move || {
                 let q = state.search.query.get();

--- a/crates/web/src/handlers.rs
+++ b/crates/web/src/handlers.rs
@@ -3,15 +3,71 @@
 //! Each function returns a closure for use as a Leptos event handler.
 //! Async client methods are wrapped in `spawn_local` since Leptos
 //! event handlers are synchronous.
+//!
+//! ## Error reporting (issue #350)
+//!
+//! Async client mutations return `anyhow::Result<()>`. Previously each
+//! handler discarded the error with `let _ = ...`, so a typed message
+//! could vanish from the input with no feedback. Every site now routes
+//! failures through [`warn_and_toast`], which logs at `WARN` and pushes
+//! an `err` toast onto the ambient [`ToastStack`] so the user sees
+//! something happened.
+//!
+//! The toast stack is captured *before* `spawn_local` (in the
+//! synchronous handler closure) — `wasm_bindgen_futures::spawn_local`
+//! does not preserve a reactive owner, so `use_context::<ToastStack>()`
+//! must be resolved on the calling task. Mirrors the pattern PR #411
+//! introduced in `sync_queue_view.rs`.
+
+use std::fmt::Debug;
 
 use leptos::prelude::*;
 
 use crate::app::WebClientHandle;
+use crate::components::{Toast, ToastStack};
 use crate::state::{AppState, AppWriteSignals};
 
 /// Parse a hex string into an `EventHash`, logging on failure.
 fn parse_event_hash(hex: &str) -> Option<willow_client::willow_state::EventHash> {
     hex.parse().ok()
+}
+
+/// Log a UI handler failure at WARN and surface it to the user via a
+/// toast.
+///
+/// `action` is a short human-readable verb-phrase (`"send message"`,
+/// `"edit message"`, …). It appears in the tracing field and in the
+/// toast copy so the user knows which action failed.
+///
+/// `toasts` is the optional toast stack captured at handler-call time
+/// (before any `spawn_local`). It is `None` in headless test harnesses
+/// or very early during boot — the `tracing::warn!` call still fires
+/// in that case so the failure is never fully silent.
+///
+/// The convenience overload [`warn_and_toast`] resolves the stack from
+/// context for callers running on a reactive owner; prefer that on
+/// synchronous code paths.
+pub fn warn_and_toast_with(action: &'static str, e: &dyn Debug, toasts: Option<&ToastStack>) {
+    tracing::warn!(error = ?e, action, "ui handler failed");
+    if let Some(stack) = toasts {
+        stack.push(
+            Toast::err(format!("Couldn't {action}. Try again."))
+                .dedup(format!("handler-error:{action}"))
+                .build(),
+        );
+    }
+}
+
+/// Reactive-owner shortcut for [`warn_and_toast_with`]: looks up the
+/// ambient [`ToastStack`] via `use_context` and forwards.
+///
+/// Only safe to call on a reactive owner — for example, a Leptos
+/// event-handler closure or a synchronous component body. Inside an
+/// `async` block spawned via `wasm_bindgen_futures::spawn_local`, no
+/// owner is preserved, so the toast stack must be captured on the
+/// outer synchronous frame and passed via [`warn_and_toast_with`].
+pub fn warn_and_toast(action: &'static str, e: &dyn Debug) {
+    warn_and_toast_with(action, e, use_context::<ToastStack>().as_ref());
 }
 
 /// Create a handler for sending messages (including replies).
@@ -24,15 +80,21 @@ pub fn make_send_handler(
         let ch = state.chat.current_channel.get_untracked();
         let h = handle.clone();
         let replying = state.chat.replying_to.get_untracked();
+        // Capture the toast stack on the outer (reactive-owner) frame
+        // — `spawn_local` strips the owner so `use_context` inside the
+        // async block would return None.
+        let toasts = use_context::<ToastStack>();
         // Clear reply state immediately so the UI updates.
         write.chat.set_replying_to.set(None);
         wasm_bindgen_futures::spawn_local(async move {
             if let Some(reply_msg) = replying {
                 if let Some(hash) = parse_event_hash(&reply_msg.id) {
-                    let _ = h.send_reply(&ch, &hash, &body).await;
+                    if let Err(e) = h.send_reply(&ch, &hash, &body).await {
+                        warn_and_toast_with("send reply", &e, toasts.as_ref());
+                    }
                 }
-            } else {
-                let _ = h.send_message(&ch, &body).await;
+            } else if let Err(e) = h.send_message(&ch, &body).await {
+                warn_and_toast_with("send message", &e, toasts.as_ref());
             }
         });
     }
@@ -47,10 +109,13 @@ pub fn make_edit_handler(
     move |(message_id, new_body): (String, String)| {
         let ch = state.chat.current_channel.get_untracked();
         let h = handle.clone();
+        let toasts = use_context::<ToastStack>();
         write.chat.set_editing.set(None);
         wasm_bindgen_futures::spawn_local(async move {
             if let Some(hash) = parse_event_hash(&message_id) {
-                let _ = h.edit_message(&ch, &hash, &new_body).await;
+                if let Err(e) = h.edit_message(&ch, &hash, &new_body).await {
+                    warn_and_toast_with("edit message", &e, toasts.as_ref());
+                }
             }
         });
     }
@@ -65,9 +130,12 @@ pub fn make_delete_handler(
     move |msg: willow_client::DisplayMessage| {
         let ch = state.chat.current_channel.get_untracked();
         let h = handle.clone();
+        let toasts = use_context::<ToastStack>();
         wasm_bindgen_futures::spawn_local(async move {
             if let Some(hash) = parse_event_hash(&msg.id) {
-                let _ = h.delete_message(&ch, &hash).await;
+                if let Err(e) = h.delete_message(&ch, &hash).await {
+                    warn_and_toast_with("delete message", &e, toasts.as_ref());
+                }
             }
         });
     }
@@ -82,9 +150,12 @@ pub fn make_react_handler(
     move |(msg, emoji): (willow_client::DisplayMessage, String)| {
         let ch = state.chat.current_channel.get_untracked();
         let h = handle.clone();
+        let toasts = use_context::<ToastStack>();
         wasm_bindgen_futures::spawn_local(async move {
             if let Some(hash) = parse_event_hash(&msg.id) {
-                let _ = h.react(&ch, &hash, &emoji).await;
+                if let Err(e) = h.react(&ch, &hash, &emoji).await {
+                    warn_and_toast_with("add reaction", &e, toasts.as_ref());
+                }
             }
         });
     }
@@ -141,12 +212,15 @@ pub fn make_pin_handler(
         let ch = state.chat.current_channel.get_untracked();
         let h = handle.clone();
         let mid = msg.id.clone();
+        let toasts = use_context::<ToastStack>();
         wasm_bindgen_futures::spawn_local(async move {
             if let Some(hash) = parse_event_hash(&mid) {
                 if h.is_pinned(&ch, &hash).await {
-                    let _ = h.unpin_message(&ch, &hash).await;
-                } else {
-                    let _ = h.pin_message(&ch, &hash).await;
+                    if let Err(e) = h.unpin_message(&ch, &hash).await {
+                        warn_and_toast_with("unpin message", &e, toasts.as_ref());
+                    }
+                } else if let Err(e) = h.pin_message(&ch, &hash).await {
+                    warn_and_toast_with("pin message", &e, toasts.as_ref());
                 }
             }
         });

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -9782,6 +9782,166 @@ mod phase_2e_search_active_row {
     }
 }
 
+// ── Phase 2e — Enter activates highlighted row (#406) ───────────────────────
+//
+// Follow-up to #344. After the active-row a11y wiring landed, Enter still
+// routed to the recents-push path instead of activating the highlighted row.
+// These tests pin the corrected contract:
+//
+// - With ≥1 result and a highlighted row, Enter must invoke the row-select
+//   callback with the row at `active_index`, NOT push to recents with the
+//   raw query string.
+// - With zero results, Enter must fall back to the recents-push path so the
+//   "submit query for later recall" affordance still works on misses.
+
+mod phase_2e_search_enter_activates {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use willow_client::{SearchResult, SearchScope};
+    use willow_web::components::SearchInput;
+    use willow_web::state::{create_signals, InitialSignals};
+
+    fn fixture_result(id: &str, body: &str, ts: u64) -> SearchResult {
+        SearchResult {
+            message_id: id.into(),
+            channel_id: "general".into(),
+            channel_name: "general".into(),
+            grove_id: Some("grove-fixture".into()),
+            letter_id: None,
+            author_display_name: "Mira".into(),
+            author_handle: "mira".into(),
+            timestamp_ms: ts,
+            body: body.into(),
+            matched_ranges: Vec::new(),
+        }
+    }
+
+    /// Captures invocations of `on_submit` (recents path) and `on_select`
+    /// (row-activation path). `Arc<Mutex<...>>` so they're `Send + Sync`
+    /// and satisfy `Callback::new`'s bound; that's overhead the harness
+    /// pays gladly to use the real callback path.
+    type SubmitLog = Arc<Mutex<Vec<String>>>;
+    type SelectLog = Arc<Mutex<Vec<SearchResult>>>;
+
+    fn mount_input_with(
+        results: Vec<SearchResult>,
+        query_text: &str,
+        active: usize,
+    ) -> (web_sys::HtmlElement, SubmitLog, SelectLog) {
+        let submitted: SubmitLog = Arc::new(Mutex::new(Vec::new()));
+        let selected: SelectLog = Arc::new(Mutex::new(Vec::new()));
+
+        let submitted_for_mount = submitted.clone();
+        let selected_for_mount = selected.clone();
+        let query_text_owned = query_text.to_string();
+
+        let container = mount_test(move || {
+            let InitialSignals {
+                app_state,
+                write,
+                trust_store: _,
+            } = create_signals();
+
+            // Pin scope to ThisChannel so the flat (in-display-order)
+            // list is just the raw results in the order we passed them
+            // — keeps the test focused on Enter wiring, not grouping.
+            write
+                .search
+                .set_scope
+                .set(SearchScope::ThisChannel("general".into()));
+            write.search.set_query.set(query_text_owned.clone());
+            write.search.set_results.set(results.clone());
+            write.search.set_active_index.set(active);
+
+            provide_context(app_state);
+            provide_context(write);
+
+            let on_submit = {
+                let log = submitted_for_mount.clone();
+                Callback::new(move |q: String| log.lock().unwrap().push(q))
+            };
+            let on_select = {
+                let log = selected_for_mount.clone();
+                Callback::new(move |r: SearchResult| log.lock().unwrap().push(r))
+            };
+
+            view! { <SearchInput on_submit=on_submit on_select=on_select /> }
+        });
+
+        (container, submitted, selected)
+    }
+
+    /// Dispatch a bubbling `keydown` of the given `key` on `el`.
+    fn dispatch_keydown(el: &web_sys::Element, key: &str) {
+        let init = web_sys::KeyboardEventInit::new();
+        init.set_key(key);
+        init.set_bubbles(true);
+        let ev =
+            web_sys::KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init).unwrap();
+        el.dyn_ref::<web_sys::EventTarget>()
+            .unwrap()
+            .dispatch_event(&ev)
+            .unwrap();
+    }
+
+    #[wasm_bindgen_test]
+    async fn enter_with_active_row_invokes_on_select_not_on_submit() {
+        let results = vec![
+            fixture_result("m-0", "first hit", 30_000),
+            fixture_result("m-1", "second hit", 20_000),
+            fixture_result("m-2", "third hit", 10_000),
+        ];
+        let (container, submitted, selected) = mount_input_with(results, "hit", 1);
+        tick().await;
+
+        let input = query(&container, ".search-input").expect("search input mounted");
+        dispatch_keydown(&input, "Enter");
+        tick().await;
+
+        // The bug: Enter was routing to on_submit("hit") instead of the
+        // row activation path.
+        let submits = submitted.lock().unwrap();
+        assert!(
+            submits.is_empty(),
+            "Enter with a highlighted row must NOT push to recents \
+             (got submits: {:?})",
+            *submits
+        );
+        drop(submits);
+
+        let picks = selected.lock().unwrap();
+        assert_eq!(
+            picks.len(),
+            1,
+            "Enter with a highlighted row must invoke on_select exactly once"
+        );
+        assert_eq!(
+            picks[0].message_id, "m-1",
+            "on_select must receive the row at active_index (1), not the first row"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    async fn enter_with_no_results_falls_back_to_on_submit() {
+        let (container, submitted, selected) = mount_input_with(Vec::new(), "nothing", 0);
+        tick().await;
+
+        let input = query(&container, ".search-input").expect("search input mounted");
+        dispatch_keydown(&input, "Enter");
+        tick().await;
+
+        assert!(
+            selected.lock().unwrap().is_empty(),
+            "with zero results there is no row to activate; on_select must not fire"
+        );
+        assert_eq!(
+            submitted.lock().unwrap().as_slice(),
+            &["nothing".to_string()],
+            "with zero results Enter must fall through to the recents-push path"
+        );
+    }
+}
+
 // ── Foundation tokens (Phase 0) ─────────────────────────────────────────────
 //
 // Closes Task 14 of `docs/plans/2026-04-19-ui-phase-0-foundation.md`.

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -12087,3 +12087,105 @@ mod phase_2d_ephemeral_channels {
         assert_eq!(input.value(), "90", "must clamp at 90-day cap");
     }
 }
+
+// ── Issue #350: handler error reporting ─────────────────────────────────────
+//
+// `crates/web/src/handlers.rs` previously discarded every async-action
+// error with `let _ = ...`. The new `warn_and_toast_with` helper logs
+// via `tracing::warn!` and pushes an err toast onto the captured
+// `ToastStack` so the user gets feedback when send/edit/delete/react/
+// pin fails.
+//
+// We test the helper directly rather than driving a fake-failing
+// client through the closures: the handler closures are pinned to the
+// real `ClientHandle<IrohNetwork>` type and there's no trait seam to
+// inject a failing double. The helper *is* the production code path
+// that every handler now goes through (handlers capture the stack via
+// `use_context` outside their `spawn_local` block, then call
+// `warn_and_toast_with` from inside), so exercising it covers all 7
+// `let _ = h.<action>(...).await` sites.
+mod handler_error_toasts {
+    use super::*;
+    use willow_web::components::{ToastStack, ToastStackView};
+    use willow_web::handlers::warn_and_toast_with;
+
+    /// `warn_and_toast_with` pushes an `err` toast onto the supplied
+    /// `ToastStack` whose copy names the action that failed. Without
+    /// this, action handlers would still be silently dropping errors.
+    #[wasm_bindgen_test]
+    async fn warn_and_toast_with_pushes_err_toast() {
+        let stack = ToastStack::new();
+        let stack_for_mount = stack.clone();
+        let container = mount_test(move || {
+            provide_context(stack_for_mount.clone());
+            view! { <ToastStackView/> }
+        });
+
+        // No toasts yet.
+        tick().await;
+        assert_eq!(query_all(&container, ".toast").len(), 0);
+
+        // Simulate a handler failure. Any `Debug`-able error stands in
+        // for the real `anyhow::Error` the production handlers pass
+        // through.
+        warn_and_toast_with("send message", &"boom", Some(&stack));
+        tick().await;
+
+        let toasts = query_all(&container, ".toast");
+        assert_eq!(
+            toasts.len(),
+            1,
+            "warn_and_toast_with must push exactly one toast"
+        );
+        let t = &toasts[0];
+        assert_eq!(
+            t.get_attribute("role").as_deref(),
+            Some("alert"),
+            "err severity routes to assertive aria-live (role=alert)"
+        );
+        let title = t
+            .query_selector(".toast-title")
+            .unwrap()
+            .expect("toast title element");
+        let title_text = text(&title);
+        assert!(
+            title_text.contains("send message"),
+            "toast title must name the failed action. got: {title_text:?}"
+        );
+    }
+
+    /// Two failures of the same action coalesce via the `dedup` key —
+    /// the user sees a single err toast updated in place rather than
+    /// a stack of identical entries piling up if the network flaps.
+    #[wasm_bindgen_test]
+    async fn warn_and_toast_with_dedups_per_action() {
+        let stack = ToastStack::new();
+        let stack_for_mount = stack.clone();
+        let container = mount_test(move || {
+            provide_context(stack_for_mount.clone());
+            view! { <ToastStackView/> }
+        });
+        tick().await;
+
+        warn_and_toast_with("send message", &"first", Some(&stack));
+        warn_and_toast_with("send message", &"second", Some(&stack));
+        tick().await;
+
+        let toasts = query_all(&container, ".toast");
+        assert_eq!(
+            toasts.len(),
+            1,
+            "two failures of the same action must coalesce, not stack"
+        );
+    }
+
+    /// When the supplied stack is `None` (early boot, stripped-down
+    /// test harness), `warn_and_toast_with` must still log without
+    /// panicking. The toast push is a best-effort surface; the
+    /// `tracing::warn!` is the load-bearing record.
+    #[wasm_bindgen_test]
+    async fn warn_and_toast_with_no_stack_does_not_panic() {
+        warn_and_toast_with("send message", &"boom", None);
+        tick().await;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       context: .
       dockerfile: docker/web.Dockerfile
     ports:
-      - "${WILLOW_WEB_PORT:-8080}:80"
+      - "${WILLOW_WEB_PORT:-8080}:8080"
     depends_on:
       - relay
     restart: unless-stopped

--- a/docker/relay.Dockerfile
+++ b/docker/relay.Dockerfile
@@ -4,9 +4,13 @@ COPY . .
 RUN cargo build --release -p willow-relay
 
 FROM rust:slim
+RUN useradd -r -u 10001 -m -d /home/willow willow \
+    && mkdir -p /etc/willow /shared \
+    && chown -R willow:willow /etc/willow /shared
 COPY --from=builder /build/target/release/willow-relay /usr/local/bin/willow-relay
-COPY docker/relay-entrypoint.sh /entrypoint.sh
+COPY --chown=willow:willow docker/relay-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+USER willow
 EXPOSE 9090 9091
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/replay.Dockerfile
+++ b/docker/replay.Dockerfile
@@ -4,8 +4,12 @@ COPY . .
 RUN cargo build --release -p willow-replay
 
 FROM rust:slim
+RUN useradd -r -u 10001 -m -d /home/willow willow \
+    && mkdir -p /etc/willow \
+    && chown -R willow:willow /etc/willow
 COPY --from=builder /build/target/release/willow-replay /usr/local/bin/willow-replay
-COPY docker/replay-entrypoint.sh /entrypoint.sh
+COPY --chown=willow:willow docker/replay-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+USER willow
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/storage.Dockerfile
+++ b/docker/storage.Dockerfile
@@ -4,8 +4,12 @@ COPY . .
 RUN cargo build --release -p willow-storage
 
 FROM rust:slim
+RUN useradd -r -u 10001 -m -d /home/willow willow \
+    && mkdir -p /etc/willow /var/lib/willow \
+    && chown -R willow:willow /etc/willow /var/lib/willow
 COPY --from=builder /build/target/release/willow-storage /usr/local/bin/willow-storage
-COPY docker/storage-entrypoint.sh /entrypoint.sh
+COPY --chown=willow:willow docker/storage-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+USER willow
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /build
 COPY . .
 RUN cd crates/web && trunk build --release
 
-FROM nginx:alpine
-COPY --from=builder /build/crates/web/dist/ /usr/share/nginx/html/
+FROM nginxinc/nginx-unprivileged:alpine
+COPY --from=builder --chown=nginx:nginx /build/crates/web/dist/ /usr/share/nginx/html/
 RUN chmod 644 /usr/share/nginx/html/*
-EXPOSE 80
+
+USER nginx
+EXPOSE 8080


### PR DESCRIPTION
auto-fix batch run. sub-PRs target this branch. merge master PR → all linked issues auto-close.

## Resolved

- Fixes #406 — Enter activates highlighted search row (sub-PR #433)
- Fixes #314 — drop root in Dockerfiles, run as willow uid 10001 (sub-PR #434)
- Fixes #324 — platform-aware worker default paths via `dirs` (sub-PR #439)
- Fixes #240 — typed `Permission` on `SetPermission` + `Role.permissions` (sub-PR #440)
- Fixes #355 — plumb `has_image` / `has_file` into search index (sub-PR #442; `letter_id` parked as #441)
- Fixes #350 — toast + log on UI handler failures (sub-PR #443)

## Skill Evolution

Three commits land lessons + reviewer feedback into `.claude/skills/resolving-issues/SKILL.md`:

- `95d007f` — initial lessons (session-open commit, sub-PR CI gating, scope-creep guard, merge gate, in-PR skill edits).
- `37988dd` — master PR opens at end of run (ready, not draft); automated complexity gate triggers `superpowers:brainstorming` + `superpowers:writing-plans` for non-trivial fixes.
- `db74ac3` — **always ship what landed**, blockers → follow-up issues, sub-PR closed (not draft-parked). Next scheduled run picks up the follow-up issue from the queue. **No in-session continuation** — sessions don't get resumed; the issue queue is the only durable handoff. Master PR body gains `## Parked` section when any rows blocked.

## Lessons Learned

what worked:
- caveman `--scope` filter early kept dispatch to obvious-fix issues. zero scope-creep flame-outs across 6 sub-PRs.
- empty session-open commit unblocked branch creation w/o waiting for first sub-PR. cheap, no downside. now codified.
- implementer-side local `cargo fmt`+clippy+test substitute fine when sub-PR base ≠ main suppresses CI workflows. master PR (base=main, opened at end of run) re-runs full CI before human merge — catches anything stale. now codified.
- "park follow-up issue" pattern (#441 letter_id) kept #355 small. follow-up issue link in sub-PR body = clear audit trail.

what didn't:
- skill said implementer merges sub-PR on green CI. but sub-PR CI never runs when base ≠ main. last implementer (#443) interpreted "no CI = don't merge" + parked open. coordinator merged after verifying local checks. now codified: local `just check` IS the gate when CI doesn't run.
- one implementer (#240) widened scope to also retype `Role.permissions: BTreeSet<String>` → `BTreeSet<Permission>`. justified (root cause) but ballooned 10 files / 299+ LOC. now codified: complexity gate (step 3) + scope-creep guard (step 6) require brainstorm checkpoint before pushing.
- this PR was opened as draft mid-run — reviewer flagged risk of accidental merge. fix: branch only mid-run, ready PR at end (commit `37988dd`).
- early skill draft kept "park as draft sub-PR" pattern for blocks — reviewer flagged session-resume risk. fix: file follow-up issue + close sub-PR, next run picks it up (commit `db74ac3`). issue queue is the durable handoff, no chasing sessions.
- implementer prompts duplicated boilerplate. follow-up: extract a shared `## Implementer Boilerplate` section in next iteration if it bites again.

