### PR TITLE
chore(docker): drop root, run containers as willow user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       context: .
       dockerfile: docker/web.Dockerfile
     ports:
-      - "${WILLOW_WEB_PORT:-8080}:80"
+      - "${WILLOW_WEB_PORT:-8080}:8080"
     depends_on:
       - relay
     restart: unless-stopped

--- a/docker/relay.Dockerfile
+++ b/docker/relay.Dockerfile
@@ -4,9 +4,13 @@ COPY . .
 RUN cargo build --release -p willow-relay
 
 FROM rust:slim
+RUN useradd -r -u 10001 -m -d /home/willow willow \
+    && mkdir -p /etc/willow /shared \
+    && chown -R willow:willow /etc/willow /shared
 COPY --from=builder /build/target/release/willow-relay /usr/local/bin/willow-relay
-COPY docker/relay-entrypoint.sh /entrypoint.sh
+COPY --chown=willow:willow docker/relay-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+USER willow
 EXPOSE 9090 9091
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/replay.Dockerfile
+++ b/docker/replay.Dockerfile
@@ -4,8 +4,12 @@ COPY . .
 RUN cargo build --release -p willow-replay
 
 FROM rust:slim
+RUN useradd -r -u 10001 -m -d /home/willow willow \
+    && mkdir -p /etc/willow \
+    && chown -R willow:willow /etc/willow
 COPY --from=builder /build/target/release/willow-replay /usr/local/bin/willow-replay
-COPY docker/replay-entrypoint.sh /entrypoint.sh
+COPY --chown=willow:willow docker/replay-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+USER willow
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/storage.Dockerfile
+++ b/docker/storage.Dockerfile
@@ -4,8 +4,12 @@ COPY . .
 RUN cargo build --release -p willow-storage
 
 FROM rust:slim
+RUN useradd -r -u 10001 -m -d /home/willow willow \
+    && mkdir -p /etc/willow /var/lib/willow \
+    && chown -R willow:willow /etc/willow /var/lib/willow
 COPY --from=builder /build/target/release/willow-storage /usr/local/bin/willow-storage
-COPY docker/storage-entrypoint.sh /entrypoint.sh
+COPY --chown=willow:willow docker/storage-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+USER willow
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /build
 COPY . .
 RUN cd crates/web && trunk build --release
 
-FROM nginx:alpine
-COPY --from=builder /build/crates/web/dist/ /usr/share/nginx/html/
+FROM nginxinc/nginx-unprivileged:alpine
+COPY --from=builder --chown=nginx:nginx /build/crates/web/dist/ /usr/share/nginx/html/
 RUN chmod 644 /usr/share/nginx/html/*
-EXPOSE 80
+
+USER nginx
+EXPOSE 8080


### PR DESCRIPTION
## what

container ran as root. bad. now run as willow.

## how

- relay/replay/storage Dockerfiles: `useradd -r -u 10001 willow`, mkdir + chown `/etc/willow`, `/shared` (relay), `/var/lib/willow` (storage), `USER willow` before ENTRYPOINT.
- web Dockerfile: swap `nginx:alpine` -> `nginxinc/nginx-unprivileged:alpine` (uid 101, listens 8080 by default). docker-compose maps host:container 8080:8080.
- entrypoint scripts already mkdir writable dirs at runtime; willow owns them, no permission errors.
- ports stay non-privileged: relay 9090/9091, web 8080.

## verify

```
$ grep -L '^USER ' docker/*.Dockerfile
(empty)
```

docker daemon not reachable in this sandbox so live `docker build` skipped. relying on master PR CI for full image build smoke. no Rust code changed so `just check` unaffected.

## tradeoff

picked `nginxinc/nginx-unprivileged` over patching nginx config to listen on 8080 + chown html dir. one-line image swap, upstream-maintained, no custom config drift. runner-up rejected: more files to maintain for same outcome.

Refs #314

https://claude.ai/code/session_016cmtqT7yEQUgjcLgz4pARP

---
_Generated by [Claude Code](https://claude.ai/code/session_016cmtqT7yEQUgjcLgz4pARP)_