### PR TITLE
docs(web): SAFETY comment for DerivedStateActor

### DIFF
--- a/crates/web/src/state_bridge.rs
+++ b/crates/web/src/state_bridge.rs
@@ -84,6 +84,17 @@ impl<T: Send + Sync + 'static, U: PartialEq + Clone + Send + Sync + 'static> Han
     }
 }
 
+// SAFETY: All four fields are Send under the `T: Send + Sync` and `U: Send + Sync`
+// bounds on the impl: `StateRef<T>` and `Arc<Mutex<Option<U>>>` propagate Send from
+// their parameters, `Arc<dyn Fn(&T) -> U + Send + Sync>` is Send by its trait object
+// bound, and `SendWrapper<WriteSignal<U>>` is unconditionally Send with a runtime
+// panic on cross-thread access. The actor framework requires `Send` for spawning
+// across its mailbox, but the actor only ever runs on a single WASM thread (Leptos
+// is browser-only), so `SendWrapper`'s runtime check is never tripped. Manual impl
+// guards against future field additions silently breaking auto-derive — any new
+// `!Send` field must reaffirm or remove this assertion. Tracked alongside the
+// `cached` Mutex follow-up in
+// docs/specs/2026-04-26-state-management-model-design.md § Follow-up F2.
 unsafe impl<T: Send + Sync + 'static, U: PartialEq + Clone + Send + Sync + 'static> Send
     for DerivedStateActor<T, U>
 {


### PR DESCRIPTION
## Why

Audit AUD-1: bare `unsafe impl Send` on `DerivedStateActor` no SAFETY comment. Future maintainer no clue if impl redundant or load-bearing.

## Fix

- Add `// SAFETY:` block above `unsafe impl Send` in `crates/web/src/state_bridge.rs`.
- Comment walks four fields: `StateRef<T>` Send via params, `Arc<dyn Fn ... + Send + Sync>` Send via trait-object bound, `Arc<Mutex<Option<U>>>` Send via params, `SendWrapper<WriteSignal<U>>` unconditional Send w/ runtime cross-thread panic.
- Calls out single-WASM-thread invariant (Leptos browser-only) so SendWrapper runtime check never trips.
- Link back to spec follow-up F2 (`docs/specs/2026-04-26-state-management-model-design.md`) since `cached` Mutex tracked there.
- Did NOT delete impl — kept as guard so future `!Send` field forces reaffirmation.

## Verify

- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` all pass
- [x] `cargo check --target wasm32-unknown-unknown` clean for all WASM crates

Refs #435

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9szFGL8fVVMtcAMy3Vjeg)_