### PR TITLE
fix(web): add CSP meta tag to index.html (#175)

### DIFF
--- a/crates/web/index.html
+++ b/crates/web/index.html
@@ -2,6 +2,30 @@
 <html lang="en" data-theme="dark">
 <head>
     <meta charset="utf-8">
+    <!--
+        Content-Security-Policy — see GitHub issue #175.
+
+        Directive notes:
+        * script-src includes 'wasm-unsafe-eval' so the Leptos WASM module can
+          execute. 'unsafe-eval' is also required today because several call
+          sites still use js_sys::eval() (theme bootstrap, focus helpers,
+          relay-URL probe). Removing it is tracked separately by issues #171
+          and #425; the CSP must not regress those code paths until then.
+        * style-src needs 'unsafe-inline' because the Leptos views render
+          inline style="…" attributes. Google Fonts is allow-listed because
+          foundation.css @imports the stylesheet from fonts.googleapis.com,
+          and the actual font files are fetched from fonts.gstatic.com
+          (font-src).
+        * connect-src permits ws:/wss: for the relay WebSocket transport
+          (ws://localhost in dev, wss://… in production) and https: for the
+          relay's /bootstrap-id HTTP endpoint.
+        * img-src and media-src include data:/blob: so that avatar data
+          URIs and runtime URL.createObjectURL blobs (file attachments,
+          inline media) render. frame-ancestors 'none' blocks clickjacking;
+          base-uri / form-action / object-src lock down the remaining
+          injection surfaces.
+    -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' ws: wss: https:; img-src 'self' data: blob:; media-src 'self' blob:; worker-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/crates/web/tests/static_assets.rs
+++ b/crates/web/tests/static_assets.rs
@@ -112,6 +112,53 @@ fn index_html_only_references_bundled_svg_icons() {
     assert_all_in_allow_list("index.html", &refs);
 }
 
+/// Required directives for the CSP meta tag baked into `index.html`.
+///
+/// Each entry is a substring search against the meta tag's `content` value;
+/// they collectively encode the policy decisions described in the inline
+/// HTML comment beside the tag (see GitHub issue #175). If you intentionally
+/// loosen or tighten one of these directives, update both this list and the
+/// inline comment so the rationale stays in sync.
+const REQUIRED_CSP_DIRECTIVES: &[&str] = &[
+    "default-src 'self'",
+    // WASM module + the still-extant js_sys::eval() sites (tracked by
+    // issues #171 / #425). Drop 'unsafe-eval' once those are gone.
+    "script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval'",
+    // Inline style="…" attrs from Leptos views + Google Fonts CSS @import.
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' https://fonts.gstatic.com",
+    // ws/wss for relay transport, https for the relay HTTP bootstrap probe.
+    "connect-src 'self' ws: wss: https:",
+    // data: for avatar URIs, blob: for runtime createObjectURL attachments.
+    "img-src 'self' data: blob:",
+    "media-src 'self' blob:",
+    "worker-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+];
+
+#[test]
+fn index_html_declares_content_security_policy() {
+    let contents = read_asset("index.html");
+    let needle = "http-equiv=\"Content-Security-Policy\"";
+    assert!(
+        contents.contains(needle),
+        "index.html is missing the Content-Security-Policy meta tag. \
+         See GitHub issue #175 — the CSP guards against script injection \
+         and clickjacking and must stay in the document head.",
+    );
+    for directive in REQUIRED_CSP_DIRECTIVES {
+        assert!(
+            contents.contains(directive),
+            "index.html CSP is missing required directive `{directive}`. \
+             Update both the meta tag in index.html and the rationale \
+             comment beside it if you are intentionally changing this.",
+        );
+    }
+}
+
 #[test]
 fn manifest_json_only_references_bundled_svg_icons() {
     let contents = read_asset("manifest.json");


### PR DESCRIPTION
## What

Add `<meta http-equiv="Content-Security-Policy">` tag to `crates/web/index.html`. Tighten the document head against script injection + clickjacking. Includes a `static_assets` test that pins the required directives so any future drift trips a test.

## Why

`crates/web/index.html` ship with no CSP. Issue #175. Any reflected-script bug currently has full DOM authority.

## Directives

```
default-src 'self';
script-src 'self' 'wasm-unsafe-eval' 'unsafe-eval';
style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
font-src 'self' https://fonts.gstatic.com;
connect-src 'self' ws: wss: https:;
img-src 'self' data: blob:;
media-src 'self' blob:;
worker-src 'self';
object-src 'none';
base-uri 'self';
form-action 'self';
frame-ancestors 'none'
```

Verified each directive against the actual app:

- `'wasm-unsafe-eval'` — Leptos WASM module needs it.
- `'unsafe-eval'` — **NOT** in the issue body, but the codebase still has live `js_sys::eval()` call sites in `crates/web/src/app.rs` (theme bootstrap, focus helpers, relay-URL probe) and `crates/web/src/main.rs` (service-worker register). Removing them is the scope of #171 / WS-1 (#425). Dropping `'unsafe-eval'` here would regress those code paths today, so I kept it and documented the link to #171 inline. Drop it once eval is gone.
- `'unsafe-inline'` for styles — Leptos views render lots of inline `style="…"` attrs (member list, message colors, settings tabs, profile popovers, …). Tightening to nonces is a separate refactor.
- Google Fonts hosts — `crates/web/foundation.css` line 15 `@import url('https://fonts.googleapis.com/css2?…')`. Fonts themselves come from `fonts.gstatic.com`.
- `connect-src ws: wss: https:` — relay WebSocket transport (`ws://localhost:9091` dev / `wss://willow.intendednull.com:9443` prod) + the `/bootstrap-id` HTTP probe in `bootstrap_id_url()`.
- `img-src data:` — base64 avatar data URIs in `message.rs:784`.
- `blob:` (img + media + default fallback) — `web_sys::Url::create_object_url_with_blob` for file-attachment downloads (`message.rs:78`) and the chime audio in `audio.rs`.
- `worker-src 'self'` — service-worker registration via `navigator.serviceWorker.register('/sw.js')` in `main.rs`.
- `frame-ancestors 'none'` / `object-src 'none'` / `base-uri 'self'` / `form-action 'self'` — straight clickjacking + injection lockdown.

## Tradeoffs

- **`'unsafe-eval'` kept.** Issue body asked for it to be excluded. Excluding it today breaks the app because `js_sys::eval()` is still in use — locking down the policy must not regress functionality. Inline comment + commit body link this to #171 / #425 so the followup is obvious.
- **`'unsafe-inline'` kept for styles.** Issue suggested tightening with nonces later. Trunk doesn't currently emit nonces, and Leptos inline styles are pervasive — out of scope here.
- **Google Fonts allow-listed.** Could be removed by self-hosting the font files; that's a separate change. Keeping the network request unblocked here.

## Verification

- `cargo fmt --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — all green; new `index_html_declares_content_security_policy` test passes alongside the rest of `crates/web/tests/static_assets.rs`.
- `cargo check --target wasm32-unknown-unknown -p willow-identity -p willow-state -p willow-messaging -p willow-crypto -p willow-transport -p willow-common -p willow-network -p willow-client -p willow-web` — clean.
- Live `just dev` + agent-browser smoke not run — sandboxed env had no `just` binary and toolchain reinstall was already needed; the static-asset test pins the meta tag survives `trunk build` (it reads from `crates/web/index.html` which trunk passes through verbatim).

Refs #175

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLnKLASSbdatEpu7vGTS93)_