### PR TITLE
fix(crypto): add RatchetCache::clear() for explicit key eviction (#178)

### DIFF
--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -597,6 +597,19 @@ impl RatchetCache {
         self.ratchet_states.remove(&epoch);
     }
 
+    /// Drop every cached message key and saved ratchet state.
+    ///
+    /// Call this on sign-out, server-leave, or any other identity-bound
+    /// teardown so derived [`ChannelKey`] material does not linger in
+    /// process memory longer than necessary. Both [`ChannelKey`] and
+    /// [`KeyRatchet`] implement [`zeroize::ZeroizeOnDrop`], so removing
+    /// them from the underlying maps wipes their secret material before
+    /// the allocation is freed.
+    pub fn clear(&mut self) {
+        self.cache.clear();
+        self.ratchet_states.clear();
+    }
+
     /// Number of entries currently in the cache.
     pub fn len(&self) -> usize {
         self.cache.len()
@@ -1178,6 +1191,56 @@ mod tests {
         let fresh = cache.derive_or_cached(&key, 0, 5);
         let direct = derive_message_key(&key, 0, 5);
         assert_eq!(fresh.as_bytes(), direct.as_bytes());
+    }
+
+    /// `clear()` must wipe both the message-key cache and the saved
+    /// per-epoch ratchet state. Issue #178: without explicit eviction,
+    /// derived `ChannelKey` material lingered in `RatchetCache` past the
+    /// point where the owning identity / server context was torn down.
+    #[test]
+    fn ratchet_cache_clear_drops_all_state() {
+        let key = generate_channel_key();
+        let mut cache = RatchetCache::new(128);
+
+        // Populate multiple epochs so both `cache` and `ratchet_states`
+        // pick up entries.
+        let _ = cache.derive_or_cached(&key, 0, 5);
+        let _ = cache.derive_or_cached(&key, 1, 7);
+        let _ = cache.derive_or_cached(&key, 2, 3);
+
+        assert!(!cache.is_empty(), "cache should be populated before clear");
+        assert!(!cache.ratchet_states.is_empty());
+
+        cache.clear();
+
+        assert!(cache.is_empty(), "clear() must empty the message-key cache");
+        assert_eq!(cache.len(), 0);
+        assert!(
+            cache.ratchet_states.is_empty(),
+            "clear() must also drop saved ratchet states"
+        );
+
+        // The cache must remain functional after clear(): derivations
+        // still produce correct keys (matching `derive_message_key`),
+        // proving we did not corrupt the cache, only emptied it.
+        let post = cache.derive_or_cached(&key, 0, 5);
+        let direct = derive_message_key(&key, 0, 5);
+        assert_eq!(
+            post.as_bytes(),
+            direct.as_bytes(),
+            "cache must remain usable after clear()"
+        );
+    }
+
+    /// `clear()` on an already-empty cache is a no-op (idempotent).
+    #[test]
+    fn ratchet_cache_clear_is_idempotent() {
+        let mut cache = RatchetCache::new(64);
+        assert!(cache.is_empty());
+        cache.clear();
+        assert!(cache.is_empty());
+        cache.clear();
+        assert!(cache.is_empty());
     }
 
     /// The cache must not grow beyond `max_entries`.


### PR DESCRIPTION
## What

Add `pub fn clear(&mut self)` to `RatchetCache`. Empty `cache` map. Empty `ratchet_states` map. ChannelKey ZeroizeOnDrop, KeyRatchet ZeroizeOnDrop. BTreeMap::clear + HashMap::clear drop each value in place. Secret bytes zero before bucket release. Issue #178 want explicit eviction. Now exist.

Two unit tests added:
- `ratchet_cache_clear_drops_all_state` — populate three epochs, call clear(), check both maps empty, check cache still usable for fresh derive.
- `ratchet_cache_clear_is_idempotent` — clear empty cache no panic, repeat ok.

## Brainstorm — wiring point

Task say "wire clear() into channel-leave / server-disconnect — adding method nobody call is theatre".

Look. RatchetCache not used outside crypto crate own tests. `derive_or_cached` zero call sites in client/web/messaging. Production decrypt path (`open_content`) not consult cache. Cache is API surface waiting integration.

**Chosen wiring point:** none today. Method exist + documented. Filed follow-up #468 so integrator wire clear() into `leave_server` + sign-out when cache lands in client decrypt path.

**Runner-up rejected:** Speculatively integrate RatchetCache into client decrypt flow now, then wire teardown. Rejected because (a) scope creep beyond #178, (b) ratchet caching is perf/correctness change distinct from this cleanup work, (c) task warn don't balloon to refactor.

**Note on existing key map:** `HashMap<String, ChannelKey>` in `crates/client/src/state_actors.rs` ServerEntry hold actual production channel keys. `leave_server` already remove ServerEntry — that drop the map — that drop each ChannelKey — ZeroizeOnDrop fire. Path safe today. No change needed.

## Verification

- `cargo test -p willow-crypto`: 64 passed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo check --target wasm32-unknown-unknown -p willow-crypto -p willow-client`: clean
- `cargo fmt --check`: clean
- `cargo test --workspace`: passed except `willow-actor::send_dead_actor_returns_send_error` flaky pre-existing (unrelated, passes in isolation)

## Tradeoffs

Skipped client-tier test asserting cache.len()==0 after sign-out: cache not yet owned by client, no fixture exist. Unit test cover the contract. Follow-up #468 cover integration test when wire-up land.

Refs #178

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLnKLASSbdatEpu7vGTS93)_