### PR TITLE
chore: prune #[allow(dead_code)] cluster (#327)

### DIFF
--- a/crates/actor/src/fsm.rs
+++ b/crates/actor/src/fsm.rs
@@ -215,7 +215,10 @@ mod tests {
     struct StrictDoor;
 
     #[derive(Debug, Clone, PartialEq)]
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "Open variant exists for completeness; tests start in Closed and assert StrictDoor rejects further transitions."
+    )]
     enum DoorState {
         Open,
         Closed,

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -45,14 +45,6 @@ fn detect_platform() -> &'static str {
     }
 }
 
-#[allow(dead_code)]
-pub fn toggle_theme() {
-    js_sys::eval(
-        r#"var h=document.documentElement;var c=h.getAttribute('data-theme')||'dark';var n=c==='dark'?'light':'dark';h.setAttribute('data-theme',n);localStorage.setItem('willow-theme',n);"#,
-    )
-    .ok();
-}
-
 /// How many milliseconds to wait before clearing the loading state automatically.
 const LOADING_TIMEOUT_MS: u32 = 5_000;
 

--- a/crates/web/src/components/mobile_shell.rs
+++ b/crates/web/src/components/mobile_shell.rs
@@ -60,7 +60,6 @@ impl MobileTab {
 /// Full-screen pushes that can be stacked over a primary tab. Each
 /// push hides the tab bar and renders translated in from the right.
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[allow(dead_code)]
 pub enum MobilePush {
     /// Channel chat view (name = channel id).
     Channel(String),

--- a/crates/web/src/palette_recents.rs
+++ b/crates/web/src/palette_recents.rs
@@ -61,7 +61,6 @@ pub fn push(entry: Recent) {
 }
 
 /// Clear all recents.
-#[allow(dead_code)]
 pub fn clear() {
     if let Some(s) = storage() {
         let _ = s.remove_item(KEY);

--- a/crates/web/src/state.rs
+++ b/crates/web/src/state.rs
@@ -358,9 +358,7 @@ pub struct ChatWriteSignals {
     pub set_channels: WriteSignal<Vec<String>>,
     pub set_replying_to: WriteSignal<Option<DisplayMessage>>,
     pub set_editing: WriteSignal<Option<DisplayMessage>>,
-    #[allow(dead_code)]
     pub set_pinned_messages: WriteSignal<Vec<DisplayMessage>>,
-    #[allow(dead_code)]
     pub set_pin_labels: WriteSignal<HashMap<String, String>>,
     pub set_channel_views: WriteSignal<HashMap<String, ChannelViewState>>,
 }

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -42,7 +42,6 @@ where
 /// [`mount_test_with_shell`] to pin the choice via a `data-shell`
 /// attribute on `<html>`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum TestShell {
     Desktop,
     Mobile,
@@ -54,7 +53,6 @@ pub enum TestShell {
 /// `.shell-desktop` / `.shell-mobile` visibility on that attribute
 /// when present (falls back to the viewport media query when the
 /// attribute is absent).
-#[allow(dead_code)]
 pub fn mount_test_with_shell<F, V>(shell: TestShell, view: F) -> web_sys::HtmlElement
 where
     F: FnOnce() -> V + 'static,
@@ -80,7 +78,6 @@ where
 /// does not pull in the app's CSS via `index.html`; without this, every
 /// element keeps its UA-default `display` and the shell override cannot
 /// be observed.
-#[allow(dead_code)]
 fn ensure_components_css_loaded(doc: &web_sys::Document) {
     const STYLE_ID: &str = "willow-test-components-css";
     if doc.get_element_by_id(STYLE_ID).is_some() {
@@ -5771,7 +5768,6 @@ mod notifications {
 /// `mobile_actions`). Each group used to carry its own copies of
 /// `click_selector` / `fill_selector` / etc.; they are hoisted here so
 /// new modules can reuse them without duplication.
-#[allow(dead_code)]
 mod test_support {
     use super::*;
     use willow_web::app::App;


### PR DESCRIPTION
audit #327 listed 13 dead_code annotations. count drifted to 10 (storage.rs gone, 2 web sites already cleaned).

## actions per site

**delete (genuinely unused):**
- `crates/web/src/app.rs::toggle_theme` — fn never called. theme toggling routes through `palette_actions::on_toggle_theme` Callback.

**remove redundant annotation (symbol IS used):**
- `crates/web/src/palette_recents.rs::clear` — used in browser test fixtures (`tests/browser.rs:5043, 5066`).
- `crates/web/tests/browser.rs::TestShell` enum — used by every flow test via `mount_app_fresh`.
- `crates/web/tests/browser.rs::mount_test_with_shell` — used 30+ times throughout browser.rs.
- `crates/web/tests/browser.rs::ensure_components_css_loaded` — called by `mount_test_with_shell` + `test_support::ensure_app_css`.
- `crates/web/tests/browser.rs::mod test_support` — used by basic_flow, mobile_ux, mobile_actions modules.
- `crates/web/src/state.rs::ChatWriteSignals::set_pinned_messages` — used in state.rs:952 (Effect feeds pinned signal).
- `crates/web/src/state.rs::ChatWriteSignals::set_pin_labels` — fed by struct init only, but masked by crate-wide `#![allow(dead_code)]` in willow-web — per-field annotation was always redundant.
- `crates/web/src/components/mobile_shell.rs::MobilePush` — Channel/Thread/Call/Onboarding all match-bound; Thread/Call/Onboarding planned per `docs/plans/2026-04-20-ui-phase-1b-mobile-shell.md`. no warning fires.

**keep with `reason`:**
- `crates/actor/src/fsm.rs::DoorState::Open` — `StrictDoor` test fixture starts in `Closed` and asserts further transitions are rejected. `Open` exists for completeness in the enum but is never constructed; removing the annotation triggers `variant Open is never constructed`. Replaced with `#[allow(dead_code, reason = ...)]` (rust 1.81+).

## scope-creep guard

`willow-web/src/lib.rs` carries crate-wide `#![allow(dead_code)]`. that's masking 9 *other* dead symbols across 5 unrelated files (downgrade_banner, day_separator, nickname_store, trust_store). per coordinator's >5-files / >200-LOC guard, **left intact** — separate follow-up. that crate-wide allow also explains why some per-site annotations on willow-web items were no-ops; removing them is still correct hygiene since the crate-wide allow itself should eventually go.

## tradeoffs

runner-up for `MobilePush`: keep `#[allow(dead_code)]` since 3/4 variants never constructed. rejected because match arms on those variants count as use — no warning fires; annotation is misleading.

runner-up for `DoorState`: delete `Open` variant entirely. rejected because the enum's binary state models a real door and the `StrictDoor::transition` `match state` on `DoorState::Open => Ok(...)` arm is the readable rejection-path test surface; gutting it would force `_` arms or single-variant enums.

## verify

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --workspace` — all green (90 actor + 298 client + 227 state + ...)
- `cargo check --target wasm32-unknown-unknown -p willow-web --tests` — clean

Refs #327

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLnKLASSbdatEpu7vGTS93)_