### PR TITLE
refactor(web): rename ServerState/ChatState/VoiceState -> *Signals (#261)

### DIFF
--- a/crates/web/src/components/call_page.rs
+++ b/crates/web/src/components/call_page.rs
@@ -167,7 +167,7 @@ pub fn CallPage(
     let handle = use_context::<WebClientHandle>().unwrap();
     let vm = use_context::<VoiceManagerHandle>().unwrap();
 
-    // Local video stream — stored globally in VoiceState so it survives remounts.
+    // Local video stream — stored globally in VoiceSignals so it survives remounts.
     let local_video_stream = app_state.voice.local_video_stream;
 
     // Duration timer — increments every second. Clean up on unmount so

--- a/crates/web/src/state.rs
+++ b/crates/web/src/state.rs
@@ -81,11 +81,11 @@ pub struct ParsedJoinToken {
 
 #[derive(Clone, Copy)]
 pub struct AppState {
-    pub chat: ChatState,
+    pub chat: ChatSignals,
     pub network: NetworkState,
-    pub server: ServerState,
+    pub server: ServerSignals,
     pub ui: UiState,
-    pub voice: VoiceState,
+    pub voice: VoiceSignals,
     pub trust: TrustState,
     pub presence: PresenceUiState,
     /// Local-search UI state (phase 2e — `local-search.md`).
@@ -224,7 +224,7 @@ pub struct TrustState {
 }
 
 #[derive(Clone, Copy)]
-pub struct ChatState {
+pub struct ChatSignals {
     pub messages: ReadSignal<Vec<DisplayMessage>>,
     pub current_channel: ReadSignal<String>,
     pub channels: ReadSignal<Vec<String>>,
@@ -249,7 +249,7 @@ pub struct NetworkState {
 }
 
 #[derive(Clone, Copy)]
-pub struct ServerState {
+pub struct ServerSignals {
     pub servers: ReadSignal<Vec<(String, String)>>,
     pub active_server_id: ReadSignal<String>,
     pub active_server_name: ReadSignal<String>,
@@ -288,7 +288,7 @@ pub struct UiState {
 }
 
 #[derive(Clone, Copy)]
-pub struct VoiceState {
+pub struct VoiceSignals {
     pub voice_channel: ReadSignal<Option<String>>,
     pub voice_muted: ReadSignal<bool>,
     pub voice_deafened: ReadSignal<bool>,
@@ -590,7 +590,7 @@ pub fn create_signals() -> InitialSignals {
     let (profile_open, set_profile_open) = signal(Option::<crate::profile::ProfileState>::None);
 
     let app_state = AppState {
-        chat: ChatState {
+        chat: ChatSignals {
             messages,
             current_channel,
             channels,
@@ -608,7 +608,7 @@ pub fn create_signals() -> InitialSignals {
             connection_state,
             loading,
         },
-        server: ServerState {
+        server: ServerSignals {
             servers,
             active_server_id,
             active_server_name,
@@ -635,7 +635,7 @@ pub fn create_signals() -> InitialSignals {
             join_token,
             join_status,
         },
-        voice: VoiceState {
+        voice: VoiceSignals {
             voice_channel,
             voice_muted,
             voice_deafened,


### PR DESCRIPTION
## what

three web sidecar types had same name as authoritative state types:
- `web::state::ServerState` vs `willow_state::ServerState`
- `web::state::ChatState` vs `willow_client::state::ChatState`
- `web::state::VoiceState` vs `willow_client::state_actors::VoiceState`

spec say `willow_state::ServerState` is THE single source of truth. web sidecar holding Leptos signals shouldnt steal the name and confuse mental model.

## fix

rename web-side types to `*Signals` suffix. they hold `ReadSignal<...>` fields, so `Signals` describes what they are. mechanical find-replace, no surrounding refactor.

- `ServerState` -> `ServerSignals`
- `ChatState` -> `ChatSignals`
- `VoiceState` -> `VoiceSignals`

## callsites

10 rename touches across 2 files:
- `crates/web/src/state.rs` (def + use sites in `AppState` + `create_signals`)
- `crates/web/src/components/call_page.rs` (1 doc comment)

browser tests in `crates/web/tests/` had zero references. no foreign imports of these types existed.

`ServerState` comments in `settings.rs`, `holder_pill.rs`, `channel_sidebar.rs` left alone — they correctly point at `willow_state::ServerState` fields (`mute_state`, `channel_keys`), the authoritative type.

## verification

- `cargo check -p willow-web --target wasm32-unknown-unknown` green
- `cargo check -p willow-web --tests --target wasm32-unknown-unknown` green
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` zero warnings
- `cargo test --workspace` all pass

## why *Signals

runner-up was `ServerViewSignals` etc — rejected, unnecessarily verbose. `*Signals` already disambiguates from authoritative `*State`, and it describes the load-bearing trait of the type (Leptos signals).

Refs #261

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLnKLASSbdatEpu7vGTS93)_