### PR TITLE
fix(web): route component handler errors through warn_and_toast_with

### DIFF
--- a/crates/web/src/components/channel_sidebar.rs
+++ b/crates/web/src/components/channel_sidebar.rs
@@ -15,7 +15,7 @@ use leptos::prelude::*;
 use crate::app::WebClientHandle;
 use crate::components::{
     ConfirmDialog, ContextMenu, StatusDot, StatusDotBorder, StatusDotSize, TempChannelCreateForm,
-    VoiceControls, TEMP_DEFAULT_DAYS,
+    ToastStack, VoiceControls, TEMP_DEFAULT_DAYS,
 };
 use crate::icons;
 
@@ -185,13 +185,29 @@ pub fn ChannelSidebar(
                 } else if let Some(kind) = kind {
                     let h = handle_create.clone();
                     let name_owned = name.clone();
+                    // Capture toast stack on the outer reactive frame —
+                    // `spawn_local` strips the owner so `use_context`
+                    // inside the async block would return None.
+                    let toasts = use_context::<ToastStack>();
                     wasm_bindgen_futures::spawn_local(async move {
                         match kind {
                             willow_state::ChannelKind::Voice => {
-                                let _ = h.create_voice_channel(&name_owned).await;
+                                if let Err(e) = h.create_voice_channel(&name_owned).await {
+                                    crate::handlers::warn_and_toast_with(
+                                        "create voice channel",
+                                        &e,
+                                        toasts.as_ref(),
+                                    );
+                                }
                             }
                             _ => {
-                                let _ = h.create_channel(&name_owned).await;
+                                if let Err(e) = h.create_channel(&name_owned).await {
+                                    crate::handlers::warn_and_toast_with(
+                                        "create channel",
+                                        &e,
+                                        toasts.as_ref(),
+                                    );
+                                }
                             }
                         }
                     });
@@ -658,8 +674,15 @@ pub fn ChannelSidebar(
                 on_confirm=Callback::new(move |_| {
                     if let Some(name) = pending_del_channel.get_untracked() {
                         let h = handle_del_confirm.clone();
+                        let toasts = use_context::<ToastStack>();
                         wasm_bindgen_futures::spawn_local(async move {
-                            let _ = h.delete_channel(&name).await;
+                            if let Err(e) = h.delete_channel(&name).await {
+                                crate::handlers::warn_and_toast_with(
+                                    "delete channel",
+                                    &e,
+                                    toasts.as_ref(),
+                                );
+                            }
                         });
                     }
                     set_pending_del_channel.set(None);
@@ -974,8 +997,18 @@ fn render_channel_row(
                             let channel = name_for_mute.clone();
                             let h = handle.clone();
                             let target = !is_muted.get_untracked();
+                            // Capture toast stack on the outer reactive frame —
+                            // `spawn_local` strips the owner so `use_context`
+                            // inside the async block would return None.
+                            let toasts = use_context::<ToastStack>();
                             wasm_bindgen_futures::spawn_local(async move {
-                                let _ = h.mutate_channel_mute(&channel, target).await;
+                                if let Err(e) = h.mutate_channel_mute(&channel, target).await {
+                                    crate::handlers::warn_and_toast_with(
+                                        "mute channel",
+                                        &e,
+                                        toasts.as_ref(),
+                                    );
+                                }
                             });
                         }
                     >

--- a/crates/web/src/components/roles.rs
+++ b/crates/web/src/components/roles.rs
@@ -1,7 +1,7 @@
 use leptos::prelude::*;
 
 use crate::app::WebClientHandle;
-use crate::components::ConfirmDialog;
+use crate::components::{ConfirmDialog, ToastStack};
 use crate::state::AppState;
 
 /// List of all permission names that can be toggled on a role.
@@ -52,8 +52,14 @@ pub fn RoleManager(
         let name = name.trim().to_string();
         if !name.is_empty() {
             let h = handle_create.clone();
+            // Capture toast stack on the outer reactive frame —
+            // `spawn_local` strips the owner so `use_context` inside
+            // the async block would return None.
+            let toasts = use_context::<ToastStack>();
             wasm_bindgen_futures::spawn_local(async move {
-                let _ = h.create_role(&name).await;
+                if let Err(e) = h.create_role(&name).await {
+                    crate::handlers::warn_and_toast_with("create role", &e, toasts.as_ref());
+                }
             });
         }
         set_new_name.set(String::new());
@@ -197,6 +203,7 @@ pub fn RoleManager(
                                                         let h = hp_t.clone();
                                                         let rid = rid_t.clone();
                                                         let perm = perm_toggle.clone();
+                                                        let toasts = use_context::<ToastStack>();
                                                         wasm_bindgen_futures::spawn_local(async move {
                                                             // Names come from PERMISSION_NAMES which is
                                                             // kept in sync with willow_state::Permission;
@@ -204,7 +211,13 @@ pub fn RoleManager(
                                                             if let Some(parsed) =
                                                                 willow_state::Permission::from_name(&perm)
                                                             {
-                                                                let _ = h.set_permission(&rid, parsed, granted).await;
+                                                                if let Err(e) = h.set_permission(&rid, parsed, granted).await {
+                                                                    crate::handlers::warn_and_toast_with(
+                                                                        "set permission",
+                                                                        &e,
+                                                                        toasts.as_ref(),
+                                                                    );
+                                                                }
                                                             }
                                                         });
                                                     }
@@ -242,8 +255,15 @@ pub fn RoleManager(
                                                             if let Ok(eid) = pid.trim().parse::<willow_identity::EndpointId>() {
                                                                 let h = ha.clone();
                                                                 let r = rid.clone();
+                                                                let toasts = use_context::<ToastStack>();
                                                                 wasm_bindgen_futures::spawn_local(async move {
-                                                                    let _ = h.assign_role(eid, &r).await;
+                                                                    if let Err(e) = h.assign_role(eid, &r).await {
+                                                                        crate::handlers::warn_and_toast_with(
+                                                                            "assign role",
+                                                                            &e,
+                                                                            toasts.as_ref(),
+                                                                        );
+                                                                    }
                                                                 });
                                                             }
                                                             set_assign_peer.set(String::new());
@@ -287,8 +307,15 @@ pub fn RoleManager(
                 on_confirm=Callback::new(move |_| {
                     if let Some((rid, _)) = pending_del_role.get_untracked() {
                         let h = handle_del_confirm.clone();
+                        let toasts = use_context::<ToastStack>();
                         wasm_bindgen_futures::spawn_local(async move {
-                            let _ = h.delete_role(&rid).await;
+                            if let Err(e) = h.delete_role(&rid).await {
+                                crate::handlers::warn_and_toast_with(
+                                    "delete role",
+                                    &e,
+                                    toasts.as_ref(),
+                                );
+                            }
                         });
                     }
                     set_pending_del_role.set(None);

--- a/crates/web/src/components/settings.rs
+++ b/crates/web/src/components/settings.rs
@@ -2,7 +2,7 @@ use leptos::prelude::*;
 use willow_client::presence::{PresenceOverride, PresenceState};
 
 use crate::app::WebClientHandle;
-use crate::components::{RoleManager, StatusDot, StatusDotBorder, StatusDotSize};
+use crate::components::{RoleManager, StatusDot, StatusDotBorder, StatusDotSize, ToastStack};
 use crate::icons;
 use crate::state::{AppState, SettingsTab};
 use crate::util::copy_to_clipboard;
@@ -54,8 +54,18 @@ pub fn SettingsPanel(
         if !name.trim().is_empty() {
             let h = handle_save.clone();
             let name = name.trim().to_string();
+            // Capture toast stack on the outer reactive frame —
+            // `spawn_local` strips the owner so `use_context` inside
+            // the async block would return None.
+            let toasts = use_context::<ToastStack>();
             wasm_bindgen_futures::spawn_local(async move {
-                let _ = h.set_server_display_name(&name).await;
+                if let Err(e) = h.set_server_display_name(&name).await {
+                    crate::handlers::warn_and_toast_with(
+                        "set server display name",
+                        &e,
+                        toasts.as_ref(),
+                    );
+                }
             });
         }
         set_status_msg.set("Saved.".to_string());
@@ -435,8 +445,14 @@ fn NotificationsTabPlaceholder() -> impl IntoView {
             let target = !local_muted.get_untracked();
             set_local_muted.set(target);
             let h = handle.clone();
+            // Capture toast stack on the outer reactive frame —
+            // `spawn_local` strips the owner so `use_context` inside
+            // the async block would return None.
+            let toasts = use_context::<ToastStack>();
             wasm_bindgen_futures::spawn_local(async move {
-                let _ = h.mutate_grove_mute(target).await;
+                if let Err(e) = h.mutate_grove_mute(target).await {
+                    crate::handlers::warn_and_toast_with("mute server", &e, toasts.as_ref());
+                }
             });
         }
     };

--- a/crates/web/src/components/sync_queue_view.rs
+++ b/crates/web/src/components/sync_queue_view.rs
@@ -76,8 +76,14 @@ pub fn SyncQueueView() -> impl IntoView {
             busy.set(false);
             return;
         };
+        // Capture toast stack on the outer reactive frame —
+        // `spawn_local` strips the owner so `use_context` inside the
+        // async block would return None.
+        let toasts = use_context::<ToastStack>();
         wasm_bindgen_futures::spawn_local(async move {
-            let _ = h.retry_queue().await;
+            if let Err(e) = h.retry_queue().await {
+                crate::handlers::warn_and_toast_with("retry queue", &e, toasts.as_ref());
+            }
             busy.set(false);
         });
     };


### PR DESCRIPTION
## Summary
- Closes the propagation gap from PR #443 (which closed #350): 11 component-internal handlers still discarded `anyhow::Result<()>` from client mutations with `let _ = h.foo(...).await`, so failures vanished without a toast or warn-log.
- Migrates all 11 sites in `crates/web/src/components/{roles,settings,sync_queue_view,channel_sidebar}.rs` to capture `let toasts = use_context::<ToastStack>()` on the outer reactive frame and dispatch via `crate::handlers::warn_and_toast_with("<action>", &e, toasts.as_ref())` on `Err`.
- Action labels match handlers.rs precedent: `create role`, `set permission`, `assign role`, `delete role`, `set server display name`, `mute server`, `retry queue`, `create voice channel`, `create channel`, `delete channel`, `mute channel`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p willow-web --all-targets -- -D warnings`
- [x] `cargo test -p willow-web` (6 tests, all green)
- [x] `cargo check -p willow-web --target wasm32-unknown-unknown`
- [x] `cargo check --target wasm32-unknown-unknown -p willow-web --tests` (wasm-pack/Firefox not available in sandbox)
- [x] `rg -n 'let _ = h\.[a-z_]+\(.*\)\.await' crates/web/src/components/` → 0 hits (was 11)

Refs #476

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwHMv32nbXhkZYY1t2W9WF)_