### PR TITLE
auto-fix batch claude/friendly-maxwell-cVhhm (2026-04-30)

### DIFF
--- a/.claude/skills/resolving-issues/SKILL.md
+++ b/.claude/skills/resolving-issues/SKILL.md
@@ -47,7 +47,18 @@ Why this shape:
 3. Skip big features + major refactors. Out of scope.
 4. No in-scope issues? Noop. Skip the rest. No master branch created, no PR opened.
 5. Create fresh master branch (see ## Master Branch Setup).
-6. Per issue, sequential, max 10 per run:
+6. **Coordinator-direct already-fixed sweep (run BEFORE any implementer dispatch).** For each picked issue, before dispatching, scan recent merged commits + closing PRs against the issue's scope:
+   - `git log --oneline <last-audit-ref>..origin/main -- <relevant paths>` to find candidate fix commits
+   - `mcp__github__search_pull_requests` w/ issue keywords for closure-by-PR cases
+   - cross-check against recent general-audit master tickets ("verified fixed by ..." entries)
+   
+   If the issue is resolved by a landed change, do the close pass directly — no implementer dispatch:
+   - caveman comment on the issue citing the upstream commit / PR + the fix location
+   - close `completed` (audit intent now holds) or `not_planned` (audit premise moot)
+   - record under `## Already-Fixed` for master PR body
+   
+   Closing GH issues = metadata work, not code work; allowed under "coordinator never codes." Implementers only dispatch for *unresolved* issues. This pass typically clears audit lessons (already folded into skills), structural-deps follow-ups (still structural), and audit findings closed by intervening fixes — saves dispatch overhead on no-op work.
+7. Per remaining issue, sequential, max 10 per run:
    - **Pre-dispatch sync:** before spawning each implementer, in the coordinator's checkout:
      ```bash
      git fetch origin <master-branch>
@@ -56,11 +67,11 @@ Why this shape:
      Prior implementers' commits must be the implementer's base; stale local state poisons the next dispatch.
    - Spawn fresh implementer agent (see ## Implementer Agent below).
    - Implementer commits directly to master branch and pushes. No worktree, no sub-PR.
-   - Track `Fixes #N` for final PR body assembly. **Already-fixed-upstream** issues go under `## Already-Fixed`, not `Fixes`.
+   - Track `Fixes #N` for final PR body assembly.
    - Next issue.
-7. Implementer finds related rot? File follow-up issue.
-8. Apply Lessons Learned skill edits to `.claude/skills/resolving-issues/SKILL.md`, commit on master branch, push. (Coordinator does this directly — see ### Coordinator never codes.)
-9. Open the master PR — **ready (not draft)** — base `main`, head master branch. Body: `Fixes #N` list + `## Already-Fixed` + `## Parked` + `## Skill Evolution` + `## Lessons Learned`. Master PR runs full CI; human merges when satisfied. If anything's unfinished, leave the branch un-PR'd instead of opening a draft.
+8. Implementer finds related rot? File follow-up issue.
+9. Apply Lessons Learned skill edits to `.claude/skills/resolving-issues/SKILL.md`, commit on master branch, push. (Coordinator does this directly — see ### Coordinator never codes.)
+10. Open the master PR — **ready (not draft)** — base `main`, head master branch. Body: `Fixes #N` list + `## Already-Fixed` + `## Parked` + `## Skill Evolution` + `## Lessons Learned`. Master PR runs full CI; human merges when satisfied. If anything's unfinished, leave the branch un-PR'd instead of opening a draft.
 
 ## Implementer Agent
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
+          components: clippy
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -119,6 +120,8 @@ jobs:
           key: wasm-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: wasm-
       - run: cargo check --target wasm32-unknown-unknown --workspace --exclude willow-relay --exclude willow-worker --exclude willow-replay --exclude willow-storage --exclude willow-agent
+      - name: Clippy (wasm32, willow-web)
+        run: cargo clippy --target wasm32-unknown-unknown -p willow-web --all-targets -- -D warnings
 
   browser:
     name: Browser tests (wasm-pack + Firefox)

--- a/crates/web/src/components/message_row/day_separator.rs
+++ b/crates/web/src/components/message_row/day_separator.rs
@@ -111,8 +111,9 @@ pub fn day_bucket(ts_ms: u64) -> DayBucket {
     use wasm_bindgen::JsValue;
 
     // Out-of-range timestamps make `js_sys::Date` accessors return NaN;
-    // the `as i32` / `as u32` casts then collapse to 0, which would index
-    // into `WEEKDAYS`/`MONTHS` and produce a bogus "sunday · 0 january"
+    // the `as i32` cast (and the implicit `u32` return on `get_month` /
+    // `get_date`) then collapse to 0, which would index into
+    // `WEEKDAYS`/`MONTHS` and produce a bogus "sunday · 0 january"
     // label. Bail to a stable fallback variant instead.
     if ts_ms > MAX_VALID_TS_MS as u64 {
         return DayBucket::Older {
@@ -127,11 +128,11 @@ pub fn day_bucket(ts_ms: u64) -> DayBucket {
     let now = js_sys::Date::new_0();
 
     let ts_y = ts.get_full_year() as i32;
-    let ts_m = ts.get_month() as u32;
+    let ts_m = ts.get_month();
     let ts_d = ts.get_date();
 
     let now_y = now.get_full_year() as i32;
-    let now_m = now.get_month() as u32;
+    let now_m = now.get_month();
     let now_d = now.get_date();
 
     if (ts_y, ts_m, ts_d) == (now_y, now_m, now_d) {
@@ -152,7 +153,7 @@ pub fn day_bucket(ts_ms: u64) -> DayBucket {
         0,
     );
     let y_y = yesterday.get_full_year() as i32;
-    let y_m = yesterday.get_month() as u32;
+    let y_m = yesterday.get_month();
     let y_d = yesterday.get_date();
     if (ts_y, ts_m, ts_d) == (y_y, y_m, y_d) {
         return DayBucket::Yesterday;


### PR DESCRIPTION
## Fixes

- Fixes #497 — drop 3 redundant `as u32` casts on `js_sys::Date::get_month()` in `crates/web/src/components/message_row/day_separator.rs`; add `cargo clippy --target wasm32-unknown-unknown -p willow-web --all-targets -- -D warnings` step to existing `wasm` job in `.github/workflows/ci.yml` (Option 1 per issue, no extra job overhead). wasm-streams blocker not hit (clippy doesn't link). Commit `c9f1ba6`.

## Already-Fixed

resolved upstream before this run; coordinator-direct close pass (no implementer dispatch):

- #465 — `resolving-issues` skill rewrite eliminate sub-PR pattern. master PR opens against `main` direct, fire main-gated CI normal. no `pull_request.branches` glob change need.
- #426 — general-audit lessons fold into `.claude/skills/general-audit/SKILL.md` via `8d91a11`.
- #438 — same fold (`8d91a11`).
- #477 — same fold (`8d91a11`).
- #493 — same fold (`8d91a11`).
- #429 — LRU cap (10k) + TTL sweep (5s) on `ProfileState.names` + `NetworkMeta.typing_peers` ship in `1a9503f`. verified by general-audit @ `0de7631` (#492).

## Parked

none. all picked issues either shipped or already-fixed.

## Skill Evolution

`da21fed docs(skill): add coordinator-direct already-fixed sweep before dispatch` — promote already-fixed sweep to first pass in Core Loop. coordinator close stale audit / lessons issues directly via `mcp__github__add_issue_comment` + `mcp__github__issue_write`, no implementer dispatch. closing GH issues = metadata work, not code, allowed under "coordinator never codes". implementers only dispatch for *unresolved* issues. saves dispatch overhead on no-op work — this run, 6/7 picks would have been wasted dispatches.

## Lessons Learned

- **already-fixed dominate the queue.** 6 of 7 picks resolved upstream by recent commits. coordinator-direct sweep at start of Core Loop = high leverage. lesson now codified in skill.
- **`mcp__github__list_issues` token-cap.** 50 open issues exceed 192k char tool-result cap. saved-to-file fallback + jq work but slow. for >25-issue label, prefer `mcp__github__search_issues` w/ narrower query (already noted in lesson #5 of #493 / general-audit skill — applies here too).
- **scope filter held.** issues skipped: #468 (depends on RatchetCache integration not done), #186 (UI emoji-picker feature, large), #195 (refactor 7 components, design discussion), #102 (relay URL, design decisions), #441 (search index app-state shape, discussion).
- **wasm-clippy CI gate works.** clippy on `wasm32-unknown-unknown` does NOT link, so the pre-existing `wasm-streams` duplicate-symbol blocker (which kills `wasm-pack test` + `trunk build`) doesn't affect this CI step. Confirmed locally — zero warnings, exit 0. CI gate was previously reverted (`c5452a4`) for a different guard that DID link; this one is safe.

## Test plan

master-PR CI runs the full gate: `cargo fmt`, `cargo clippy` (native), `cargo test`, `cargo check --target wasm32-unknown-unknown`, `wasm-pack test --headless --firefox`, plus the new `wasm-clippy` step on `willow-web`. Local merge gate verified green by implementer (`c9f1ba6` report):

- `cargo fmt --all -- --check` — clean
- `cargo clippy --target wasm32-unknown-unknown -p willow-web --all-targets -- -D warnings` — clean, zero warnings
- `cargo clippy --workspace --all-targets -- -D warnings` (native) — clean
- `cargo check --target wasm32-unknown-unknown -p willow-web` — clean
- `cargo test -p willow-web --lib` — 77 passed, 0 failed

---
_Generated by [Claude Code](https://claude.ai/code/session_014jtJ7KBWBSdZf9YuMmE5Bq)_