### PR TITLE
auto-fix batch claude/friendly-maxwell-uPyR3 (2026-04-30)

### DIFF
--- a/.claude/skills/resolving-issues/SKILL.md
+++ b/.claude/skills/resolving-issues/SKILL.md
@@ -149,6 +149,19 @@ Never defer skill edits to a follow-up — they ship with the run that surfaced 
 - Research subagents *inside* an implementer may run in parallel.
 - Cap = 10 issues per run.
 
+### Waiting for implementer commits without polling
+- Implementer agent runs in the background. Coordinator gets a notification when the agent's tool call completes — but the agent's *commit* may land seconds before that, and the harness's stop hook fires on uncommitted changes during cargo gates.
+- **Don't sleep, don't poll, don't read the agent's output file.** The system explicitly blocks long sleeps and warns against reading sub-agent transcripts (context overflow).
+- **Use `Monitor` with an `until` loop watching for HEAD to advance** past the prior known SHA. One notification fires when the loop exits; the coordinator stays idle in between. Pattern:
+  ```bash
+  cd /home/user/willow && until [ "$(git log -1 --format='%H')" != "<prior-sha>" ]; do sleep 5; done; echo "agent committed: $(git log -1 --oneline)"
+  ```
+  Set `timeout_ms` to ~5–10 minutes for typical implementer runs (longer for cross-crate gates). The coordinator can do GitHub-API metadata work (filing follow-up issues, drafting PR body) while waiting; just don't touch files in the implementer's scope.
+
+### Implementer-flagged out-of-scope rot
+- When the implementer surfaces pre-existing rot it intentionally doesn't fix (e.g. unrelated wasm break under `--all-features`, dead-code warnings in untouched files), the coordinator files a follow-up GH issue using `mcp__github__issue_write` (metadata work, allowed under the Coordinator-never-codes rule). Cite the discovery context (which dispatch surfaced it, which commit + gate step) so the next run has full provenance.
+- This is the same shape as the "implementer files follow-up" rule — coordinator just does the filing because the implementer is single-task and exits after commit.
+
 ### Fresh agent per issue
 - New implementer each issue. No state leak.
 - Each implementer gets only its issue + master branch ref.

--- a/crates/network/src/mem.rs
+++ b/crates/network/src/mem.rs
@@ -277,7 +277,7 @@ impl TopicEvents for MemTopicEvents {
                             // Filter out events about ourselves
                             match &event {
                                 GossipEvent::NeighborUp(id) | GossipEvent::NeighborDown(id) if *id == self.id => continue,
-                                _ => return Some(Ok(event)),
+                                GossipEvent::Received(_) | GossipEvent::NeighborUp(_) | GossipEvent::NeighborDown(_) => return Some(Ok(event)),
                             }
                         }
                         Err(broadcast::error::RecvError::Closed) => return None,

--- a/docs/plans/STATUS.md
+++ b/docs/plans/STATUS.md
@@ -1,0 +1,33 @@
+# Phase-plan status
+
+At a glance, for each UI-design phase plan in `docs/plans/`, which state-layer prerequisites are already in `crates/state/src/event.rs` and which still need to land.
+
+**Rationale.** Per `docs/specs/2026-04-19-ui-design/README.md`, "Feature disparity between spec and client is expected and acceptable." This file makes that disparity legible without grepping across crates. It exists to answer one question quickly: when a plan reserves a wire type or `EventKind` variant that has not shipped, can a reader spot the gap before tracing it through the spec? The audit that prompted this file (issue #337, ARCH-07) flagged exactly that pattern: phase-2e reserves `SearchScope::ThisLetter` / `SearchScope::AllLetters` while the DAG has no `Letter` `EventKind`.
+
+**Maintenance.** This is a snapshot in time, not a live tracker. Updated by hand when plans land or new state primitives ship. If the table drifts from `crates/state/src/event.rs`, treat the source as canonical and patch the table.
+
+## Status table
+
+| Plan | UI scope | State-layer prereq | Landed? | Notes |
+|------|----------|--------------------|---------|-------|
+| [`2026-04-19-ui-phase-0-foundation.md`](2026-04-19-ui-phase-0-foundation.md) | Design tokens (palette, typography, motion) reskin | none — view layer only | yes | Pure CSS / token plumbing; no Rust state changes. |
+| [`2026-04-20-ui-phase-1a-desktop-shell.md`](2026-04-20-ui-phase-1a-desktop-shell.md) | Desktop three-pane shell, grove rail, channel sidebar, right rail | none new — consumes existing `CreateChannel`, `ChannelKind`, members | yes | Plan explicitly defers ephemeral / archive / muted / per-grove-accent flags to later phases (covered by 2d / 1f). |
+| [`2026-04-20-ui-phase-1b-mobile-shell.md`](2026-04-20-ui-phase-1b-mobile-shell.md) | Mobile shell — tab bar, top bar, grove drawer, bottom sheets | none — view layer only | yes | No new events; mounts on existing channel / member views. |
+| [`2026-04-20-ui-phase-1c-palette-a11y.md`](2026-04-20-ui-phase-1c-palette-a11y.md) | Command palette, ARIA landmarks, keyboard close-stack | none — view layer only | yes | Local-search handoff is surface only; index ships in 2e. |
+| [`2026-04-20-ui-phase-1d-trust-verification.md`](2026-04-20-ui-phase-1d-trust-verification.md) | SAS fingerprints, trust badges, compare-friend flow | none new — local-only per-device belief | yes | Plan §Architecture: "no new `EventKind`. Trust is local per-device." Shared-trust event explicitly out of scope. |
+| [`2026-04-20-ui-phase-1e-presence.md`](2026-04-20-ui-phase-1e-presence.md) | 7-state presence, status dot, presence menu | none new — derived from network reachability + local override | yes | Plan §Architecture: "Presence is derived, not event-sourced in 1e." `PresenceHeartbeat` `EventKind` flagged as future work. |
+| [`2026-04-20-ui-phase-1f-notifications.md`](2026-04-20-ui-phase-1f-notifications.md) | Toast stack, unread badges, OS push contract, per-surface mute | `MuteChannel` + `MuteGrove` `EventKind` | yes | Both variants present in `event.rs` (lines ~355, ~361). VAPID wire format + relay-side dispatch are out of scope. |
+| [`2026-04-20-ui-phase-2a-message-row.md`](2026-04-20-ui-phase-2a-message-row.md) | Message row anatomy, mentions, code, day separators, jump-to-latest | uses existing `Message`, `EditMessage`, `DeleteMessage`, `PinMessage` | partial | Plan gates a `WhisperStart` placeholder behind always-false flag — `WhisperStart` `EventKind` is not in `event.rs`; whisper body styling deferred to `whisper-mode.md` (no plan yet). Quote-reply uses existing `Message.reply_to`. |
+| [`2026-04-21-ui-phase-2b-sync-queue.md`](2026-04-21-ui-phase-2b-sync-queue.md) | Offline strip, queue pills, sync-queue screen, reconnection toast | none new — `ServerState` unchanged; `MessageStore::delivery_state` + relay status are local | partial | Plan §Architecture: "No new `EventKind`. Queue state is purely local / per-device." Peer-identity tombstone signal flagged as out of scope (deferred to `letters-dms.md`); inbound queue heartbeat extension is an open dep. |
+| [`2026-04-21-ui-phase-2c-profile-card.md`](2026-04-21-ui-phase-2c-profile-card.md) | Profile popover / sheet, 17 fields, crest banner, nickname editor | `EventKind::UpdateProfile(Box<ProfileDelta>)` + extended `Profile` fields (pronouns, bio, tagline, crest, pinned, elsewhere, since) | yes | `UpdateProfile` present (line ~322). Nickname store is local-only per spec — no event needed. |
+| [`2026-04-21-ui-phase-2e-local-search.md`](2026-04-21-ui-phase-2e-local-search.md) | On-device search index, scope ladder, results surface, palette bridge | no new `EventKind`; `SearchScope::ThisLetter` + `SearchScope::AllLetters` reserved on the client side | partial | The two letter scopes have no backing `EventKind` — there is no `Letter` / DM variant in `event.rs`. Plan flags this with `TODO(letters-dms.md)` on letter-scope filter branches. The audit that prompted this status file (issue #337) called out exactly this drift. |
+| [`2026-04-25-ui-phase-2d-ephemeral-channels.md`](2026-04-25-ui-phase-2d-ephemeral-channels.md) | Auto-archive on inactivity, archives surface, kind chip, revive | `CreateChannel.ephemeral: Option<EphemeralConfig>` + `EventKind::ChannelRevive { channel_id }` + `Channel.last_activity_hlc` | yes | Both present (lines ~250, ~263). Replaces the `_ephemeral-` name-prefix heuristic from 1a. |
+
+## Aggregate
+
+- **12 plans tabulated.**
+- **9 yes** (state-layer prereqs all landed or none required).
+- **3 partial** — 2a (whisper placeholder gate, no `WhisperStart`), 2b (peer tombstone + inbound heartbeat deferred), 2e (letter scopes reserved with no `Letter` `EventKind`).
+- **0 no** — every plan has at least started landing in `crates/state/src/event.rs` or is intentionally view-layer-only.
+
+The recurring blocker across the partial rows is the absence of a `Letter` / DM family of `EventKind` variants. `letters-dms.md` is a spec but has no implementation plan yet; until one lands, plans 2a / 2b / 2e all carry forward-references that are correct but unbacked.


### PR DESCRIPTION
## Fixes

- Fixes #258 — replace `_ =>` catch-all in `crates/network/src/mem.rs:280` `MemTopicEvents::next` neighbor-channel match with explicit `GossipEvent::Received(_) | GossipEvent::NeighborUp(_) | GossipEvent::NeighborDown(_) =>` so future `GossipEvent` additions force a compile error here. iroh side already exhaustive at `crates/network/src/iroh.rs:150-181`. zero behavior change current variant set; compiler enforce future revisit. commit `d19de75`.
- Fixes #337 — add `docs/plans/STATUS.md` tabulate 12 UI-design phase plans + their state-layer prereqs + landed-state. 9 `yes` + 3 `partial` (2a whisper-placeholder, 2b sync-queue tombstone defer, 2e letter scope — the original ARCH-07 case). table make Letter/DM EventKind gap legible without grep cross-crate. snapshot doc, manual patch when plan ship. commit `dad9765`.

## Already-Fixed

resolve upstream before this run; coordinator-direct close pass (no implementer dispatch):

- #234 [SEC-V-05] `ProfileState.names` / `typing_peers` unbounded — LRU cap (10k) + 5 s TTL sweep on typing_peers ship `1a9503f`. verify `crates/client/src/state_actors.rs:121-203`. audit @ `0de7631` (#492) confirm.
- #326 [TD-08] `Arc<Mutex<_>>` quartet in `search/handle.rs` — superseded by actor migration `64417e2`. handle now `addr: Addr<SearchActor>`, mailbox FIFO atomic. close `not_planned` (audit premise moot).
- #103 cross-browser e2e need Firefox — `firefoxAvailable()` probe + `test.skip(!firefoxAvailable(), …)` ship in `e2e/cross-browser-sync.spec.ts:21-29,49`. exact option-1 from issue.

## Parked

none. all picked issues either ship or already-fix.

## Follow-up filed

- #502 — `cargo check --target wasm32-unknown-unknown -p willow-network --all-features` fail on tokio import in `mem.rs`. pre-existing on parent commit `96dfce0`; surface during #258 implementer's local gate. project's actual `just check-wasm` no use `--all-features` so green today. file as separate tech-debt tracker, not fix in this batch.

## Skill Evolution

`0647319 docs(skill): Monitor wait pattern + coordinator-files-rot escape hatch`. two add to `.claude/skills/resolving-issues/SKILL.md`:

1. **`### Waiting for implementer commits without polling`** subsection. stop hook fire while implementer mid-cargo-gates; coordinator no commit (skill rule), need wait without poll. canonical pattern: `Monitor` + `until [ "$(git log -1 --format='%H')" != "<prior-sha>" ]; do sleep 5; done` — one notification when HEAD advance. coordinator do GH-API metadata work (file follow-up, draft PR body) in mean time, no touch implementer file scope.

2. **`### Implementer-flagged out-of-scope rot`** subsection. when implementer surface pre-existing rot it intentionally no fix (e.g. unrelated wasm break under `--all-features`), coordinator file follow-up via `mcp__github__issue_write` — metadata work, allow under coordinator-never-codes rule. cite discovery context (which dispatch + gate step) so next run have provenance. this run example: #258 → #502.

## Lessons Learned

- **already-fixed dominate again.** 3 of 5 picks resolve upstream by recent commit. coordinator-direct sweep continue high-leverage at start of Core Loop. third consecutive run hit same pattern (PR #501 hit 6/7).
- **stop hook + implementer cargo gate = real friction.** stop hook check uncommitted file in repo, implementer have edit but not yet commit (cargo gate run). coordinator no permit code commit. Monitor + until-loop = clean fix; lesson now codify in skill (`### Waiting for implementer commits without polling`).
- **`mcp__github__list_issues` token-cap, again.** 50-result page exceed 192k char tool-result cap. saved-to-file fallback + jq work but slow + token-heavy on coordinator side. lesson #5 from #493 / general-audit skill already note same; recur this run too.
- **scope filter hold.** issue skip: #423/422/421/419/418/417 (testing work, multi-day), #325 (`.clone()` cascade refactor), #321 (1521 unwrap call site), #382/381/380/… (full feature spec implementations).
- **implementer flag pre-existing rot well.** #258 implementer surface `--all-features` wasm break, name parent commit it reproduce on, suggest two fix option, tag out-of-scope. coordinator file as #502 — follow-up handoff clean. validate the new `### Implementer-flagged out-of-scope rot` skill addition.

## Test plan

master-PR CI run full gate: `cargo fmt`, `cargo clippy` (native + wasm-clippy on `willow-web` per #501), `cargo test`, `cargo check --target wasm32-unknown-unknown`, `wasm-pack test --headless --firefox`. Local merge gate verify green per implementer report:

- **`d19de75` (#258)** — `cargo fmt --all -- --check` clean, `cargo clippy -p willow-network --all-features --all-targets -- -D warnings` clean, `cargo test -p willow-network --all-features` 18 unit + 5 integration + 2 doc-tests pass, `cargo check --target wasm32-unknown-unknown -p willow-network` (default features, matching `just check-wasm`) clean. `--all-features` wasm path fail pre-existing → #502.
- **`dad9765` (#337)** — docs-only, no Rust change. `cargo fmt --all -- --check` clean. markdown table validated 14 rows × 7 columns consistent.
- **`0647319` (skill edit)** — docs-only, no Rust change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8q3aDhCUVv6LB4HaoM4sA)_