### PR TITLE
ui(phase-3c.2): wire EmojiPicker into composer + row toolbars

### DIFF
--- a/crates/web/src/components/composer/composer.rs
+++ b/crates/web/src/components/composer/composer.rs
@@ -546,18 +546,51 @@ pub fn Composer(
 
     let send_disabled = move || input_text.get().trim().is_empty();
 
-    // Attach + emoji buttons: stub click handlers per plan §Ambiguity
-    // decisions point 5. The actual file dialog (`files-inline.md`,
-    // Phase 3b) and emoji picker (`reactions-pins.md`, Phase 3c) drop
-    // in here without re-shaping props — the buttons render now with
-    // the spec-mandated aria-labels so screen readers can already
-    // discover them, and the click handlers are intentional no-ops.
+    // Phase 3c.2: emoji picker open-state. The button below flips it;
+    // the popover mounts conditionally at the bottom of the composer
+    // tree. `picker_recent` is left empty in v1 — the static category
+    // browse covers the full picker contract; per-channel recents
+    // surface in a follow-up that threads the WebClientHandle context
+    // through the composer (today AppState is what's plumbed and it
+    // doesn't expose `recent_reactions`).
+    let (emoji_picker_open, set_emoji_picker_open) = signal(false);
+    let picker_recent: Signal<Vec<String>> = Signal::derive(Vec::new);
+
+    // Attach button: stub click handler per plan §Ambiguity decisions
+    // point 5; full file dialog lands in `files-inline.md` Phase 3b.
     let on_click_attach = |_ev: web_sys::MouseEvent| {
         // TODO(files-inline.md): open file dialog.
     };
-    let on_click_emoji = |_ev: web_sys::MouseEvent| {
-        // TODO(reactions-pins.md): open emoji picker popover.
+    let on_click_emoji = move |_ev: web_sys::MouseEvent| {
+        set_emoji_picker_open.update(|v| *v = !*v);
     };
+
+    // Insert a picked emoji glyph at the textarea's current caret
+    // position. Mirrors `insert_selected_mention` above — splices the
+    // glyph into the existing value, advances the caret to just after
+    // it, and closes the picker.
+    let insert_emoji_at_caret = move |glyph: String| {
+        let Some(el) = textarea_ref.get_untracked() else {
+            set_emoji_picker_open.set(false);
+            return;
+        };
+        let dom: &web_sys::HtmlTextAreaElement = &el;
+        let value = dom.value();
+        let caret_chars = dom.selection_end().ok().flatten().unwrap_or(0) as usize;
+        let caret_byte = char_index_to_byte(&value, caret_chars).unwrap_or(value.len());
+        let mut new_value = String::with_capacity(value.len() + glyph.len());
+        new_value.push_str(&value[..caret_byte]);
+        new_value.push_str(&glyph);
+        new_value.push_str(&value[caret_byte..]);
+        let new_caret_chars = byte_index_to_char(&new_value, caret_byte + glyph.len())
+            .unwrap_or_else(|| new_value.chars().count()) as u32;
+        dom.set_value(&new_value);
+        set_input_text.set(new_value);
+        let _ = dom.set_selection_range(new_caret_chars, new_caret_chars);
+        set_emoji_picker_open.set(false);
+    };
+    let on_picker_select = Callback::new(insert_emoji_at_caret);
+    let on_picker_close = Callback::new(move |()| set_emoji_picker_open.set(false));
 
     view! {
         // `input-area` retained alongside `composer` for backward
@@ -718,6 +751,21 @@ pub fn Composer(
                 peer_count=peer_count_sig
                 is_mobile=is_mobile_sig
             />
+            // Phase 3c emoji picker. Mounts conditionally below the
+            // composer pill — visibility owned by the local
+            // `emoji_picker_open` signal flipped by the smile button.
+            // Recent shelf is empty in v1; the static categories cover
+            // the full browse contract until a follow-up threads the
+            // WebClientHandle through the composer for live reads.
+            <Show when=move || emoji_picker_open.get()>
+                <div class="composer__emoji-picker-anchor">
+                    <crate::components::emoji_picker::EmojiPicker
+                        recent=picker_recent
+                        on_select=on_picker_select
+                        on_close=on_picker_close
+                    />
+                </div>
+            </Show>
         </div>
     }
 }

--- a/crates/web/src/components/message.rs
+++ b/crates/web/src/components/message.rs
@@ -1092,7 +1092,6 @@ pub fn MessageView(
                 // `@media (max-width: 720px)` CSS rule; the long-press action
                 // sheet remains the mobile entry.
                 let react_cb_for_quick = on_react;
-                let msg_for_more_reactions = msg_for_react.clone();
                 Some(view! {
                     <div class="message-actions">
                         <div class="message-hover-toolbar" role="toolbar" aria-label="message actions">

--- a/crates/web/src/components/message.rs
+++ b/crates/web/src/components/message.rs
@@ -336,6 +336,10 @@ pub fn MessageView(
     // Signal controlling the dropdown menu visibility.
     let (show_dropdown, set_show_dropdown) = signal(false);
     let (show_react_row, set_show_react_row) = signal(false);
+    // Phase 3c.2: emoji picker open-state. The hover toolbar's smile
+    // button (and the dropdown's More-reactions row) flips this; the
+    // popover mounts below the row when open.
+    let (emoji_picker_open, set_emoji_picker_open) = signal(false);
 
     // Delete confirmation state.
     let (show_del_confirm, set_show_del_confirm) = signal(false);
@@ -1125,8 +1129,6 @@ pub fn MessageView(
                                 <span class="toolbar-divider" aria-hidden="true"></span>
                             })}
                             {has_react.then(|| {
-                                let msg_for_click = msg_for_more_reactions.clone();
-                                let _ = msg_for_click; // reserved for future emoji-picker route
                                 view! {
                                     <button
                                         class="toolbar-btn"
@@ -1134,14 +1136,12 @@ pub fn MessageView(
                                         aria-label="more reactions"
                                         on:click=move |ev| {
                                             ev.stop_propagation();
-                                            // Toggle the existing React row
-                                            // inside the dropdown, opening the
-                                            // dropdown if it's closed so the
-                                            // row is visible. `reactions-pins.md`
-                                            // will replace this with a full
-                                            // emoji picker.
-                                            set_show_dropdown.set(true);
-                                            set_show_react_row.update(|v| *v = !*v);
+                                            // Phase 3c.2: open the emoji picker
+                                            // popover instead of the legacy in-
+                                            // dropdown react row. The picker
+                                            // mounts below the row; on_select
+                                            // routes through `on_react`.
+                                            set_emoji_picker_open.update(|v| *v = !*v);
                                         }
                                     >
                                         {icons::icon_smile()}
@@ -1323,6 +1323,40 @@ pub fn MessageView(
                                 None
                             }
                         }}
+                        // Phase 3c.2 emoji picker. Mounts conditionally
+                        // inside `.message-actions` so its absolute
+                        // positioning lands relative to the row. The
+                        // smile button in the hover toolbar (above)
+                        // flips `emoji_picker_open`; on_select routes
+                        // through `on_react`. Recent shelf is empty in
+                        // v1 — the static categories cover the picker
+                        // contract until a follow-up plumbs
+                        // `client.recent_reactions(channel)` through
+                        // the row.
+                        {
+                            let react_cb_for_picker = on_react;
+                            let msg_for_picker = message.clone();
+                            let on_select = Callback::new(move |glyph: String| {
+                                if let Some(cb) = react_cb_for_picker {
+                                    cb.run((msg_for_picker.clone(), glyph));
+                                }
+                                set_emoji_picker_open.set(false);
+                            });
+                            let on_close = Callback::new(move |()| {
+                                set_emoji_picker_open.set(false);
+                            });
+                            view! {
+                                <Show when=move || emoji_picker_open.get()>
+                                    <div class="message-emoji-picker-anchor">
+                                        <crate::components::emoji_picker::EmojiPicker
+                                            recent=Signal::derive(Vec::new)
+                                            on_select=on_select
+                                            on_close=on_close
+                                        />
+                                    </div>
+                                </Show>
+                            }
+                        }
                     </div>
                 })
             } else {

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -6934,3 +6934,32 @@ select:focus-visible {
     background: var(--amber);
     color: var(--bg-1);
 }
+
+/* ── Phase 3c.2 — emoji picker mount anchors ────────────────────────────
+ *
+ * The picker popover is absolutely-positioned so it floats above the
+ * row / composer instead of pushing layout. Click-away dismissal is
+ * the picker's own Escape callback (wired by the host components).
+ */
+
+.composer__emoji-picker-anchor,
+.message-emoji-picker-anchor {
+    position: absolute;
+    z-index: 60;
+}
+
+.composer__emoji-picker-anchor {
+    /* Above the composer pill, anchored to the right edge so the
+     * smile button stays under it. */
+    bottom: 100%;
+    right: 0;
+    margin-bottom: 6px;
+}
+
+.message-emoji-picker-anchor {
+    /* Below the hover toolbar's smile button — the toolbar floats at
+     * top: -14px above the row, so the picker drops just under it. */
+    top: 28px;
+    right: 8px;
+}
+


### PR DESCRIPTION
## Summary

Phase 3c shipped the `<EmojiPicker>` component but no callsite mounted it. This PR wires the two surfaces called out by spec [`reactions-pins.md`](https://github.com/intendednull/willow/blob/main/docs/specs/2026-04-19-ui-design/reactions-pins.md) §Emoji picker.

## What ships

1. **Composer emoji IconBtn** — replaces the `TODO(reactions-pins.md)` no-op with a real toggle + caret-aware glyph insertion. Click the smile button → picker opens above the composer pill → click a glyph → it splices into the textarea at the current caret position → picker closes. Mirrors `insert_selected_mention` so mention/emoji unification stays straightforward.
2. **Row hover toolbar's "more reactions" smile button** — replaces the legacy `set_show_react_row` toggle with `set_emoji_picker_open` flip. On select the picked glyph routes through the existing `on_react` callback so the reaction applies immediately.

CSS adds two `*-emoji-picker-anchor` rules for absolute positioning + z-index above the message list. Foundation tokens only.

## Deferred

- Recent shelf is `Signal::derive(Vec::new)` in v1. The recency LRU is ticking on `ChatMeta` (phase 3c) but threading `WebClientHandle::recent_reactions(channel)` through the composer + message-row needs context plumbing those components don't have today (only `AppState` is plumbed). The static categories cover the full picker contract until that follow-up lands.
- Click-away dismissal: the picker's own Escape key closes it; click-outside-to-dismiss is a follow-up that needs a global click listener.

## Test plan

- [x] `just check` clean — fmt + clippy + native tests + WASM.
- [ ] Browser-tier interaction tests for the picker mount + insert wire-up land alongside the recent-shelf plumbing follow-up so a single fixture covers the end-to-end flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)