### PR TITLE
ui(phase-3c): wire pinned_count + can_unpin/on_unpin into live UI

### DIFF
--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -8,7 +8,7 @@ use willow_client::{ClientConfig, ClientEvent, ClientHandle, DisplayMessage, Voi
 use crate::components::{
     AddServerPanel, CallPage, ChannelSidebar, CommandPalette, Composer, GroveRail, JoinPage,
     MainPaneHeader, MessageList, MobileShell, ReadOnlyBanner, RightRail, RightRailWhich,
-    SettingsPanel, ToastStackView, UploadDialog, WelcomeScreen,
+    SettingsPanel, ToastStack, ToastStackView, UploadDialog, WelcomeScreen,
 };
 use crate::event_processing::process_event_batch;
 use crate::handlers;
@@ -1320,6 +1320,34 @@ pub fn App() -> impl IntoView {
                                 }
                                 write.ui.set_show_pinned.set(false);
                             });
+                            // Phase 3c — per-entry `unpin` button in the pinned
+                            // panel is permission-gated on `ManageChannels` per
+                            // spec `docs/specs/2026-04-19-ui-design/reactions-pins.md`
+                            // §Pinned panel contents. Permission signal greys the
+                            // button + flips its tooltip; the callback mirrors the
+                            // `make_pin_handler` async/toast pattern but always
+                            // unpins (the panel only lists already-pinned rows).
+                            let can_unpin: Signal<bool> =
+                                app_state.server.local_can_manage_channels.into();
+                            let unpin_handle = handle.clone();
+                            let on_unpin = Callback::new(move |id: String| {
+                                let ch = current_channel.get_untracked();
+                                let h = unpin_handle.clone();
+                                let toasts = use_context::<ToastStack>();
+                                wasm_bindgen_futures::spawn_local(async move {
+                                    let Ok(hash) = id.parse::<willow_client::willow_state::EventHash>() else {
+                                        tracing::warn!(id, "pinned panel unpin: invalid event hash");
+                                        return;
+                                    };
+                                    if let Err(e) = h.unpin_message(&ch, &hash).await {
+                                        crate::handlers::warn_and_toast_with(
+                                            "unpin message",
+                                            &e,
+                                            toasts.as_ref(),
+                                        );
+                                    }
+                                });
+                            });
                             view! {
                                 <RightRail
                                     which=rail_which
@@ -1328,6 +1356,8 @@ pub fn App() -> impl IntoView {
                                     peer_id=peer_id
                                     pinned_messages=pinned_messages
                                     on_pinned_jump=on_pinned_jump
+                                    can_unpin=can_unpin
+                                    on_unpin=on_unpin
                                 />
                             }
                         }

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -1159,6 +1159,13 @@ pub fn App() -> impl IntoView {
                                         let _ = current_channel.get();
                                         set_composer_revealed.set(false);
                                     });
+                                    // Phase 3c — surface the pinned-message count to
+                                    // the header so the pin IconBtn picks up the
+                                    // `--amber` tint + mono superscript count when
+                                    // the active channel has pins, per spec
+                                    // `docs/specs/2026-04-19-ui-design/reactions-pins.md`
+                                    // §Header entry point.
+                                    let pinned_count = Signal::derive(move || pinned_messages.get().len());
                                     view! {
                                         <main
                                             class="chat-container main-pane"
@@ -1170,6 +1177,7 @@ pub fn App() -> impl IntoView {
                                                 which=which_signal
                                                 on_set_which=on_set_which
                                                 on_search_click=Callback::new(move |_| write.ui.set_show_palette.set(true))
+                                                pinned_count=pinned_count
                                             />
                                             {move || {
                                                 if channels_signal.get().is_empty() {

--- a/crates/web/src/components/right_rail.rs
+++ b/crates/web/src/components/right_rail.rs
@@ -28,6 +28,18 @@ pub fn RightRail(
     /// Called when the user clicks "jump" on a pinned message.
     #[prop(into)]
     on_pinned_jump: Callback<String>,
+    /// Drives the per-entry `unpin` button's enabled state in the
+    /// pinned panel. Callers thread their local-peer `ManageChannels`
+    /// permission signal so the button greys out when the user can't
+    /// unpin. Optional so test mounts that only render the members /
+    /// thread panes don't have to construct a stub signal.
+    #[prop(optional, into)]
+    can_unpin: Option<Signal<bool>>,
+    /// Called with the message id when the user clicks the per-entry
+    /// `unpin` button in the pinned panel. Optional — when absent, the
+    /// pinned panel does not render the unpin affordance at all.
+    #[prop(optional)]
+    on_unpin: Option<Callback<String>>,
 ) -> impl IntoView {
     let is_open = Signal::derive(move || !matches!(which.get(), RightRailWhich::None));
     let aria_label = move || match which.get() {
@@ -65,15 +77,44 @@ pub fn RightRail(
                     RightRailWhich::Pinned => {
                         let on_jump = on_pinned_jump;
                         let on_close_cb = on_close;
+                        // Unwrap the optional permission signal with a
+                        // safe default so tests / harnesses that omit
+                        // it get the locked-down behaviour (button
+                        // greyed). When `on_unpin` is `None` the
+                        // pinned panel suppresses the unpin button
+                        // entirely (button is opt-in on the callback).
+                        let can_unpin_sig = can_unpin
+                            .unwrap_or_else(|| Signal::derive(|| false));
                         view! {
                             <div class="right-rail-pane" data-pane="pinned">
-                                <PinnedPanel
-                                    messages=pinned_messages
-                                    on_jump=move |id: String| on_jump.run(id)
-                                    on_close=move |_| {
-                                        if let Some(cb) = on_close_cb { cb.run(()); }
+                                {
+                                    let on_jump_inner = on_jump;
+                                    let on_close_inner = on_close_cb;
+                                    if let Some(unpin_cb) = on_unpin {
+                                        view! {
+                                            <PinnedPanel
+                                                messages=pinned_messages
+                                                can_unpin=can_unpin_sig
+                                                on_jump=move |id: String| on_jump_inner.run(id)
+                                                on_unpin=unpin_cb
+                                                on_close=move |_| {
+                                                    if let Some(cb) = on_close_inner { cb.run(()); }
+                                                }
+                                            />
+                                        }.into_any()
+                                    } else {
+                                        view! {
+                                            <PinnedPanel
+                                                messages=pinned_messages
+                                                can_unpin=can_unpin_sig
+                                                on_jump=move |id: String| on_jump_inner.run(id)
+                                                on_close=move |_| {
+                                                    if let Some(cb) = on_close_inner { cb.run(()); }
+                                                }
+                                            />
+                                        }.into_any()
                                     }
-                                />
+                                }
                             </div>
                         }.into_any()
                     },

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -2985,6 +2985,209 @@ async fn pinned_panel_close_button_fires_callback() {
     assert!(closed.get_untracked(), "close callback should have fired");
 }
 
+// ── Phase 3c — visibility fixes (PR-A) ──────────────────────────────────────
+//
+// The header pin tint + per-entry unpin button landed component-side in PRs
+// #634 / #635 / #637 but no caller threaded the new optional props, so the
+// affordances never reached the live UI. These tests assert the prop
+// boundary at the smallest granularity that proves the wiring works.
+
+mod phase_3c_callsite_wiring {
+    use leptos::prelude::*;
+    use wasm_bindgen_test::*;
+    use willow_web::components::{MainPaneHeader, PinnedPanel, RightRailWhich};
+
+    use super::{make_msg, mount_test, query, simulate_click, text, tick};
+
+    /// AG-9: when the active channel has pinned messages, the header pin
+    /// button picks up the `.action-btn--lit` class (amber tint) and
+    /// renders an `.action-btn__count--pin` superscript with the count.
+    /// `MainPaneHeader` exposes `pinned_count` as an optional prop — this
+    /// test mounts the component directly with a count of 2, which is
+    /// exactly what `app.rs` now derives from `pinned_messages.len()`.
+    #[wasm_bindgen_test]
+    async fn header_pin_button_renders_amber_with_count_when_channel_has_pins() {
+        let (channel, _) = signal("general".to_string());
+        let (which, _) = signal(RightRailWhich::None);
+        let which_sig = Signal::derive(move || which.get());
+        let pinned_count = Signal::derive(|| 2usize);
+
+        let container = mount_test(move || {
+            view! {
+                <MainPaneHeader
+                    channel=channel
+                    which=which_sig
+                    on_set_which=Callback::new(move |_: RightRailWhich| ())
+                    on_search_click=Callback::new(move |_: ()| ())
+                    pinned_count=pinned_count
+                />
+            }
+        });
+        tick().await;
+
+        let pin_btn = query(&container, "button[aria-label^=\"pinned messages\"]")
+            .expect("pin button rendered");
+        let classes = pin_btn.get_attribute("class").unwrap_or_default();
+        assert!(
+            classes.contains("action-btn--lit"),
+            "pin button has amber `action-btn--lit` class when channel has pins, got: {classes}"
+        );
+
+        let count_el = query(&container, ".action-btn__count--pin")
+            .expect("count overlay rendered when pinned_count > 0");
+        assert_eq!(
+            text(&count_el).trim(),
+            "2",
+            "count overlay shows the pinned-message count"
+        );
+
+        // ARIA label flips to `pinned messages (N)` per spec §Header entry point.
+        let aria = pin_btn.get_attribute("aria-label").unwrap_or_default();
+        assert_eq!(
+            aria, "pinned messages (2)",
+            "aria-label exposes the count to assistive tech"
+        );
+    }
+
+    /// AG-9 (negative): when the channel has no pins, the pin button keeps
+    /// its baseline class set and does NOT render the count overlay. Locks
+    /// in the threshold so a future regression that always renders the
+    /// overlay would fail.
+    #[wasm_bindgen_test]
+    async fn header_pin_button_has_no_count_when_channel_empty() {
+        let (channel, _) = signal("general".to_string());
+        let (which, _) = signal(RightRailWhich::None);
+        let which_sig = Signal::derive(move || which.get());
+        let pinned_count = Signal::derive(|| 0usize);
+
+        let container = mount_test(move || {
+            view! {
+                <MainPaneHeader
+                    channel=channel
+                    which=which_sig
+                    on_set_which=Callback::new(move |_: RightRailWhich| ())
+                    on_search_click=Callback::new(move |_: ()| ())
+                    pinned_count=pinned_count
+                />
+            }
+        });
+        tick().await;
+
+        let pin_btn = query(&container, "button[aria-label=\"pinned messages\"]")
+            .expect("pin button rendered with bare aria-label");
+        let classes = pin_btn.get_attribute("class").unwrap_or_default();
+        assert!(
+            !classes.contains("action-btn--lit"),
+            "pin button has no amber class when count is zero, got: {classes}"
+        );
+        assert!(
+            query(&container, ".action-btn__count--pin").is_none(),
+            "count overlay is absent when pinned_count == 0"
+        );
+    }
+
+    /// AG-8: the pinned panel's per-entry unpin button renders when
+    /// `can_unpin` is true, is enabled, and clicking it fires the
+    /// `on_unpin` callback with the message id.
+    #[wasm_bindgen_test]
+    async fn pinned_panel_per_entry_unpin_renders_when_can_unpin() {
+        let msg = make_msg("Alice", "pin me then unpin me", 1000);
+        let msg_id = msg.id.clone();
+        let (msgs, _) = signal(vec![msg]);
+        let (clicked_id, set_clicked_id) = signal(Option::<String>::None);
+        let can_unpin = Signal::derive(|| true);
+
+        let container = mount_test(move || {
+            view! {
+                <PinnedPanel
+                    messages=msgs
+                    can_unpin=can_unpin
+                    on_jump=move |_: String| {}
+                    on_unpin=Callback::new(move |id: String| set_clicked_id.set(Some(id)))
+                    on_close=move |_| {}
+                />
+            }
+        });
+        tick().await;
+
+        let unpin_btn = query(&container, ".pinned-entry__unpin")
+            .expect("unpin button renders when on_unpin is wired");
+        // Enabled when can_unpin = true.
+        assert_eq!(
+            unpin_btn.get_attribute("aria-disabled").as_deref(),
+            Some("false"),
+            "unpin button is not aria-disabled when caller has ManageChannels"
+        );
+        assert!(
+            !unpin_btn.has_attribute("disabled"),
+            "unpin button is not `disabled` when can_unpin == true"
+        );
+
+        simulate_click(&unpin_btn);
+        tick().await;
+
+        assert_eq!(
+            clicked_id.get_untracked().as_deref(),
+            Some(msg_id.as_str()),
+            "on_unpin callback fires with the row's message id"
+        );
+    }
+
+    /// AG-8: when the local peer lacks `ManageChannels`, the per-entry
+    /// unpin button still renders (so the affordance is discoverable) but
+    /// is `disabled` + `aria-disabled="true"` and its tooltip is the
+    /// spec-exact `only stewards can pin here`. Clicking does NOT fire
+    /// the callback.
+    #[wasm_bindgen_test]
+    async fn pinned_panel_per_entry_unpin_disabled_without_permission() {
+        let msg = make_msg("Alice", "pinned but locked", 1000);
+        let (msgs, _) = signal(vec![msg]);
+        let (clicked_id, set_clicked_id) = signal(Option::<String>::None);
+        let can_unpin = Signal::derive(|| false);
+
+        let container = mount_test(move || {
+            view! {
+                <PinnedPanel
+                    messages=msgs
+                    can_unpin=can_unpin
+                    on_jump=move |_: String| {}
+                    on_unpin=Callback::new(move |id: String| set_clicked_id.set(Some(id)))
+                    on_close=move |_| {}
+                />
+            }
+        });
+        tick().await;
+
+        let unpin_btn = query(&container, ".pinned-entry__unpin")
+            .expect("unpin button still renders so the affordance is discoverable");
+        assert_eq!(
+            unpin_btn.get_attribute("aria-disabled").as_deref(),
+            Some("true"),
+            "aria-disabled flips to `true` when can_unpin == false"
+        );
+        assert!(
+            unpin_btn.has_attribute("disabled"),
+            "native `disabled` attribute is set so click is suppressed"
+        );
+        assert_eq!(
+            unpin_btn.get_attribute("title").as_deref(),
+            Some("only stewards can pin here"),
+            "tooltip is the spec-exact permission-denied copy"
+        );
+
+        // Clicking a disabled button should NOT fire the callback. The
+        // panel's click handler also gates on `!unpin_disabled()`, so
+        // even if the browser dispatches the synthetic event the
+        // callback short-circuits.
+        simulate_click(&unpin_btn);
+        tick().await;
+        assert!(
+            clicked_id.get_untracked().is_none(),
+            "on_unpin callback does NOT fire when can_unpin == false"
+        );
+    }
+}
+
 // ── Typing Indicator Tests ──────────────────────────────────────────────────
 
 #[wasm_bindgen_test]

--- a/docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md
+++ b/docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md
@@ -72,8 +72,8 @@
 - [x] **AG-5.** `<ReactorTooltip>` shows the spec copy: `mira, ori, kes reacted` for ≤ 3 reactors, `first two, and N others` past 3.
 - [x] **AG-6.** `client.recent_reactions(channel_id)` returns the 5 most-recent reactions in the channel, MRU-first; falls back to the spec default until the LRU fills. Per-channel — different channels keep separate recency.
 - [ ] **AG-7.** Pinned panel renders entries with avatar + display name + timestamp + 2-line preview + optional `pinned by {name} · {when}` footer. Empty state copy is byte-exact `nothing pinned yet.`.
-- [ ] **AG-8.** Pinned panel `unpin` button is permission-gated: greyed + `aria-disabled="true"` + tooltip `only stewards can pin here` when local peer lacks `ManageChannels`.
-- [ ] **AG-9.** Header pin IconBtn tints `--amber` when channel has pins; superscript count overlay shows the count.
+- [x] **AG-8.** Pinned panel `unpin` button is permission-gated: greyed + `aria-disabled="true"` + tooltip `only stewards can pin here` when local peer lacks `ManageChannels`.
+- [x] **AG-9.** Header pin IconBtn tints `--amber` when channel has pins; superscript count overlay shows the count.
 - [x] **AG-10.** Pin / unpin keyboard binding (`P`) on a focused row is permission-gated.
 - [x] **AG-11.** Composer emoji IconBtn opens the same `<EmojiPicker>` as the row's add-reaction chip.
 - [x] **AG-12.** ARIA labels match the spec table for every interactive element added in this phase.


### PR DESCRIPTION
## Summary

PR-A of the phase-3c close-out. Two latent UI bugs landed in PRs #634
(MainPaneHeader `pinned_count` prop) and #635/#637 (PinnedPanel
`can_unpin` + `on_unpin` props): the optional props existed and the
component-side rendering was correct, but **no caller threaded them**,
so the spec-mandated affordances never appeared in the live UI:

- **AG-9** (`docs/specs/2026-04-19-ui-design/reactions-pins.md` §Header
  entry point): the channel header's pin IconBtn must tint `--amber`
  and render a mono superscript count when the active channel has
  pins. Without `pinned_count` threaded from `app_state.chat.pinned_messages`,
  the button stayed grey + countless.
- **AG-8** (§Pinned panel contents): each pinned entry must show a
  permission-gated `unpin` button (greyed + `aria-disabled="true"` +
  tooltip `only stewards can pin here` when local peer lacks
  `ManageChannels`). Without `can_unpin` + `on_unpin` threaded from
  `<RightRail>`, the button never rendered at all.

## Changes

Four logical commits:

1. **`ui(phase-3c): thread pinned_count into MainPaneHeader callsite`**
   Derives `pinned_count = pinned_messages.len()` at the `app.rs`
   MainPaneHeader mount site and passes it through.

2. **`ui(phase-3c): thread can_unpin + on_unpin from RightRail to PinnedPanel`**
   Adds the two optional props to `<RightRail>`, forwards them when
   the `Pinned` pane mounts, and wires the production callsite to:
   - `can_unpin = app_state.server.local_can_manage_channels`
   - `on_unpin = Callback` that mirrors `make_pin_handler`'s
     async/toast pattern but always unpins (the panel only lists
     already-pinned rows).
   The `Pinned` branch of `RightRail`'s render now picks one of two
   `<PinnedPanel>` invocations depending on `on_unpin.is_some()`,
   because Leptos's `#[prop(optional)]` doesn't accept `Option<_>`
   directly — the panel-side `on_unpin.is_some()` gate becomes the
   rail-level branch on whether the caller supplied the callback.

3. **`test(phase-3c): browser tests for header pin tint + unpin permission gate`**
   Four browser tests at the smallest tier that proves the prop
   boundary (`crates/web/tests/browser.rs`):
   - `header_pin_button_renders_amber_with_count_when_channel_has_pins`
     — `.action-btn--lit` + `.action-btn__count--pin` text "2" +
     aria-label `pinned messages (2)`.
   - `header_pin_button_has_no_count_when_channel_empty` — negative-
     path threshold lock.
   - `pinned_panel_per_entry_unpin_renders_when_can_unpin` — button
     renders enabled, click fires the callback with the row's id.
   - `pinned_panel_per_entry_unpin_disabled_without_permission` —
     `aria-disabled="true"` + `disabled` + tooltip
     `only stewards can pin here` + click does NOT fire the callback.

4. **`docs(phase-3c): tick AG-8 + AG-9 after wiring the missing callsites`**
   Tick the two gates in `docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md`.

## Tradeoffs

- **Branched render in `RightRail::Pinned` (chosen) vs. always passing a
  no-op `on_unpin`.** I picked the branched render to preserve
  `<PinnedPanel>`'s existing semantics: `on_unpin == None` ->
  no unpin button. The no-op alternative would always render the
  (disabled) button even when the caller didn't opt in, which would
  drift the panel's behaviour in headless tests that mount it
  without an unpin handler.
- **Test tier (chosen browser-tier).** Per `## Which test tier to use`
  in `CLAUDE.md`, the smallest tier that asserts DOM rendering of
  a single component in a single viewport is the wasm-pack browser
  tier. State / client tests can't observe DOM classes; Playwright
  would be over-spec.

## Test plan

- [x] `wasm-pack test --headless --firefox crates/web --test browser -- phase_3c_callsite_wiring` — 4/4 pass
- [x] `wasm-pack test --headless --firefox crates/web --test browser -- pinned` — 13/13 pass (no regressions to existing pinned-panel tests)
- [x] `just check` clean (fmt + clippy + tests + WASM) — willow-actor's debounce/derived timing tests are pre-existing flakes that pass on rerun; unrelated to this PR

## PR-B follow-up

PR-B will sweep the remaining phase-3c checkboxes (T4-T7 reactions
strip + chip + tooltip + composer wiring, T11 keyboard binding gate,
T12 browser-tier sweep, T13 spec checkbox tick-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)