### PR TITLE
ui+state(phase-3c): pinned-by footer + PinMetadata state schema

### DIFF
--- a/crates/client/src/actions.rs
+++ b/crates/client/src/actions.rs
@@ -218,8 +218,12 @@ impl<N: willow_network::Network> ClientHandle<N> {
             es.channels
                 .get(&channel_id)
                 .map(|ch| {
+                    // `pinned_messages` is keyed by message hash; the
+                    // metadata value (pinner + pin time) is consumed
+                    // by the pinned-panel projection in `views.rs` and
+                    // ignored here.
                     let mut ids: Vec<willow_state::EventHash> =
-                        ch.pinned_messages.iter().cloned().collect();
+                        ch.pinned_messages.keys().copied().collect();
                     ids.sort();
                     ids
                 })

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -215,7 +215,7 @@ pub mod event_receiver {
         }
     }
 }
-pub use state::{DisplayMessage, QueueNote};
+pub use state::{DisplayMessage, PinnedMetadata, QueueNote};
 pub use views::{
     derive_archives_view, since_hint, ArchivedChannelSummary, ArchivesView, ProfileDelta,
     ProfileView,

--- a/crates/client/src/mentions.rs
+++ b/crates/client/src/mentions.rs
@@ -375,6 +375,7 @@ mod tests {
             reply_preview: None,
             mentions,
             pinned: false,
+            pinned_metadata: None,
             queue_note: crate::state::QueueNote::None,
             whisper: false,
             attachment: None,

--- a/crates/client/src/search/tests.rs
+++ b/crates/client/src/search/tests.rs
@@ -969,6 +969,7 @@ mod from_display_message_tests {
             reply_preview: None,
             mentions: Vec::new(),
             pinned: false,
+            pinned_metadata: None,
             whisper: false,
             queue_note: QueueNote::None,
             attachment: None,

--- a/crates/client/src/state.rs
+++ b/crates/client/src/state.rs
@@ -86,6 +86,28 @@ pub enum QueueNote {
     Pending,
 }
 
+/// Pinned-message attribution + time, surfaced to the pinned-panel
+/// renderer for the `pinned by {name} · {when}` footer
+/// (`docs/specs/2026-04-19-ui-design/reactions-pins.md` §Pinned panel
+/// contents). Populated by the view projection in `views.rs` from
+/// `Channel::pinned_messages[hash]`; the display name is resolved at
+/// projection time via the same `resolve_display_name` ladder used by
+/// the row author name (profile → ProfileState → `unknown peer`).
+///
+/// `Some` when the carrying `DisplayMessage.pinned == true` and the
+/// channel's `PinMetadata` is present; `None` otherwise. The renderer
+/// gates the footer on `pinned_metadata.is_some()` so missing pinner
+/// data never leaks an empty footer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinnedMetadata {
+    /// Human display name of the peer who pinned the message.
+    pub pinner_display_name: String,
+    /// Wall-clock pin time in milliseconds (from the `PinMessage`
+    /// event's `timestamp_hint_ms`). The renderer formats this via
+    /// the same `format_relative_time` helper used for message rows.
+    pub pinned_at_ms: u64,
+}
+
 /// A message prepared for display. Computed on-the-fly from
 /// event_state, never stored. Display names are resolved at
 /// construction time so they're never stale.
@@ -120,6 +142,13 @@ pub struct DisplayMessage {
     /// the projection to drive the row marker + badge + run-break rule
     /// per `docs/specs/2026-04-19-ui-design/message-row.md` §Pins.
     pub pinned: bool,
+    /// `Some(_)` when [`Self::pinned`] is `true` and the channel's
+    /// `PinMetadata` is present in the materialized state. Surfaces
+    /// the pinner display name + pin time so the pinned-panel
+    /// renderer can show the `pinned by {name} · {when}` footer
+    /// (`docs/specs/2026-04-19-ui-design/reactions-pins.md` §Pinned
+    /// panel contents, line 123). `None` for non-pinned rows.
+    pub pinned_metadata: Option<PinnedMetadata>,
     /// Whether this message is part of a whisper (violet-rule placeholder).
     ///
     /// Phase 2a Task 8 reserves the layout + styling surface behind an

--- a/crates/client/src/views.rs
+++ b/crates/client/src/views.rs
@@ -18,7 +18,7 @@ use willow_identity::EndpointId;
 
 use crate::mentions::{extract_mention_peers, parse_mentions, PeerRef};
 use crate::presence::{derive_peer_presence, derive_self_presence, PresenceInputs, PresenceState};
-use crate::state::{DisplayMessage, QueueNote};
+use crate::state::{DisplayMessage, PinnedMetadata, QueueNote};
 use crate::state_actors::*;
 
 // ───── Profile card surfaces (phase 2c) ─────────────────────────────────
@@ -677,15 +677,25 @@ pub fn compute_messages_view(
             // `ServerState::channels[cid].pinned_messages` is a
             // `BTreeMap<EventHash, PinMetadata>` owned by the
             // pin-event projection in willow-state; message-row.md
-            // §Pins consumes it here as a quiet 1 px amber row marker +
-            // `pinned` badge. The metadata value (pinner + pin time)
-            // surfaces separately on the pinned-panel projection for
-            // the `pinned by {name} · {when}` footer.
-            let pinned = events
+            // §Pins consumes the `pinned` bool here as a quiet 1 px
+            // amber row marker + `pinned` badge.
+            //
+            // When the row is pinned we also project the
+            // `PinMetadata` value into a `PinnedMetadata` that
+            // resolves the pinner's display name via the same
+            // `resolve_display_name` ladder used for the row author.
+            // The renderer in `pinned.rs` reads this for the
+            // `pinned by {name} · {when}` footer
+            // (reactions-pins.md §Pinned panel contents, line 123).
+            let pin_meta = events
                 .channels
                 .get(&m.channel_id)
-                .map(|ch| ch.pinned_messages.contains_key(&m.id))
-                .unwrap_or(false);
+                .and_then(|ch| ch.pinned_messages.get(&m.id));
+            let pinned = pin_meta.is_some();
+            let pinned_metadata = pin_meta.map(|meta| PinnedMetadata {
+                pinner_display_name: resolve_display_name(events, profiles, &meta.pinner),
+                pinned_at_ms: meta.pinned_at_ms,
+            });
             // Queue-note derivation. Phase 2b wires the full
             // tri-state: `Pending` (local author still waiting on
             // acks) + `LateArrival` (remote author was offline near
@@ -735,6 +745,7 @@ pub fn compute_messages_view(
                 reply_preview,
                 mentions,
                 pinned,
+                pinned_metadata,
                 queue_note,
                 whisper,
                 attachment: m.attachment.clone(),
@@ -1437,6 +1448,147 @@ mod tests {
         assert!(
             !view.messages[0].pinned,
             "UnpinMessage must flip `pinned` back to false on projection"
+        );
+    }
+
+    /// `DisplayMessage.pinned_metadata` must surface the pinner's
+    /// resolved display name + the captured `pinned_at_ms` whenever a
+    /// row projects to `pinned == true`. Drives the
+    /// `pinned by {name} · {when}` footer in the pinned panel
+    /// (`docs/specs/2026-04-19-ui-design/reactions-pins.md` §Pinned
+    /// panel contents).
+    #[test]
+    fn projection_pinned_metadata_populated_with_resolved_display_name() {
+        let owner = Identity::generate().endpoint_id();
+        let pinner_id = Identity::generate().endpoint_id();
+        let mut state = fresh_state(owner);
+        // Make the pinner a member with a profile, so
+        // `resolve_display_name` returns the profile's display name.
+        state.members.insert(
+            pinner_id,
+            Member {
+                peer_id: pinner_id,
+                roles: Default::default(),
+                display_name: None,
+            },
+        );
+        state.profiles.insert(pinner_id, {
+            let mut p = Profile::new(pinner_id);
+            p.display_name = "mira".into();
+            p
+        });
+        push_channel(&mut state, "ch-1", "general");
+        let msg_hash = push_message(&mut state, "ch-1", owner, "pin me", 1_000);
+        state
+            .channels
+            .get_mut("ch-1")
+            .unwrap()
+            .pinned_messages
+            .insert(
+                msg_hash,
+                PinMetadata {
+                    pinner: pinner_id,
+                    pinned_at_ms: 1_700_000_000_000,
+                },
+            );
+
+        let events = Arc::new(state);
+        let registry = Arc::new(ServerRegistry::default());
+        let chat = Arc::new(ChatMeta {
+            current_channel: "general".into(),
+            peers: Vec::new(),
+            reaction_recency: Default::default(),
+        });
+        let profiles = Arc::new(ProfileState::default());
+        let queue_meta = Arc::new(QueueMeta::default());
+        let view = compute_messages_view(&events, &registry, &chat, &profiles, &queue_meta, owner);
+        assert_eq!(view.messages.len(), 1);
+        let pm = view.messages[0]
+            .pinned_metadata
+            .as_ref()
+            .expect("pinned row must carry PinnedMetadata");
+        assert_eq!(
+            pm.pinner_display_name, "mira",
+            "pinner_display_name must resolve via profile.display_name",
+        );
+        assert_eq!(
+            pm.pinned_at_ms, 1_700_000_000_000,
+            "pinned_at_ms must equal the source PinMetadata value",
+        );
+    }
+
+    /// `DisplayMessage.pinned_metadata` must fall back through the
+    /// same `resolve_display_name` ladder as the row author —
+    /// `unknown peer` when neither the server profile registry nor
+    /// the local `ProfileState.names` map carries an entry for the
+    /// pinner. Keeps the footer renderable even when profile sync is
+    /// lagging.
+    #[test]
+    fn projection_pinned_metadata_falls_back_to_unknown_peer() {
+        let owner = Identity::generate().endpoint_id();
+        let stranger = Identity::generate().endpoint_id();
+        let mut state = fresh_state(owner);
+        push_channel(&mut state, "ch-1", "general");
+        let msg_hash = push_message(&mut state, "ch-1", owner, "pin me", 1_000);
+        state
+            .channels
+            .get_mut("ch-1")
+            .unwrap()
+            .pinned_messages
+            .insert(
+                msg_hash,
+                PinMetadata {
+                    pinner: stranger,
+                    pinned_at_ms: 42,
+                },
+            );
+
+        let events = Arc::new(state);
+        let registry = Arc::new(ServerRegistry::default());
+        let chat = Arc::new(ChatMeta {
+            current_channel: "general".into(),
+            peers: Vec::new(),
+            reaction_recency: Default::default(),
+        });
+        let profiles = Arc::new(ProfileState::default());
+        let queue_meta = Arc::new(QueueMeta::default());
+        let view = compute_messages_view(&events, &registry, &chat, &profiles, &queue_meta, owner);
+        let pm = view.messages[0]
+            .pinned_metadata
+            .as_ref()
+            .expect("pinned row must carry PinnedMetadata even when profile is missing");
+        assert_eq!(
+            pm.pinner_display_name, "unknown peer",
+            "missing profile must surface the `unknown peer` fallback",
+        );
+        assert_eq!(pm.pinned_at_ms, 42);
+    }
+
+    /// Non-pinned rows must leave `pinned_metadata` as `None` — the
+    /// renderer gates the footer on `Some(_)`, so leaking a stale
+    /// value here would surface a "pinned by …" line on an unpinned
+    /// row.
+    #[test]
+    fn projection_pinned_metadata_is_none_for_unpinned_row() {
+        let owner = Identity::generate().endpoint_id();
+        let mut state = fresh_state(owner);
+        push_channel(&mut state, "ch-1", "general");
+        let _ = push_message(&mut state, "ch-1", owner, "not pinned", 1_000);
+
+        let events = Arc::new(state);
+        let registry = Arc::new(ServerRegistry::default());
+        let chat = Arc::new(ChatMeta {
+            current_channel: "general".into(),
+            peers: Vec::new(),
+            reaction_recency: Default::default(),
+        });
+        let profiles = Arc::new(ProfileState::default());
+        let queue_meta = Arc::new(QueueMeta::default());
+        let view = compute_messages_view(&events, &registry, &chat, &profiles, &queue_meta, owner);
+        assert!(!view.messages[0].pinned);
+        assert!(
+            view.messages[0].pinned_metadata.is_none(),
+            "unpinned rows must not carry PinnedMetadata",
         );
     }
 

--- a/crates/client/src/views.rs
+++ b/crates/client/src/views.rs
@@ -673,15 +673,18 @@ pub fn compute_messages_view(
                 .collect();
             let mention_segments = parse_mentions(&m.body, &peer_refs, &local_peer_id);
             let mentions = extract_mention_peers(&mention_segments);
-            // Stamp pinned from the channel's pinned-message set.
+            // Stamp pinned from the channel's pinned-message map.
             // `ServerState::channels[cid].pinned_messages` is a
-            // `BTreeSet<EventHash>` owned by the pin-event projection in
-            // willow-state; message-row.md §Pins consumes it here as a
-            // quiet 1 px amber row marker + `pinned` badge.
+            // `BTreeMap<EventHash, PinMetadata>` owned by the
+            // pin-event projection in willow-state; message-row.md
+            // §Pins consumes it here as a quiet 1 px amber row marker +
+            // `pinned` badge. The metadata value (pinner + pin time)
+            // surfaces separately on the pinned-panel projection for
+            // the `pinned by {name} · {when}` footer.
             let pinned = events
                 .channels
                 .get(&m.channel_id)
-                .map(|ch| ch.pinned_messages.contains(&m.id))
+                .map(|ch| ch.pinned_messages.contains_key(&m.id))
                 .unwrap_or(false);
             // Queue-note derivation. Phase 2b wires the full
             // tri-state: `Pending` (local author still waiting on
@@ -1156,7 +1159,9 @@ mod tests {
     use super::*;
     use std::collections::{BTreeMap, HashMap};
     use willow_identity::Identity;
-    use willow_state::{Channel, ChannelKind, ChatMessage, Member, Profile, ServerState};
+    use willow_state::{
+        Channel, ChannelKind, ChatMessage, Member, PinMetadata, Profile, ServerState,
+    };
 
     fn fresh_state(owner: EndpointId) -> ServerState {
         ServerState::new("srv", "Test", owner)
@@ -1374,7 +1379,13 @@ mod tests {
             .get_mut("ch-1")
             .unwrap()
             .pinned_messages
-            .insert(msg_hash);
+            .insert(
+                msg_hash,
+                PinMetadata {
+                    pinner: owner,
+                    pinned_at_ms: 1_000,
+                },
+            );
 
         let events = Arc::new(state);
         let registry = Arc::new(ServerRegistry::default());
@@ -1403,7 +1414,13 @@ mod tests {
         push_channel(&mut state, "ch-1", "general");
         let msg_hash = push_message(&mut state, "ch-1", owner, "pin me", 1_000);
         let ch = state.channels.get_mut("ch-1").unwrap();
-        ch.pinned_messages.insert(msg_hash);
+        ch.pinned_messages.insert(
+            msg_hash,
+            PinMetadata {
+                pinner: owner,
+                pinned_at_ms: 1_000,
+            },
+        );
         ch.pinned_messages.remove(&msg_hash);
 
         let events = Arc::new(state);

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -57,5 +57,5 @@ pub use sync::{
 };
 pub use types::{
     Channel, ChannelKind, ChatMessage, CrestPattern, FileAttachment, Member, MuteState,
-    PinnedFragment, PinnedKind, Profile, ProfileDelta, Role,
+    PinMetadata, PinnedFragment, PinnedKind, Profile, ProfileDelta, Role,
 };

--- a/crates/state/src/materialize.rs
+++ b/crates/state/src/materialize.rs
@@ -14,9 +14,10 @@ use crate::event::{Event, EventKind, Permission, ProposedAction, MAX_ENCRYPTED_K
 use crate::hash::EventHash;
 use crate::server::{PendingProposal, ServerState};
 use crate::types::{
-    Channel, ChatMessage, FileAttachment, Member, PinnedFragment, Profile, PROFILE_CAP_BIO,
-    PROFILE_CAP_CREST_COLOR, PROFILE_CAP_ELSEWHERE_ENTRY, PROFILE_CAP_ELSEWHERE_LEN,
-    PROFILE_CAP_PINNED_BODY, PROFILE_CAP_PRONOUNS, PROFILE_CAP_SINCE, PROFILE_CAP_TAGLINE,
+    Channel, ChatMessage, FileAttachment, Member, PinMetadata, PinnedFragment, Profile,
+    PROFILE_CAP_BIO, PROFILE_CAP_CREST_COLOR, PROFILE_CAP_ELSEWHERE_ENTRY,
+    PROFILE_CAP_ELSEWHERE_LEN, PROFILE_CAP_PINNED_BODY, PROFILE_CAP_PRONOUNS, PROFILE_CAP_SINCE,
+    PROFILE_CAP_TAGLINE,
 };
 
 /// Truncate `s` to at most `cap` UTF-8 characters.
@@ -381,7 +382,7 @@ fn apply_mutation(state: &mut ServerState, event: &Event) -> ApplyResult {
                     Channel {
                         id: channel_id.clone(),
                         name: name.clone(),
-                        pinned_messages: BTreeSet::new(),
+                        pinned_messages: BTreeMap::new(),
                         kind: kind.clone(),
                         ephemeral: ephemeral.clone(),
                         last_activity_hlc: None,
@@ -833,7 +834,18 @@ fn apply_mutation(state: &mut ServerState, event: &Event) -> ApplyResult {
                 return ApplyResult::Rejected(format!("author '{}' is not a member", event.author));
             }
             if let Some(ch) = state.channels.get_mut(channel_id) {
-                ch.pinned_messages.insert(*message_id);
+                // Capture pinner identity + pin time from the event so
+                // the pinned-panel UI can render the
+                // `pinned by {name} · {when}` footer without walking
+                // the DAG. See
+                // `docs/specs/2026-05-21-pinned-message-metadata-design.md`.
+                ch.pinned_messages.insert(
+                    *message_id,
+                    PinMetadata {
+                        pinner: event.author,
+                        pinned_at_ms: event.timestamp_hint_ms,
+                    },
+                );
             }
         }
 

--- a/crates/state/src/tests/materialize.rs
+++ b/crates/state/src/tests/materialize.rs
@@ -720,7 +720,7 @@ fn pin_and_unpin_message() {
     let state = materialize(&dag);
     let channel = state.channels.get(&ch_id).expect("channel should exist");
     assert!(
-        channel.pinned_messages.contains(&msg.hash),
+        channel.pinned_messages.contains_key(&msg.hash),
         "message should be pinned"
     );
 
@@ -737,8 +737,71 @@ fn pin_and_unpin_message() {
     let state = materialize(&dag);
     let channel = state.channels.get(&ch_id).expect("channel should exist");
     assert!(
-        !channel.pinned_messages.contains(&msg.hash),
+        !channel.pinned_messages.contains_key(&msg.hash),
         "message should be unpinned"
+    );
+}
+
+/// `PinMessage` apply must capture the pinner's `EndpointId` and the
+/// event's `timestamp_hint_ms` into `Channel::pinned_messages`. The
+/// `pinned by {name} · {when}` footer in the pinned-panel UI reads
+/// these fields directly from the materialized state without walking
+/// the DAG (see
+/// `docs/specs/2026-05-21-pinned-message-metadata-design.md`).
+#[test]
+fn pin_message_captures_pinner_and_timestamp() {
+    let owner = Identity::generate();
+    let mut dag = test_dag(&owner);
+    let ch_id = "general".to_string();
+    do_emit(
+        &mut dag,
+        &owner,
+        EventKind::CreateChannel {
+            name: "general".into(),
+            channel_id: ch_id.clone(),
+            kind: crate::types::ChannelKind::Text,
+            ephemeral: None,
+        },
+    );
+    let msg = do_emit(
+        &mut dag,
+        &owner,
+        EventKind::Message {
+            channel_id: ch_id.clone(),
+            body: "pin me".into(),
+            reply_to: None,
+        },
+    );
+
+    // Use a non-zero timestamp_hint_ms on the pin event so the
+    // assertion proves the field is copied from the event rather
+    // than defaulted.
+    const PIN_AT_MS: u64 = 1_700_000_123_456;
+    let pin_event = dag.create_event(
+        &owner,
+        EventKind::PinMessage {
+            channel_id: ch_id.clone(),
+            message_id: msg.hash,
+        },
+        vec![],
+        PIN_AT_MS,
+    );
+    dag.insert(pin_event).unwrap();
+
+    let state = materialize(&dag);
+    let channel = state.channels.get(&ch_id).expect("channel exists");
+    let meta = channel
+        .pinned_messages
+        .get(&msg.hash)
+        .expect("PinMessage must populate PinMetadata for the message");
+    assert_eq!(
+        meta.pinner,
+        owner.endpoint_id(),
+        "PinMetadata.pinner must equal event.author",
+    );
+    assert_eq!(
+        meta.pinned_at_ms, PIN_AT_MS,
+        "PinMetadata.pinned_at_ms must equal event.timestamp_hint_ms",
     );
 }
 

--- a/crates/state/src/tests/permissions.rs
+++ b/crates/state/src/tests/permissions.rs
@@ -1557,7 +1557,7 @@ fn pin_message_by_member_is_applied() {
         .get("ch1")
         .unwrap()
         .pinned_messages
-        .contains(&msg_hash));
+        .contains_key(&msg_hash));
 }
 
 #[test]
@@ -1622,7 +1622,7 @@ fn pin_message_by_kicked_member_is_rejected() {
             .get("ch1")
             .unwrap()
             .pinned_messages
-            .contains(&msg_hash),
+            .contains_key(&msg_hash),
         "kicked peer must not mutate pinned_messages",
     );
 }
@@ -1690,7 +1690,7 @@ fn pin_message_by_non_member_is_rejected() {
             .get("ch1")
             .unwrap()
             .pinned_messages
-            .contains(&msg_hash),
+            .contains_key(&msg_hash),
         "non-member must not mutate pinned_messages",
     );
 }
@@ -1749,7 +1749,7 @@ fn unpin_message_by_member_is_applied() {
         .get("ch1")
         .unwrap()
         .pinned_messages
-        .contains(&msg_hash));
+        .contains_key(&msg_hash));
 }
 
 #[test]
@@ -1790,7 +1790,7 @@ fn unpin_message_by_kicked_member_is_rejected() {
         .get("ch1")
         .unwrap()
         .pinned_messages
-        .contains(&msg_hash));
+        .contains_key(&msg_hash));
 
     // Kick peer.
     let kick = managed.dag().create_event(
@@ -1833,7 +1833,7 @@ fn unpin_message_by_kicked_member_is_rejected() {
             .get("ch1")
             .unwrap()
             .pinned_messages
-            .contains(&msg_hash),
+            .contains_key(&msg_hash),
         "kicked peer must not unpin",
     );
 }
@@ -1910,7 +1910,7 @@ fn unpin_message_by_non_member_is_rejected() {
             .get("ch1")
             .unwrap()
             .pinned_messages
-            .contains(&msg_hash),
+            .contains_key(&msg_hash),
         "non-member must not unpin",
     );
 }

--- a/crates/state/src/types.rs
+++ b/crates/state/src/types.rs
@@ -11,6 +11,29 @@ use willow_identity::EndpointId;
 
 use crate::hash::EventHash;
 
+/// Metadata captured at the moment a message is pinned.
+///
+/// Surfaced by the pinned-panel UI to render the `pinned by {name} ·
+/// {when}` footer (spec
+/// `docs/specs/2026-04-19-ui-design/reactions-pins.md` §Pinned panel
+/// contents, line 123). Populated by the `PinMessage` apply branch in
+/// `materialize::apply_event` from the source event's `author` and
+/// `timestamp_hint_ms` so the metadata travels with the materialized
+/// state and the renderer never has to walk the DAG.
+///
+/// See `docs/specs/2026-05-21-pinned-message-metadata-design.md` for
+/// the schema rationale + the rejected alternatives (derive-from-DAG
+/// and parallel `pin_metadata` index).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PinMetadata {
+    /// Peer id of the user who emitted the `PinMessage` event.
+    pub pinner: EndpointId,
+    /// Wall-clock timestamp hint in milliseconds, copied from the
+    /// `PinMessage` event's `timestamp_hint_ms`. Display only — never
+    /// used for ordering inside the state machine.
+    pub pinned_at_ms: u64,
+}
+
 /// Channel kind — text chat or voice.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ChannelKind {
@@ -30,9 +53,13 @@ pub struct Channel {
     pub id: String,
     /// Display name (e.g. "general").
     pub name: String,
-    /// Hashes of pinned messages in this channel.
+    /// Pinned messages in this channel keyed by message hash. The
+    /// value carries the pinner identity + pin time so the pinned-panel
+    /// UI can render the `pinned by {name} · {when}` footer without
+    /// walking the DAG (see
+    /// `docs/specs/2026-05-21-pinned-message-metadata-design.md`).
     #[serde(default)]
-    pub pinned_messages: BTreeSet<EventHash>,
+    pub pinned_messages: BTreeMap<EventHash, PinMetadata>,
     /// Text or voice.
     #[serde(default)]
     pub kind: ChannelKind,

--- a/crates/web/src/components/pinned.rs
+++ b/crates/web/src/components/pinned.rs
@@ -98,6 +98,24 @@ pub fn PinnedPanel(
                         let on_jump = on_jump.clone();
                         let unpin_disabled = move || !can_unpin.get();
                         let unpin_aria_label = "unpin message".to_string();
+                        // `pinned by {name} · {when}` footer — spec
+                        // `docs/specs/2026-04-19-ui-design/reactions-pins.md`
+                        // §Pinned panel contents, line 123. Rendered
+                        // only when the projection populated
+                        // `pinned_metadata`; absent metadata omits the
+                        // entire <footer> per the
+                        // `pinned-message-metadata-design` doc's
+                        // omission contract.
+                        let pinner_footer = msg.pinned_metadata.as_ref().map(|meta| {
+                            let name = meta.pinner_display_name.clone();
+                            let pin_when = pinned_timestamp(meta.pinned_at_ms);
+                            view! {
+                                <footer class="pinned-entry__footer">
+                                    "pinned by " {name} " · "
+                                    <span class="pinned-entry__footer-when">{pin_when}</span>
+                                </footer>
+                            }
+                        });
                         view! {
                             <article class="pinned-entry">
                                 <div class="pinned-entry__meta">
@@ -110,6 +128,7 @@ pub fn PinnedPanel(
                                 <div class="pinned-entry__body">
                                     {render_body_with_links(&body)}
                                 </div>
+                                {pinner_footer}
                                 <div class="pinned-entry__actions">
                                     <button
                                         class="pinned-entry__jump"

--- a/crates/web/style.css
+++ b/crates/web/style.css
@@ -7195,6 +7195,22 @@ select:focus-visible {
     overflow: hidden;
 }
 
+/*
+ * `pinned by {name} · {when}` footer per spec
+ * `docs/specs/2026-04-19-ui-design/reactions-pins.md`
+ * §Pinned panel contents (line 123): --ink-3, 10 px, mono `when`.
+ */
+.pinned-entry__footer {
+    color: var(--ink-3);
+    font-family: var(--font-ui);
+    font-size: 10px;
+    margin-top: 4px;
+}
+
+.pinned-entry__footer-when {
+    font-family: var(--font-mono);
+}
+
 .pinned-entry__actions {
     display: inline-flex;
     gap: 8px;

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -135,6 +135,7 @@ fn make_msg(author: &str, body: &str, timestamp_ms: u64) -> willow_client::Displ
         reply_preview: None,
         mentions: Vec::new(),
         pinned: false,
+        pinned_metadata: None,
         queue_note: willow_client::QueueNote::None,
         whisper: false,
         attachment: None,

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -3220,8 +3220,8 @@ mod phase_3c_callsite_wiring {
         });
         tick().await;
 
-        let footer = query(&container, ".pinned-entry__footer")
-            .expect(".pinned-entry__footer must render");
+        let footer =
+            query(&container, ".pinned-entry__footer").expect(".pinned-entry__footer must render");
         let footer_text = text(&footer);
         assert!(
             footer_text.contains("pinned by"),

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -2986,12 +2986,19 @@ async fn pinned_panel_close_button_fires_callback() {
     assert!(closed.get_untracked(), "close callback should have fired");
 }
 
-// ── Phase 3c — visibility fixes (PR-A) ──────────────────────────────────────
+// ── Phase 3c — visibility fixes + pinned-by footer ──────────────────────────
 //
-// The header pin tint + per-entry unpin button landed component-side in PRs
-// #634 / #635 / #637 but no caller threaded the new optional props, so the
-// affordances never reached the live UI. These tests assert the prop
-// boundary at the smallest granularity that proves the wiring works.
+// Two phase-3c gaps land here together:
+//   - **AG-8 / AG-9 (callsite wiring).** The header pin tint + per-entry
+//     unpin button landed component-side in PRs #634 / #635 / #637 but no
+//     caller threaded the new optional props, so the affordances never
+//     reached the live UI.
+//   - **AG-7 (pinned-by footer).** `<PinnedPanel>` must render a
+//     `pinned by {name} · {when}` footer whenever the row's
+//     `pinned_metadata` is `Some(_)`, per spec §Pinned panel contents.
+//
+// Both sets of tests share the same `make_msg` fixture + DOM helpers, so
+// they live in one module for clarity.
 
 mod phase_3c_callsite_wiring {
     use leptos::prelude::*;
@@ -3185,6 +3192,88 @@ mod phase_3c_callsite_wiring {
         assert!(
             clicked_id.get_untracked().is_none(),
             "on_unpin callback does NOT fire when can_unpin == false"
+        );
+    }
+    /// AG-7: `<PinnedPanel>` must render a `.pinned-entry__footer`
+    /// carrying the spec-exact `pinned by {name} · {when}` copy whenever
+    /// the row's `pinned_metadata` is `Some(_)`. Drives the footer
+    /// contract in `docs/specs/2026-04-19-ui-design/reactions-pins.md`
+    /// §Pinned panel contents, line 123.
+    #[wasm_bindgen_test]
+    async fn pinned_panel_renders_pinned_by_footer_when_metadata_present() {
+        let mut msg = make_msg("Mira", "pinned body", 1_000);
+        msg.pinned = true;
+        msg.pinned_metadata = Some(willow_client::PinnedMetadata {
+            pinner_display_name: "ori".into(),
+            pinned_at_ms: 1_000,
+        });
+        let (msgs, _) = signal(vec![msg]);
+
+        let container = mount_test(move || {
+            view! {
+                <PinnedPanel
+                    messages=msgs
+                    on_jump=move |_: String| ()
+                    on_close=move |_: ()| ()
+                />
+            }
+        });
+        tick().await;
+
+        let footer = query(&container, ".pinned-entry__footer")
+            .expect(".pinned-entry__footer must render");
+        let footer_text = text(&footer);
+        assert!(
+            footer_text.contains("pinned by"),
+            "footer must start with `pinned by`, got: {footer_text:?}"
+        );
+        assert!(
+            footer_text.contains("ori"),
+            "footer must include the pinner name, got: {footer_text:?}"
+        );
+        assert!(
+            footer_text.contains("·"),
+            "footer must include the spec's middot separator, got: {footer_text:?}"
+        );
+        let when_span = query(&container, ".pinned-entry__footer-when").expect(
+            ".pinned-entry__footer-when must render so the spec's mono `when` is styleable",
+        );
+        assert!(
+            !text(&when_span).trim().is_empty(),
+            "`when` span must carry the relative-time string",
+        );
+    }
+
+    /// AG-7 (negative): defense-in-depth against leaking the footer onto
+    /// unpinned rows or rows where the pinner metadata never materialized.
+    /// When `pinned_metadata` is `None`, `<PinnedPanel>` must omit the
+    /// `.pinned-entry__footer` element entirely.
+    #[wasm_bindgen_test]
+    async fn pinned_panel_omits_footer_when_metadata_absent() {
+        let msg = make_msg("Mira", "no pinner metadata", 1_000);
+        // `make_msg` defaults `pinned_metadata` to `None`. The row is
+        // therefore still rendered (`<PinnedPanel>` doesn't gate on
+        // `pinned`) but the footer line must NOT appear.
+        let (msgs, _) = signal(vec![msg]);
+
+        let container = mount_test(move || {
+            view! {
+                <PinnedPanel
+                    messages=msgs
+                    on_jump=move |_: String| ()
+                    on_close=move |_: ()| ()
+                />
+            }
+        });
+        tick().await;
+
+        assert!(
+            query(&container, ".pinned-entry").is_some(),
+            "the pinned entry should still render (smoke check on the fixture)",
+        );
+        assert!(
+            query(&container, ".pinned-entry__footer").is_none(),
+            "footer must be omitted when `pinned_metadata` is None",
         );
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,7 @@ Every entry below carries one of:
 **Specs**
 
 - [Willow UI — target UX bundle](specs/2026-04-19-ui-design/README.md) — 20+ child specs covering desktop and mobile target UX across layout, components, and interactions. `[active]`
+- [Pinned-message metadata](specs/2026-05-21-pinned-message-metadata-design.md) — extends Channel pinned_messages to carry pinner + pin-time. `[active]`
 - [UX navigation improvements](specs/2026-03-25-ux-navigation-improvements-design.md) — unifies settings, adds confirmation dialogs, breadcrumbs, and command palette. `[active]`
 - [Video, screen sharing + call page](specs/2026-03-26-screen-sharing-call-page-design.md) — adds camera video, screen sharing, and full call page UI to voice chat. `[active]`
 - [Async client + UI refactor](specs/2026-03-24-async-client-ui-refactor-design.md) — eliminates polling by splitting `Client` into `ClientHandle` + async event loop. `[landed]`

--- a/docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md
+++ b/docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md
@@ -71,7 +71,7 @@
 - [x] **AG-4.** `<EmojiPicker>` search filter narrows the grid to matching glyphs.
 - [x] **AG-5.** `<ReactorTooltip>` shows the spec copy: `mira, ori, kes reacted` for ≤ 3 reactors, `first two, and N others` past 3.
 - [x] **AG-6.** `client.recent_reactions(channel_id)` returns the 5 most-recent reactions in the channel, MRU-first; falls back to the spec default until the LRU fills. Per-channel — different channels keep separate recency.
-- [ ] **AG-7.** Pinned panel renders entries with avatar + display name + timestamp + 2-line preview + optional `pinned by {name} · {when}` footer. Empty state copy is byte-exact `nothing pinned yet.`.
+- [x] **AG-7.** Pinned panel renders entries with avatar + display name + timestamp + 2-line preview + optional `pinned by {name} · {when}` footer. Empty state copy is byte-exact `nothing pinned yet.`. *(Footer + `PinMetadata` state-schema change landed in the phase-3c close-out PR — see `docs/specs/2026-05-21-pinned-message-metadata-design.md`.)*
 - [x] **AG-8.** Pinned panel `unpin` button is permission-gated: greyed + `aria-disabled="true"` + tooltip `only stewards can pin here` when local peer lacks `ManageChannels`.
 - [x] **AG-9.** Header pin IconBtn tints `--amber` when channel has pins; superscript count overlay shows the count.
 - [x] **AG-10.** Pin / unpin keyboard binding (`P`) on a focused row is permission-gated.

--- a/docs/specs/2026-04-19-ui-design/reactions-pins.md
+++ b/docs/specs/2026-04-19-ui-design/reactions-pins.md
@@ -121,7 +121,11 @@ The pinned panel is the right-rail / overlay slot:
 - Each entry: mini message card — avatar (24 px), display name (body
   weight 500), timestamp (`--ink-3`, 11 px), body preview (2 lines
   max, ellipsis), optional `pinned by {name} · {when}` footer row
-  (`--ink-3`, 10 px, mono `when`).
+  (`--ink-3`, 10 px, mono `when`). The footer is omitted when the
+  pinner's `PinMetadata` has not yet materialized for this peer
+  (rare; resolves on the next profile sync). Schema for
+  `PinMetadata` lives in
+  [`../2026-05-21-pinned-message-metadata-design.md`](../2026-05-21-pinned-message-metadata-design.md).
 - Entry actions (right-aligned on hover / always on mobile): `jump to`
   (scrolls the channel list to the parent message and flashes it via
   the same 180 ms `willow-pop-in` as reply-jump), `unpin`
@@ -227,9 +231,12 @@ Color is never the sole signifier.
 - [x] Header pin IconBtn shows a superscript count when > 0 and tints
       amber; click opens the pinned panel. *(`<MainPaneHeader>` +
       `pinned_count` prop — phase 3c.)*
-- [x] Pinned panel lists pinned messages newest-first, jump-to scrolls
-      and flashes the parent, unpin honours the permission check.
-      *(`<PinnedPanel>` rewrite — phase 3c.)*
+- [x] Pinned panel lists pinned messages newest-first, each entry
+      shows a `pinned by {name} · {when}` footer (omitted only when
+      pinner metadata is not yet materialized), jump-to scrolls and
+      flashes the parent, unpin honours the permission check.
+      *(`<PinnedPanel>` rewrite — phase 3c; footer + `PinMetadata`
+      state-schema change — phase 3c close-out.)*
 - [x] Every interactive element has an ARIA label per §Accessibility.
       *(`add reaction`, `download {filename}`, `react with {emoji}`,
       `{emoji} reacted by {count} — toggle your reaction`,

--- a/docs/specs/2026-05-21-pinned-message-metadata-design.md
+++ b/docs/specs/2026-05-21-pinned-message-metadata-design.md
@@ -1,0 +1,103 @@
+# Pinned-message metadata — `pinned by {name} · {when}` footer
+
+**Date:** 2026-05-21
+**Status:** active
+**Parent specs:**
+[`reactions-pins.md`](2026-04-19-ui-design/reactions-pins.md),
+[`2026-04-12-state-authority-and-mutations.md`](2026-04-12-state-authority-and-mutations.md)
+**Implementation plan:** PR-C of phase-3c close-out
+(`docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md` AG-7 / T8)
+
+## Problem
+
+`docs/specs/2026-04-19-ui-design/reactions-pins.md` §Pinned panel contents
+(line 123) specifies an optional `pinned by {name} · {when}` footer on each
+pinned-panel entry — `--ink-3`, 10 px, mono `when`. The current
+implementation does not render this footer, and the acceptance criterion at
+line 230 has been ticked anyway. The root cause is upstream: the materialized
+state stores `Channel::pinned_messages: BTreeSet<EventHash>` and so loses the
+pinner identity + pin time from the `PinMessage` event. The renderer has
+nothing to read.
+
+## Decision
+
+Replace the pinned-messages set with a map carrying capture metadata:
+
+```rust
+pub struct PinMetadata {
+    /// Peer id of the user who emitted the PinMessage event.
+    pub pinner: EndpointId,
+    /// `event.timestamp_hint_ms` from the PinMessage event (ms wall clock).
+    pub pinned_at_ms: u64,
+}
+
+// On Channel:
+pub pinned_messages: BTreeMap<EventHash, PinMetadata>,
+```
+
+`willow-state::materialize` captures `event.author` and
+`event.timestamp_hint_ms` when applying `EventKind::PinMessage`. The client
+projection surfaces a derived `PinnedMetadata { pinner_display_name,
+pinned_at_ms }` on `DisplayMessage` for the pinned-panel projection only
+(message-list projections leave it `None`). The web renderer reads the
+metadata to render the footer.
+
+## Rejected alternatives
+
+### Derive from the DAG on every render
+
+Walk the DAG to locate the `PinMessage` event for each pinned hash and read
+`author` + `timestamp_hint_ms` there. Rejected because:
+
+- O(messages × pins) per pinned-panel render — the panel re-renders on every
+  channel switch.
+- Forces the client to retain old `PinMessage` events forever, even after
+  `UnpinMessage` — those events have no other consumer once the materialized
+  state has applied them.
+
+The metadata captured eagerly at apply time is O(pins) extra memory per
+channel and zero extra IO per render — strictly cheaper.
+
+### Parallel `pin_metadata` index alongside the existing set
+
+Keep `pinned_messages: BTreeSet<EventHash>` and add
+`pin_metadata: BTreeMap<EventHash, PinMetadata>` as a sibling field on
+`Channel`. Rejected because it doubles the invariants the apply branch must
+maintain — every `PinMessage` would have to update both, and `UnpinMessage`
+would have to remove from both. Replacing the set with a map keeps a single
+source of truth: presence in the map *is* the "pinned" bit.
+
+## Migration
+
+None required. `ServerState` is materialized from the DAG by every consumer
+(web/client, replay worker, storage worker, agent); there is no persisted
+state-level struct. `Channel` derives `Serialize`/`Deserialize` but is not
+written to disk or to the wire in any production path — the only call site
+is a round-trip test in `crates/state/src/tests/materialize.rs`.
+
+## Wire format
+
+Unchanged. No new `EventKind`; the `PinMessage` payload remains
+`{ channel_id, message_id }`. Only the materialized projection schema
+changes, and the materialized schema is not part of the wire protocol.
+
+## Footer omission contract
+
+The footer renders whenever `DisplayMessage.pinned_metadata` is `Some`. The
+projection populates `pinner_display_name` via `resolve_display_name`, which
+already has a documented fallback ladder (`profile.display_name` →
+`ProfileState.names` → `unknown peer`). The footer therefore renders even
+when the pinner is a stranger or absent; the `pinned by unknown peer · …`
+form is acceptable.
+
+If the projection ever needs to *suppress* the footer (e.g. for very recent
+pins where profile data has not yet synced), it can leave `pinned_metadata`
+as `None`. v1 always emits it.
+
+## Open question (resolved)
+
+**Should the footer surface for the local user's own pins?** Yes. The spec
+says "optional `pinned by {name} · {when}` footer" — interpret as "shown
+when meaningful". Self-attribution is meaningful for audit trails ("yes, I
+pinned this last spring") and keeps the rendering branch single-path. The
+footer renders for all pinners including self.


### PR DESCRIPTION
## Summary

Implements PR-C of the phase-3c close-out: the spec-required
`pinned by {name} · {when}` footer on each pinned-panel entry.
Carries the change all the way through the stack — state, client
projection, and web renderer — because the materialized state
lacked the pinner identity + pin time the footer needs.

**Audit finding.** `docs/specs/2026-04-19-ui-design/reactions-pins.md`
§Pinned panel contents (line 123) specifies the footer as part of
the entry layout, and acceptance criterion #6 had been ticked,
but the production renderer never emitted it. Root cause: the
materialized `Channel::pinned_messages` field stored
`BTreeSet<EventHash>` — only "is pinned?", no pinner, no pin time.

**Schema change.** Replaces the set with
`BTreeMap<EventHash, PinMetadata>` where
`PinMetadata { pinner: EndpointId, pinned_at_ms: u64 }` is captured
from `event.author` and `event.timestamp_hint_ms` at PinMessage
apply time. The map's keys serve the same "is pinned?" role as
the old set, so there is a single source of truth.

**Design doc.** Full rationale + rejected alternatives:
[`docs/specs/2026-05-21-pinned-message-metadata-design.md`](../tree/phase-3c/pinned-by-footer/docs/specs/2026-05-21-pinned-message-metadata-design.md).
Covers why we capture eagerly (not derive-from-DAG) and why we
replace the set (not add a parallel `pin_metadata` index).

**No migration.** `ServerState` is materialized from the DAG by
every consumer; there is no on-disk or on-wire serialization of the
`Channel` struct in any production path.

## Commits

1. `docs(spec): add pinned-message-metadata design`
2. `state(phase-3c): replace pinned_messages BTreeSet with BTreeMap<EventHash, PinMetadata>`
3. `client(phase-3c): surface pinned_metadata on DisplayMessage for pinned-panel projections`
4. `ui(phase-3c): render pinned-entry footer with pinner + when`
5. `docs(phase-3c): tick AG-7, amend spec criterion #6, add footer omission note`

## Tests

- **State:** +1 — `pin_message_captures_pinner_and_timestamp`
  asserts `apply_event(PinMessage)` copies `event.author` and a
  non-zero `timestamp_hint_ms` into `PinMetadata`. Existing pin/unpin
  + permission tests migrated from `.contains` to `.contains_key`.
  All 260 state tests pass.
- **Client:** +3 —
  `projection_pinned_metadata_populated_with_resolved_display_name`
  (profile-name resolution),
  `projection_pinned_metadata_falls_back_to_unknown_peer`
  (resolution ladder fallback),
  `projection_pinned_metadata_is_none_for_unpinned_row` (defense in
  depth). All 354 client tests pass.
- **Browser:** +2 —
  `pinned_panel_renders_pinned_by_footer_when_metadata_present`
  (mounts the real `<PinnedPanel>` with `PinnedMetadata` and asserts
  footer text + structure) and
  `pinned_panel_omits_footer_when_metadata_absent` (no footer
  element when metadata is `None`). All 385 browser tests pass.

## Test plan

- [ ] CI green on all three tiers.
- [ ] Reviewer spot-checks the design note for the schema decision
  rationale and confirms the no-migration claim against any state
  serialization path I might have missed.
- [ ] Visual smoke against `just dev`: pin a message in the web UI,
  open the pinned panel, confirm the footer reads
  `pinned by {your name} · {when}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)