### PR TITLE
ci: bump taiki-e/install-action to v2.79.3 — fixes wasm-pack 404

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           key: browser-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: browser-
       - name: Install wasm-pack
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.9.4
+        uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3
         with:
           tool: wasm-pack
       - id: browser

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
           restore-keys: deploy-
 
       - name: Install trunk
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.9.4 trunk
+        uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3 trunk
         with:
           tool: trunk@0.21.14
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,7 +39,7 @@ jobs:
           restore-keys: e2e-
 
       - name: Install just
-        uses: taiki-e/install-action@cf525cb33f51aca27cd6fa02034117ab963ff9f1 # v2.9.4 just
+        uses: taiki-e/install-action@65851e10cd6c377f11a60e600abc07cb08643468 # v2.79.3 just
         with:
           tool: just
 


### PR DESCRIPTION
## Summary

- The pinned SHA `cf525cb…` was actually **v2.75.22** (April-2026) — the workflow comments lied (they said `# v2.9.4`); the SHA itself resolves to v2.75.22. Confirmed via `gh api repos/taiki-e/install-action/commits/cf525cb…`.
- v2.75.22's bundled wasm-pack URL manifest still pointed at `github.com/drager/wasm-pack/releases/...`, which now returns **404**. wasm-pack's release artifacts were relocated upstream to `wasm-bindgen/wasm-pack`. The install-action release notes for v2.78.2 explicitly mention "Update `wasm-pack@latest` to 0.15.0" — that's the version that picked up the new URL.
- This blocks the **Browser tests (wasm-pack + Firefox)** CI job on every PR; there is no code-side mitigation because the URL table is bundled at the pinned SHA. PRs #643 and #644 both hit this failure today (each spent ~25 min in CI before failing).
- Bumping all three workflows (`ci.yml`, `deploy.yml`, `e2e.yml`) to **v2.79.3** (latest stable, published 2026-05-20, SHA `65851e1…`) restores the job. Also corrects the workflow comments which were already stale.
- This supersedes #642 (dependabot, 2.75.22 → 2.78.2) — v2.79.3 is newer.

## Test plan
- [ ] CI green on this PR (especially the Browser tests job).
- [ ] PR #643 (`phase-3c/visibility-fixes`) re-runs and turns green after merge.
- [ ] PR #644 (`phase-3c/pinned-by-footer`) re-runs and turns green after merge.
- [ ] PR #646 (`phase-3c/docs-close-out`) re-runs and turns green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)