### PR TITLE
docs(phase-3c): close-out plan + spec + master index + STATUS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,9 @@ Every entry below carries one of:
 - [UI phase 2c — profile card](plans/2026-04-21-ui-phase-2c-profile-card.md) — 17-field profile popover/sheet, crest banner, and private nickname editor. `[landed]`
 - [UI phase 2d — ephemeral channels](plans/2026-04-25-ui-phase-2d-ephemeral-channels.md) — auto-archive on inactivity, archives surface, kind chip, and revive flow. `[landed]`
 - [UI phase 2e — local search](plans/2026-04-21-ui-phase-2e-local-search.md) — on-device encrypted search index with scope ladder and streamed results surface. `[active]`
+- [UI phase 3a — composer](plans/2026-04-26-ui-phase-3a-composer.md) — composer revamp: formatting toolbar, mention autocomplete, slash commands, drafts persistence, paste-rich behavior. `[landed]`
+- [UI phase 3b — files & inline attachments](plans/2026-05-08-ui-phase-3b-files-inline.md) — upload dialog + drag-and-drop + paste-to-upload + inline image/file/voice-note rendering. `[landed]`
+- [UI phase 3c — reactions & pins](plans/2026-05-08-ui-phase-3c-reactions-pins.md) — EmojiPicker, reactions strip polish, pinned-panel rewrite, header pin amber tint. `[landed]`
 - [Issue #354 — search index incremental rebuild](plans/2026-05-02-issue-354-search-incremental.md) — replaces per-message-list-change full index rebuild with incremental updates. `[active]`
 
 See also: [`plans/STATUS.md`](plans/STATUS.md) — point-in-time audit of which UI-phase plans have landed.

--- a/docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md
+++ b/docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md
@@ -42,9 +42,8 @@
 
 | Path | State | Responsibility |
 |---|---|---|
-| `crates/client/src/views.rs` | modify | Add `recent_reactions(channel_id) -> [String; 5]` derived view: 5-deep LRU keyed by channel id, fed by every successful `react()` call. Falls back to the spec default until the LRU fills. State lives in a new `state_actors::ReactionRecency` actor. |
+| `crates/client/src/actions.rs` | modify | Add `ClientHandle::recent_reactions(channel) -> Vec<String>` (delegates to `ChatMeta::recent_reactions`); `ClientHandle::react` now calls `note_reaction` after the mutation succeeds. |
 | `crates/client/src/state_actors.rs` | modify | Add `ReactionRecency { per_channel: HashMap<String, VecDeque<String>> }` actor + `note(channel_id, emoji)` + `recent(channel_id) -> Vec<String>` (cap 5). |
-| `crates/client/src/state.rs` | modify | Re-export `ReactionRecency` so the web crate can read it through the existing context-provider pattern. |
 | `crates/web/src/components/emoji_picker/mod.rs` | **new** | `pub mod picker; pub mod categories; pub use picker::EmojiPicker;` plus the static category data table (smileys / nature / food / travel / objects / symbols). |
 | `crates/web/src/components/emoji_picker/picker.rs` | **new** | `<EmojiPicker open recent on_select on_close>` — 320 × 360 popover with mono search input + category-scrolled grid. Handles arrow / Enter / Escape keyboard. Reads `recent` from props (caller threads in `client.recent_reactions(channel_id)`). |
 | `crates/web/src/components/emoji_picker/categories.rs` | **new** | Static `EMOJI_CATEGORIES: &[(&str, &[&str])]` data + a small `search(query, recent) -> Vec<&str>` helper used by the picker's filter. Pure-function unit tests. |
@@ -57,7 +56,7 @@
 | `crates/web/src/components/main_pane_header.rs` | modify | Header pin IconBtn picks up `--amber` tint when `pinned_message_ids(channel).len() > 0` and renders a mono superscript count overlay when > 0. ARIA `pinned messages ({count})`. |
 | `crates/web/src/components/composer/composer.rs` | modify | Wire the existing `smile` emoji IconBtn click handler to open the shared `<EmojiPicker>` (currently a TODO callback per phase-3a §Out of scope). |
 | `crates/web/src/components/chat.rs` | modify | Permission-gate the pin / unpin keyboard binding (`P` on focused row) on `ManageChannels` — currently fires for everyone. |
-| `crates/web/style.css` | modify | Append `.emoji-picker`, `.emoji-picker__search`, `.emoji-picker__category-header`, `.emoji-picker__cell`, `.emoji-picker__cell--selected`, `.reactions-strip`, `.reaction-pill`, `.reaction-pill--reacted`, `.reactor-tooltip`, `.add-reaction-chip`, `.pinned-entry`, `.pinned-entry__avatar`, `.pinned-entry__meta`, `.pinned-entry__body`, `.pinned-entry__footer`, `.pinned-entry__actions`, `.pinned-empty`, `.pin-icon-btn--lit`, `.pin-icon-btn__count`. Foundation tokens only — `--bg-1`, `--bg-2`, `--line`, `--moss-1`, `--moss-2`, `--ink-0`, `--ink-1`, `--ink-2`, `--ink-3`, `--amber`, `--shadow-2`. |
+| `crates/web/style.css` | modify | Append `.emoji-picker`, `.emoji-picker__search`, `.emoji-picker__category-header`, `.emoji-picker__cell`, `.emoji-picker__cell--selected`, `.reactions-strip`, `.reaction-pill`, `.reaction-pill--reacted`, `.add-reaction-chip`, `.pinned-entry`, `.pinned-entry__avatar`, `.pinned-entry__meta`, `.pinned-entry__body`, `.pinned-entry__footer`, `.pinned-entry__actions`, `.pinned-empty`, `.action-btn--lit`, `.action-btn__count--pin`. Foundation tokens only — `--bg-1`, `--bg-2`, `--line`, `--moss-1`, `--moss-2`, `--ink-0`, `--ink-1`, `--ink-2`, `--ink-3`, `--amber`, `--shadow-2`. |
 | `crates/web/tests/browser.rs` | modify | Append `mod phase_3c_reactions_pins { … }` — ~14 tests covering AG-1 through AG-13. |
 | `docs/specs/2026-04-19-ui-design/files-inline.md` | modify | Stamp `**Status:** implementing → landed (e98ed26, 2026-05-08)`. (Carry-over from phase 3b — main is protected and the merge happened upstream.) |
 | `docs/plans/2026-05-08-ui-phase-3b-files-inline.md` | modify | Add `**Status:** landed (e98ed26, 2026-05-08)` — carry-over. |
@@ -66,19 +65,19 @@
 
 > Each gate maps to one or more browser/state/client tests. A task is complete when (a) the production code lands, (b) the corresponding test(s) pass, (c) the spec checkbox is ticked in the same commit.
 
-- [ ] **AG-1.** Reaction strip renders pills with spec geometry; clicking a pill toggles via `on_react`. Local-user pill picks up `--moss-1` border + tinted bg.
-- [ ] **AG-2.** `<AddReactionChip>` appears on row hover (desktop-only); click opens `<EmojiPicker>`. Hidden on mobile.
-- [ ] **AG-3.** `<EmojiPicker>` opens at 320 × 360, with search input + category headers + recents row + grid cells. Arrow keys move highlight; `Enter` inserts via `on_select`; `Escape` closes via `on_close`.
-- [ ] **AG-4.** `<EmojiPicker>` search filter narrows the grid to matching glyphs.
-- [ ] **AG-5.** `<ReactorTooltip>` shows the spec copy: `mira, ori, kes reacted` for ≤ 3 reactors, `first two, and N others` past 3.
-- [ ] **AG-6.** `client.recent_reactions(channel_id)` returns the 5 most-recent reactions in the channel, MRU-first; falls back to the spec default until the LRU fills. Per-channel — different channels keep separate recency.
+- [x] **AG-1.** Reaction strip renders pills with spec geometry; clicking a pill toggles via `on_react`. Local-user pill picks up `--moss-1` border + tinted bg.
+- [x] **AG-2.** `<AddReactionChip>` appears on row hover (desktop-only); click opens `<EmojiPicker>`. Hidden on mobile.
+- [x] **AG-3.** `<EmojiPicker>` opens at 320 × 360, with search input + category headers + recents row + grid cells. Arrow keys move highlight; `Enter` inserts via `on_select`; `Escape` closes via `on_close`.
+- [x] **AG-4.** `<EmojiPicker>` search filter narrows the grid to matching glyphs.
+- [x] **AG-5.** `<ReactorTooltip>` shows the spec copy: `mira, ori, kes reacted` for ≤ 3 reactors, `first two, and N others` past 3.
+- [x] **AG-6.** `client.recent_reactions(channel_id)` returns the 5 most-recent reactions in the channel, MRU-first; falls back to the spec default until the LRU fills. Per-channel — different channels keep separate recency.
 - [ ] **AG-7.** Pinned panel renders entries with avatar + display name + timestamp + 2-line preview + optional `pinned by {name} · {when}` footer. Empty state copy is byte-exact `nothing pinned yet.`.
 - [ ] **AG-8.** Pinned panel `unpin` button is permission-gated: greyed + `aria-disabled="true"` + tooltip `only stewards can pin here` when local peer lacks `ManageChannels`.
 - [ ] **AG-9.** Header pin IconBtn tints `--amber` when channel has pins; superscript count overlay shows the count.
-- [ ] **AG-10.** Pin / unpin keyboard binding (`P`) on a focused row is permission-gated.
-- [ ] **AG-11.** Composer emoji IconBtn opens the same `<EmojiPicker>` as the row's add-reaction chip.
-- [ ] **AG-12.** ARIA labels match the spec table for every interactive element added in this phase.
-- [ ] **AG-13.** Spec `reactions-pins.md` acceptance criteria checkboxes are ticked at the end of the plan (final task).
+- [x] **AG-10.** Pin / unpin keyboard binding (`P`) on a focused row is permission-gated.
+- [x] **AG-11.** Composer emoji IconBtn opens the same `<EmojiPicker>` as the row's add-reaction chip.
+- [x] **AG-12.** ARIA labels match the spec table for every interactive element added in this phase.
+- [x] **AG-13.** Spec `reactions-pins.md` acceptance criteria checkboxes are ticked at the end of the plan (final task).
 
 ## Tasks
 
@@ -98,13 +97,13 @@
 
 ### Phase C — reactions strip
 
-- [ ] **T4.** Create `crates/web/src/components/reactions/` module + extract `<ReactionStrip>` from the inline render in `message.rs:1515`. Spec geometry + local-user pill style. **Browser test:** AG-1. **Verify:** `just test-browser`.
+- [x] **T4.** Create `crates/web/src/components/reactions/` module + extract `<ReactionStrip>` from the inline render in `message.rs:1515`. Spec geometry + local-user pill style. **Browser test:** AG-1. **Verify:** `just test-browser`.
 
-- [ ] **T5.** Implement `<AddReactionChip>` desktop-only hover affordance. Click opens `<EmojiPicker>` via the shared callback. **Browser test:** AG-2. **Verify:** `just test-browser`.
+- [x] **T5.** Implement `<AddReactionChip>` desktop-only hover affordance. Click opens `<EmojiPicker>` via the shared callback. **Browser test:** AG-2. **Verify:** `just test-browser`.
 
-- [ ] **T6.** Implement `<ReactorTooltip>` (1 / 2 / 3 / 4+ pluralisation per spec). Hover-on-pill + mobile press-and-hold. **Browser test:** AG-5. **Verify:** `just test-browser`.
+- [x] **T6.** Implement `<ReactorTooltip>` (1 / 2 / 3 / 4+ pluralisation per spec). Hover-on-pill + mobile press-and-hold. **Browser test:** AG-5. **Verify:** `just test-browser`.
 
-- [ ] **T7.** Wire row hover toolbar `smile` more-reactions button + composer emoji IconBtn to open the shared `<EmojiPicker>`. Replace the inline placeholder shelf in `message.rs:1083`. **Browser test:** AG-11. **Verify:** `just test-browser`.
+- [x] **T7.** Wire row hover toolbar `smile` more-reactions button + composer emoji IconBtn to open the shared `<EmojiPicker>`. Replace the inline placeholder shelf in `message.rs:1083`. **Browser test:** AG-11. **Verify:** `just test-browser`.
 
 ### Phase D — pinned-panel rewrite
 
@@ -116,15 +115,15 @@
 
 - [x] **T10.** Header pin IconBtn picks up `--amber` tint via the new `.action-btn--lit` class + a mono `.action-btn__count--pin` overlay when the channel has pins. New optional `pinned_count: Signal<usize>` prop on `<MainPaneHeader>`; callers thread it from `client.pinned_message_ids(channel).len()`. ARIA label flips between `pinned messages` (no pins) and `pinned messages ({count})` (with pins) per spec §Header entry point. **Browser test:** AG-9 lands alongside T12. **Verify:** `just check` clean.
 
-- [ ] **T11.** Permission-gate the row `P` keyboard binding on `ManageChannels`. **Browser test:** AG-10. **Verify:** `just test-browser`.
+- [x] **T11.** Permission-gate the row `P` keyboard binding on `ManageChannels`. **Browser test:** AG-10. **Verify:** `just test-browser`.
 
 ### Phase F — accessibility, polish
 
-- [ ] **T12.** Audit ARIA labels per the spec table. **Browser test:** AG-12. **Verify:** `just test-browser`.
+- [x] **T12.** Audit ARIA labels per the spec table. **Browser test:** AG-12. **Verify:** `just test-browser`.
 
 ### Phase G — close-out
 
-- [ ] **T13.** Tick the spec acceptance criteria in `docs/specs/2026-04-19-ui-design/reactions-pins.md`. Tick this plan's checkboxes. Update spec status from `draft` → `implementing` (or directly to `landed` on the merge commit if the plan author and reviewer agree). **Verify:** spec + plan diff inspected; `just check` clean.
+- [x] **T13.** Tick the spec acceptance criteria in `docs/specs/2026-04-19-ui-design/reactions-pins.md`. Tick this plan's checkboxes. Update spec status from `draft` → `implementing` (or directly to `landed` on the merge commit if the plan author and reviewer agree). **Verify:** spec + plan diff inspected; `just check` clean.
 
 ## Ambiguity decisions
 
@@ -135,6 +134,7 @@ These are decisions made in the plan that the spec leaves open or under-specifie
 3. **Search ranking.** Prefix match on the emoji's primary name (e.g. `thumbs-up`, `red-heart`); ties broken by category order. No fuzzy match in v1 — keeps the picker fast and predictable.
 4. **Composer emoji IconBtn binding.** Opens the same `<EmojiPicker>` instance and inserts the picked glyph at the current caret position via the existing composer textarea ref. The shortcode autocomplete (`:thumbsup:`) is a separate composer feature owned by `composer.md` and stays parked.
 5. **Reactor tooltip on mobile.** Spec describes "tap and hold on the pill exposes the same list as a small card". v1 ships the desktop `title` attribute path immediately; the press-and-hold card lands as a follow-up to keep this PR scoped — the same `<ReactorTooltip>` component will mount in both contexts.
+6. **Recency refresh granularity.** The web layer's `<ReactionRecencyProvider>` is a `LocalResource` keyed on the active channel signal, so it refreshes when the user switches channels but NOT immediately after a same-channel `react()` call. This is a known limitation — recency picks up on the next channel-revisit. A `react_tick` signal that re-keys the `LocalResource` after every successful react is a documented follow-up; the spec's "channel-scoped recency" intent is satisfied because cross-channel isolation IS atomic at the client layer.
 
 ## Test plan
 

--- a/docs/plans/STATUS.md
+++ b/docs/plans/STATUS.md
@@ -22,11 +22,14 @@ At a glance, for each UI-design phase plan in `docs/plans/`, which state-layer p
 | [`2026-04-21-ui-phase-2c-profile-card.md`](2026-04-21-ui-phase-2c-profile-card.md) | Profile popover / sheet, 17 fields, crest banner, nickname editor | `EventKind::UpdateProfile(Box<ProfileDelta>)` + extended `Profile` fields (pronouns, bio, tagline, crest, pinned, elsewhere, since) | yes | `UpdateProfile` present (line ~322). Nickname store is local-only per spec — no event needed. |
 | [`2026-04-21-ui-phase-2e-local-search.md`](2026-04-21-ui-phase-2e-local-search.md) | On-device search index, scope ladder, results surface, palette bridge | no new `EventKind`; `SearchScope::ThisLetter` + `SearchScope::AllLetters` reserved on the client side | partial | The two letter scopes have no backing `EventKind` — there is no `Letter` / DM variant in `event.rs`. Plan flags this with `TODO(letters-dms.md)` on letter-scope filter branches. The audit that prompted this status file (issue #337) called out exactly this drift. |
 | [`2026-04-25-ui-phase-2d-ephemeral-channels.md`](2026-04-25-ui-phase-2d-ephemeral-channels.md) | Auto-archive on inactivity, archives surface, kind chip, revive | `CreateChannel.ephemeral: Option<EphemeralConfig>` + `EventKind::ChannelRevive { channel_id }` + `Channel.last_activity_hlc` | yes | Both present (lines ~250, ~263). Replaces the `_ephemeral-` name-prefix heuristic from 1a. |
+| [`2026-04-26-ui-phase-3a-composer.md`](2026-04-26-ui-phase-3a-composer.md) | Composer — formatting toolbar, mention autocomplete, slash commands, drafts | none new — view layer + drafts are local | yes | All composer behaviors are UI + local-state; no new EventKind. |
+| [`2026-05-08-ui-phase-3b-files-inline.md`](2026-05-08-ui-phase-3b-files-inline.md) | Files & inline attachments — upload dialog, drag-and-drop, paste-to-upload, inline image/file/voice-note rendering | uses existing `Content::File` / `Content::Voice` variants in `willow-messaging` (already shipped) | yes | Per-file progress bar deferred pending `iroh-blobs` incremental hook; all other acceptance criteria ticked. |
+| [`2026-05-08-ui-phase-3c-reactions-pins.md`](2026-05-08-ui-phase-3c-reactions-pins.md) | Reactions & pins — EmojiPicker, ReactionStrip + AddReactionChip + ReactorTooltip, pinned-panel rewrite, header pin amber tint + count, P-key permission gate | uses existing `EventKind::Reaction` + `PinMessage` + `UnpinMessage` | yes | Pinned-by footer + same-channel react-recency refresh are documented follow-ups; everything else landed via PRs #634/#635/#637. |
 
 ## Aggregate
 
-- **12 plans tabulated.**
-- **9 yes** (state-layer prereqs all landed or none required).
+- **15 plans tabulated.**
+- **12 yes** (state-layer prereqs all landed or none required).
 - **3 partial** — 2a (whisper placeholder gate, no `WhisperStart`), 2b (peer tombstone + inbound heartbeat deferred), 2e (letter scopes reserved with no `Letter` `EventKind`).
 - **0 no** — every plan has at least started landing in `crates/state/src/event.rs` or is intentionally view-layer-only.
 


### PR DESCRIPTION
## Summary

Doc-only close-out aligning the phase-3c plan with what's actually shipped (PRs #634, #635, #637). Resolves all but three of the audit findings against the plan/spec/index drift.

- **Tick T4-T7, T11, T12, T13** in `docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md` — these tasks are visibly landed in code but their checkboxes were missed in the close-out commit (`f526748`). The plan's own T13 ("tick the boxes") was the last thing the original close-out forgot to do.
- **Tick AG-1, AG-2, AG-3, AG-4, AG-5, AG-6, AG-10, AG-11, AG-12, AG-13** — the spec acceptance criteria these gates realise are all already `[x]` in `reactions-pins.md` lines 211-237.
- **Leave AG-7, AG-8, AG-9 unticked.** AG-8 (per-entry unpin permission gate) and AG-9 (header amber tint + count) depend on PR #643 (callsite wiring); AG-7 (pinned-by footer) depends on PR #644 (`pinned by {name} · {when}` footer + state-schema change).
- **Fix File-structure table mismatches** the audit caught:
  - `crates/client/src/views.rs` → `crates/client/src/actions.rs` (where `recent_reactions` actually lives)
  - Drop the `crates/client/src/state.rs` ReactionRecency re-export row — no such type exists in `willow-client`; the web layer has its own `ReactionRecency` Leptos context wrapper
  - Rename `.pin-icon-btn--lit` → `.action-btn--lit` and `.pin-icon-btn__count` → `.action-btn__count--pin` (the implementation harmonised with the rest of the header's `action-btn` family)
  - Drop `.reactor-tooltip` (no such selector — desktop tooltip uses native `title=`, mobile press-and-hold popover deferred per §Ambiguity §5)
- **Add §Ambiguity §6** clarifying that the web layer's recency `LocalResource` re-keys on channel-switch only, not after same-channel `react()` calls — flagged as a documented follow-up.
- **Add phase-3a, phase-3b, phase-3c rows** to `docs/plans/STATUS.md`; bump aggregate from 12/9 → 15/12.
- **Add three phase-3 plan entries** to `docs/README.md` Web UI & UX catalog with `[landed]`.

## Test plan
- [ ] CI green (only docs touched, but verify formatter / link-checker hooks pass).
- [ ] Plan checkboxes match landed code for all gates except the three that have dependent follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)