### PR TITLE
docs(issue-354): mark search-incremental plan as landed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -130,7 +130,7 @@ Every entry below carries one of:
 - [UI phase 3a — composer](plans/2026-04-26-ui-phase-3a-composer.md) — composer revamp: formatting toolbar, mention autocomplete, slash commands, drafts persistence, paste-rich behavior. `[landed]`
 - [UI phase 3b — files & inline attachments](plans/2026-05-08-ui-phase-3b-files-inline.md) — upload dialog + drag-and-drop + paste-to-upload + inline image/file/voice-note rendering. `[landed]`
 - [UI phase 3c — reactions & pins](plans/2026-05-08-ui-phase-3c-reactions-pins.md) — EmojiPicker, reactions strip polish, pinned-panel rewrite, header pin amber tint. `[landed]`
-- [Issue #354 — search index incremental rebuild](plans/2026-05-02-issue-354-search-incremental.md) — replaces per-message-list-change full index rebuild with incremental updates. `[active]`
+- [Issue #354 — search index incremental rebuild](plans/2026-05-02-issue-354-search-incremental.md) — replaces per-message-list-change full index rebuild with incremental updates. `[landed]`
 
 See also: [`plans/STATUS.md`](plans/STATUS.md) — point-in-time audit of which UI-phase plans have landed.
 

--- a/docs/plans/2026-05-02-issue-354-search-incremental.md
+++ b/docs/plans/2026-05-02-issue-354-search-incremental.md
@@ -1,5 +1,7 @@
 # Issue #354 — search index rebuilt from scratch on every message-list change
 
+**Status:** landed (PR #507, commit `e07d974`, 2026-05-02) — `bootstrap.rs` with `hydrate_index` / `index_message` / `reindex_message` shipped alongside the dropped Effect in `app.rs:436` and the new `bootstrap_tests` module in `crates/client/src/search/tests.rs:1048`.
+
 ## Problem
 
 `crates/web/src/app.rs:419` Effect reads `messages_sig.get()`


### PR DESCRIPTION
## Summary

Bookkeeping-only: the issue #354 plan (search index incremental rebuild) was fully implemented in PR #507 / commit \`e07d974\` on 2026-05-02 but the master index still listed it \`[active]\` and the plan itself had no Status frontmatter.

Verified the implementation is on main:
- \`crates/client/src/search/bootstrap.rs\` — \`hydrate_index\`, \`index_message\`, \`reindex_message\` all present
- \`crates/web/src/app.rs:436\` — old rebuild Effect dropped, new spawned indexer task subscribes to ClientEvent + dispatches MessageReceived/MessageEdited/MessageDeleted/ChannelDeleted
- \`crates/client/src/search/tests.rs:1048\` — \`bootstrap_tests\` module with the 4 tests from the plan's Tests section

Same shape as the recent phase-3c docs-tidy work (PR #649) — code-vs-doc drift caused by a status flip never happening at merge time. No code changes.

## Test plan
- [ ] CI green (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)