### PR TITLE
docs(plans): add Status frontmatter to 12 landed plans

### DIFF
--- a/docs/plans/2026-03-24-multi-peer-e2e-tests.md
+++ b/docs/plans/2026-03-24-multi-peer-e2e-tests.md
@@ -1,5 +1,7 @@
 # Multi-Peer E2E Browser Tests Implementation Plan
 
+**Status:** landed (commits `eeb8329` initial multi-peer/permissions/mobile specs + `f715387` code-review followup) — `e2e/{multi-peer-sync,permissions,multi-peer-mobile}.spec.ts` shipped; `just test-e2e-sync` / `test-e2e-perms` recipes wired; legacy `e2e/{two-peer,state-sync}.spec.ts` deleted in favor of the new fixtures.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Comprehensive Playwright E2E tests for multi-peer state sync, permissions, and mobile interactions — running across all 4 browser projects (Desktop Chrome, Mobile Chrome, Desktop Firefox, Mobile Firefox).

--- a/docs/plans/2026-03-25-ux-navigation-improvements.md
+++ b/docs/plans/2026-03-25-ux-navigation-improvements.md
@@ -1,5 +1,7 @@
 # UX Navigation Improvements Implementation Plan
 
+**Status:** landed (commit `0ffb33a` confirmation dialogs; broader Ctrl+K palette + context menu + leave-server in subsequent commits) — `crates/web/src/components/{confirm_dialog,command_palette,context_menu}.rs` shipped; `fn leave_server` at `crates/client/src/servers.rs:83`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Fix 6 UX friction points: unify settings into tabs, add confirmation dialogs for destructive actions, add breadcrumb navigation, server context menu with leave-server, quick peer ID copy, and Ctrl+K command palette.

--- a/docs/plans/2026-03-26-video-screen-sharing-call-page.md
+++ b/docs/plans/2026-03-26-video-screen-sharing-call-page.md
@@ -1,5 +1,7 @@
 # Video, Screen Sharing + Call Page Implementation Plan
 
+**Status:** landed (commit `545cd97` call page foundation + `e4e1e1f` speaking detection) — `crates/web/src/components/{call_page,participant_tile}.rs` shipped; `AudioContext` speaking detection wired; grid/focus layout, camera + screen-share controls in place.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build a full call page with camera video, screen sharing, speaking detection, and grid/focus layout — turning Willow's minimal voice chat into a complete video calling experience.

--- a/docs/plans/2026-03-27-shareable-join-links.md
+++ b/docs/plans/2026-03-27-shareable-join-links.md
@@ -1,5 +1,7 @@
 # Shareable Join Links Implementation Plan
 
+**Status:** landed (commit `eb950ee`) — `crates/web/src/components/join_page.rs` ships the JoinPage component; `JoinToken` / `JoinLink` in `crates/client/src/ops.rs`; URL routing + signal wiring complete.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add shareable URL-based join links that trigger automatic P2P key exchange when clicked, with a dedicated join page that serves as a welcoming front door to the app.

--- a/docs/plans/2026-03-31-actor-library-migration.md
+++ b/docs/plans/2026-03-31-actor-library-migration.md
@@ -1,6 +1,7 @@
 # Actor Library Migration Plan
 
 **Date**: 2026-03-31
+**Status**: landed (commit `c862ff4`) — `state_actors.rs`, `views.rs`, `persistence_actor.rs`, `mutations.rs` shipped; legacy init types de-exported.
 **Spec**: `docs/specs/2026-03-31-reactive-client-state-design.md`
 
 ## Overview

--- a/docs/plans/2026-04-01-agentic-peer-api.md
+++ b/docs/plans/2026-04-01-agentic-peer-api.md
@@ -1,6 +1,7 @@
 # Agentic Peer API — Implementation Plan
 
 **Date**: 2026-04-01
+**Status**: landed (commits `faeb988` Phases 1-3, `fee84c3` Phase 4) — `crates/agent/src/{main,server,tools,resources,auth,notifications,scopes}.rs` ship; multi-peer E2E harness wired.
 **Spec**: `docs/specs/2026-03-29-agentic-peer-api-design.md`
 
 ## Overview

--- a/docs/plans/2026-04-12-willow-channel-removal.md
+++ b/docs/plans/2026-04-12-willow-channel-removal.md
@@ -1,6 +1,7 @@
 # Willow-Channel Removal — Implementation Plan
 
 **Date**: 2026-04-12
+**Status**: landed (commit `ddb2cdc`) — `crates/channel/` deleted; `ChannelKind` enum at `crates/state/src/types.rs:39`; `ServerState` is the client's sole source of truth.
 **Spec**: `docs/specs/2026-04-12-willow-channel-removal.md`
 **Depends on**: `docs/plans/2026-04-12-state-authority-and-mutations.md`
 (permission pre-check must be in place before mutations are rewritten)

--- a/docs/plans/2026-04-20-ui-phase-2a-message-row.md
+++ b/docs/plans/2026-04-20-ui-phase-2a-message-row.md
@@ -1,5 +1,7 @@
 # UI Phase 2a — Message row Implementation Plan
 
+**Status:** landed (commits `74c08c5` / `2c07f64` / `0be5b23` ui(phase-2) series; `abf83b0` closed the `Pending → None` state-flip gate via phase-2b) — `crates/web/src/components/message_row/{mod,mention,code,day_separator,jump_latest}.rs` ship.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development + superpowers:test-driven-development.
 
 **Goal:** Ship `docs/specs/2026-04-19-ui-design/message-row.md` — row anatomy/grouping/day separators, mentions (parsing + pills + self-mention highlight), inline + fenced code, pinned marker, queue notes (LateArrival + Pending), whisper hand-off placeholder, empty/loading states, jump-to-latest pill, swipe-left quote-reply (swipe-right already ships), long-press action sheet compliance, hover toolbar anatomy, spec copy + ARIA contract.

--- a/docs/plans/2026-04-21-e2e-test-architecture.md
+++ b/docs/plans/2026-04-21-e2e-test-architecture.md
@@ -1,5 +1,7 @@
 # E2E Test Architecture Implementation Plan
 
+**Status:** landed (commit `8d58232`) — `crates/client/src/tests/{trust_flow,multi_peer_sync}.rs` migrated from Playwright; `e2e/README.md` documents the tier rules; `just check-all` recipe wired; `e2e/basic-flow.spec.ts` deleted as redundant with the Rust-tier coverage.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Push every test to the lowest tier that can cover it (Rust state / client, wasm-pack browser, Playwright) so the full test suite runs as fast as possible while keeping coverage.

--- a/docs/plans/2026-04-21-ui-phase-2b-sync-queue.md
+++ b/docs/plans/2026-04-21-ui-phase-2b-sync-queue.md
@@ -1,5 +1,7 @@
 # UI Phase 2b — Sync queue Implementation Plan
 
+**Status:** landed (commit `99f8283` SyncQueueView + `70db3c7` browser tests + RelaySignalButton close-out) — `crates/client/src/queue.rs` ships the per-peer queue; `crates/web/src/components/{offline_strip,queue_pill,inline_queue_note,sync_queue_view}.rs` render the surfaces. Plan's self-review checklist is all ticked.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development + superpowers:test-driven-development.
 
 **Goal:** Ship `docs/specs/2026-04-19-ui-design/sync-queue.md` — the visible representation of patient P2P messaging: amber offline status strip, per-peer queue pills on letter / member rows, per-message inline queue notes, mobile pull-down + desktop chevron summary, dedicated sync-queue screen (outbound / inbound tabs + recent arrivals), relay-awareness badge, reconnection toast, welcome-back banner, and the signal contract between `crates/web` and `willow-client`. Closes the Phase 2a `Pending → None` state-flip gate left open in `views.rs`.

--- a/docs/plans/2026-04-21-ui-phase-2e-local-search.md
+++ b/docs/plans/2026-04-21-ui-phase-2e-local-search.md
@@ -1,5 +1,7 @@
 # UI Phase 2e — Local search Implementation Plan
 
+**Status:** landed (commit `7edaa96` "docs(plan): tick plan + record PR 187") — `crates/client/src/search/` (11 files) ships the index + bootstrap + actor; `crates/web/src/components/search/` (6 files) ships the results UI + recents + scope chip. Letter-scope filter branches remain reserved with `TODO(letters-dms.md)` markers per `docs/plans/STATUS.md`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development + superpowers:test-driven-development + superpowers:verification-before-completion.
 
 **Goal:** Ship `docs/specs/2026-04-19-ui-design/local-search.md` — an on-device, encrypted-at-rest search index with scope ladder (`this letter` / `this channel` / `all letters` / `all groves + letters`), desktop + mobile entry points, query language (plain + prefix operators + quoted phrases), streamed results surface with grouping and highlight, `⌘K` palette bridge, privacy copy, settings-owned recents/horizon hooks, and a full a11y contract.

--- a/docs/plans/2026-04-30-event-based-waits-pr4-ratchet-flake-harness.md
+++ b/docs/plans/2026-04-30-event-based-waits-pr4-ratchet-flake-harness.md
@@ -1,5 +1,7 @@
 # Event-Based Waits PR-4 — Wait-Timeout Ratchet + Flake Harness
 
+**Status:** landed (commit `5b84ef5` ratchet enforcer; `1283430` wired into `check-all`; `eeed70f` follow-up fixes) — `scripts/check-wait-timeout-count.sh` enforces the baseline; `e2e/.wait-timeout-baseline` is the source of truth; `test-e2e-flake` + `check-wait-timeout` recipes in `justfile`. Plan task boxes never got ticked but all artifacts ship.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Lock in the current `waitForTimeout` count so future PRs cannot regress, ship a flake harness that runs the e2e suite N times to surface intermittent failures, and prove the ESLint rule's sunset cutoff is enforced by CI.


### PR DESCRIPTION
## Summary

Follow-up to PR #651. Adds a \`**Status:**\` frontmatter line to each of the 12 plan files whose README badges PR #651 flipped from \`[active]\` → \`[landed]\`. The 13th plan (\`docs-organization\`) already had its Status updated in #651.

Each Status line cites the landing commit(s) + a one-sentence verification pointer naming the key file path or component shipped, so a future reader spot-checking can confirm in one grep.

## Test plan
- [ ] CI green (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)