### PR TITLE
docs(organization): close out spec — flip [draft]→[landed] + backfill

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -173,7 +173,7 @@ See also: [`plans/STATUS.md`](plans/STATUS.md) — point-in-time audit of which 
 **Specs**
 
 - [Machine-readable wire-rejection reasons](specs/2026-04-24-error-prefixes.md) — typed `WireRejectReason` enum in `WireMessage::Reject` replacing free-form error strings. `[active]`
-- [Docs organization — target structure](specs/2026-05-07-docs-organization-design.md) — target structure for `docs/`, master index, naming conventions, and nesting rules. `[active]`
+- [Docs organization — target structure](specs/2026-05-07-docs-organization-design.md) — target structure for `docs/`, master index, naming conventions, and nesting rules. `[landed]`
 
 **Plans**
 

--- a/docs/plans/2026-05-08-ui-phase-3b-files-inline.md
+++ b/docs/plans/2026-05-08-ui-phase-3b-files-inline.md
@@ -1,6 +1,8 @@
 # UI Phase 3b — Files & Inline Attachments Implementation Plan
 
+**Date:** 2026-05-08
 **Status:** landed (e98ed26, 2026-05-08)
+**Spec:** [`docs/specs/2026-04-19-ui-design/files-inline.md`](../specs/2026-04-19-ui-design/files-inline.md)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development + superpowers:test-driven-development. Every task = one commit; tick the checkbox in the same commit.
 

--- a/docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md
+++ b/docs/plans/2026-05-08-ui-phase-3c-reactions-pins.md
@@ -1,6 +1,8 @@
 # UI Phase 3c — Reactions & Pins Implementation Plan
 
+**Date:** 2026-05-08
 **Status:** landed (foundation PR #634 + picker wireup PR #635 + initial close-out PR #637 + cascade close-out PRs #643 visibility wiring, #644 pinned-by footer + `PinMetadata`, #646 plan/spec/index close-out, #647 same-channel react-recency refresh, #648 DOM coverage tests)
+**Spec:** [`docs/specs/2026-04-19-ui-design/reactions-pins.md`](../specs/2026-04-19-ui-design/reactions-pins.md)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development + superpowers:test-driven-development. Every task = one commit; tick the checkbox in the same commit.
 

--- a/docs/specs/2026-05-07-docs-organization-design.md
+++ b/docs/specs/2026-05-07-docs-organization-design.md
@@ -1,7 +1,8 @@
 # Docs organization — target structure
 
 **Date:** 2026-05-07
-**Status:** draft
+**Status:** landed (migration plan landed 2026-05-07; README + skill + CLAUDE.md pointer in place; STATUS frontmatter backfilled across all landed plans in PRs #651 / #652)
+**Implementation plan:** [`docs/plans/2026-05-07-docs-organization.md`](../plans/2026-05-07-docs-organization.md)
 
 ## Purpose
 
@@ -90,9 +91,18 @@ predating this convention are not retrofitted (see *Non-goals*).
 ```
 **Date:** YYYY-MM-DD
 **Status:** draft | active | landed | superseded
-**Spec:** docs/specs/...      (plans only — REQUIRED, points at the spec being realized)
-**Supersedes:** docs/specs/... (if applicable)
+**Spec:** docs/specs/...               (plans only — REQUIRED, points at the spec being realized)
+**Supersedes:** docs/specs/...         (if applicable)
+**Parent specs:** docs/specs/...       (optional — for specs that descend from one or more existing specs)
+**Implementation plan:** docs/plans/...(optional — back-pointer when the doc is a spec and the plan is known)
 ```
+
+The first four fields are the minimum. `**Parent specs:**` and
+`**Implementation plan:**` are optional extensions used when the doc lives in
+a richer cross-reference graph (e.g. a child spec descending from a multi-file
+parent, or a freestanding spec whose realizing plan is already known).
+Additional `**Key:**` extensions are allowed when they make navigation
+cheaper for the next reader — keep them rare and self-explanatory.
 
 Status semantics:
 
@@ -242,7 +252,12 @@ of the surfaces above:
 > **Docs entry point:** `docs/README.md` is the master index of specs and
 > plans, grouped by feature area. Read it before adding any new spec or plan,
 > or before searching for an existing one. The `organizing-willow-docs` skill
-> mirrors the conventions for on-demand loading.
+> mirrors the conventions for on-demand loading. Cemented in
+> `docs/specs/2026-05-07-docs-organization-design.md`.
+
+The trailing back-pointer to this spec gives the reader a one-hop path to the
+canonical rules when they want more than the pointer paragraph itself
+contains.
 
 Existing CLAUDE.md sections that duplicate doc-discovery information (e.g.
 the per-task "see `docs/specs/...`" pointers in *Architecture Notes*) are
@@ -261,14 +276,18 @@ left in place — they are useful inline context, not redundant with the index.
   project-management tool. Stale tags are tolerable; missing entries are not.
 - **Per-area sub-READMEs.** Single-file index until volume justifies a split.
 
-## Open questions
+## Resolved questions
 
-- A handful of filenames currently appear in both `docs/specs/` and
-  `docs/plans/` with the same date and topic (e.g.
-  `2026-04-12-state-authority-and-mutations.md`,
-  `2026-04-12-willow-channel-removal.md`). The migration plan must verify
-  whether each pair is genuinely a spec + plan (correct, keep both) or an
-  accidental misclassification (move to the right folder).
-- The exact set of nine feature areas may shift slightly during catalog
-  population if a real entry resists a clean home; the area list is
-  load-bearing for navigation and worth a final pass during the migration.
+The migration closed out two open questions; recorded here so future readers
+don't re-litigate them.
+
+- **Same-date spec/plan pairs.** Pairs like
+  `2026-04-12-state-authority-and-mutations.md` and
+  `2026-04-12-willow-channel-removal.md` were verified during the migration:
+  each is a genuine spec + plan pair (the plan's header cites the spec). No
+  misclassifications were found. Future same-date pairs are legitimate and
+  expected when a target and its migration are designed together.
+- **Nine-area catalog.** The nine areas in §3 populated cleanly with no
+  entries that resisted a home. The area list is stable. Future areas can be
+  added if a new feature cluster justifies one — the convention does not cap
+  the count.


### PR DESCRIPTION
## Summary

Audit-and-align pass against the docs-organization spec (`docs/specs/2026-05-07-docs-organization-design.md`) surfaced 5 actionable findings, all docs-only. Closes them out and flips the spec from `[active]` → `[landed]` in the master index.

## Findings addressed

1. **Spec header `draft`** while plan landed and README said `[active]` → bumped to `landed` + added `**Implementation plan:**` back-pointer.
2. **"Open questions" already resolved** (same-date spec/plan pairs verified; nine-area catalog stable) → converted to "Resolved questions".
3. **CLAUDE.md pointer drifted** (added a useful trailing "Cemented in..." sentence the spec didn't quote) → updated spec's quoted block to match.
4. **Two post-convention plans regressed on required headers** (`2026-05-08-ui-phase-3b-files-inline.md`, `2026-05-08-ui-phase-3c-reactions-pins.md`) → added `**Date:**` + `**Spec:**`.
5. **New spec uses extra header fields not yet legitimized** (`**Parent specs:**`, `**Implementation plan:**` in `2026-05-21-pinned-message-metadata-design.md`) → extended Document headers section to document them as optional extensions plus a general `**Key:**`-extension allowance clause.

README badge flipped `[active]` → `[landed]`.

## Out of scope

Two AMBIGUOUS findings left alone — both are intentional shape choices per the spec's own §4 distillation contract (reading list at exactly 4 / conventions restated as table).

## Test plan
- [x] No code changes — pure docs PR. CI's docs-only path applies.
- [x] Spec header is internally consistent with the README badge after this PR.
- [x] Plans 2026-05-08-* now satisfy the required-header rule the spec mandates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)