### PR TITLE
docs(willow-channel): close out spec — flip [active]→[landed]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,7 +79,7 @@ Every entry below carries one of:
 
 **Specs**
 
-- [Willow-channel removal](specs/2026-04-12-willow-channel-removal.md) — eliminates `willow-channel` crate, making `ServerState` the client's sole source of truth. `[active]`
+- [Willow-channel removal](specs/2026-04-12-willow-channel-removal.md) — eliminates `willow-channel` crate, making `ServerState` the client's sole source of truth. `[landed]`
 
 **Plans**
 

--- a/docs/specs/2026-04-12-willow-channel-removal.md
+++ b/docs/specs/2026-04-12-willow-channel-removal.md
@@ -1,5 +1,9 @@
 # Willow-Channel Removal
 
+**Date:** 2026-04-12
+**Status:** landed — `willow-channel` crate deleted; `ServerState` is the sole shared-type owner. One named follow-up remains in `crates/client/src/lib.rs::reconcile_topic_map` (see *Deferred follow-ups* at the bottom).
+**Implementation plan:** [`docs/plans/2026-04-12-willow-channel-removal.md`](../plans/2026-04-12-willow-channel-removal.md)
+
 > Remove the `willow-channel` crate entirely. Consolidate all shared
 > types into `willow-state` and eliminate the dual-state representation
 > in the client.
@@ -130,7 +134,7 @@ All changes are in `crates/client/src/`:
 | `persistence_actor.rs` | Persist `ServerState`, not `Server` |
 | `servers.rs` | Use event pipeline for server creation |
 | `util.rs` | `make_topic()` takes `&str` server ID, not `&Server` |
-| `lib.rs` | Remove `reconcile_topic_map()`, remove `parse_permission()` |
+| `lib.rs` | Remove `parse_permission()`. `reconcile_topic_map()` is retained as a documented helper for invite-validation follow-up — see *Deferred follow-ups* below. |
 
 ### Workspace changes
 
@@ -139,3 +143,25 @@ All changes are in `crates/client/src/`:
 - Remove `willow-channel` from `crates/client/Cargo.toml`.
 - Add `willow-state` to `crates/client/Cargo.toml` (if not present).
 - Update `CLAUDE.md` dependency graph to remove `willow-channel`.
+
+## Deferred follow-ups
+
+### `reconcile_topic_map()` cleanup
+
+`crates/client/src/lib.rs::reconcile_topic_map<V>()` was *not* deleted as
+originally specified. It now converts `HashMap<String, V>` →
+`HashMap<willow_messaging::ChannelId, V>` and gracefully skips entries with
+unparseable UUIDs (cf. issue #141 — previously, unparseable IDs were
+silently replaced by random UUIDs, causing the client to diverge from the
+network).
+
+The function is currently dead in production (only its own regression test
+exercises it). It is retained as a pre-wired utility for callers that
+deserialize topic maps from wire data (`accept_invite`, the join path).
+Integration into the full invite/join flow is tracked as follow-up work —
+once those sites consume the helper, this section can be removed and the
+table row above can drop to "Removed."
+
+If the follow-up never lands, `reconcile_topic_map` and its test should be
+deleted along with the vestigial `willow_messaging::ChannelId` import — it
+adds nothing to the current code path.


### PR DESCRIPTION
## Summary

Audit-and-align pass against `docs/specs/2026-04-12-willow-channel-removal.md` found 1 actionable finding:

- Spec's `lib.rs` row in the Files-to-modify table said "Remove `reconcile_topic_map()`, remove `parse_permission()`". `parse_permission` is removed; `reconcile_topic_map` lives on as a documented helper whose own doc comment (crates/client/src/lib.rs:1024-1027) ties it to invite/join follow-up work.

Everything else verified clean: `crates/channel/` is gone, zero `willow-channel`/`willow_channel` refs in code, `ChannelKind` enum is in `willow-state::types`, all mutations go through the event pipeline, `ServerEntry` matches the spec's After-sketch, no `willow-channel` dep in `crates/client/Cargo.toml` or CLAUDE.md dependency graph.

## Changes

- Table row clarified: the row is now accurate about what was removed and what survives.
- New **Deferred follow-ups** section documents `reconcile_topic_map`'s current state (dead in production, retained for invite/join wire-data deserialization), cites issue #141 (the divergence bug it was hardened against), and articulates the exit condition.
- Added **Date** / **Status** / **Implementation plan** header per the now-landed docs-organization convention (PR #653).
- README master index flipped `[active]` → `[landed]`.

## Test plan
- [x] No code changes — pure docs PR. CI's docs-only path applies.
- [x] Spec header is internally consistent with the README badge after this PR.
- [x] Deferred-follow-up section gives the next maintainer a clear exit condition (no orphan helper without a paper trail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)