### PR TITLE
feat(client): persist join links + emit JoinDenied for invalid links

### DIFF
--- a/crates/client/src/joining.rs
+++ b/crates/client/src/joining.rs
@@ -282,12 +282,13 @@ impl<N: willow_network::Network> ClientHandle<N> {
         };
         let token = ops::JoinToken {
             inviter_peer_id: pid,
-            server_id,
+            server_id: server_id.clone(),
             link_id: link.link_id.clone(),
             server_name,
             inviter_name,
         };
         self.join_links.lock().push(link);
+        self.persist_join_links_for(&server_id);
         Ok(token.encode())
     }
 
@@ -297,7 +298,41 @@ impl<N: willow_network::Network> ClientHandle<N> {
 
     pub async fn delete_join_link(&self, link_id: &str) {
         let link_id = link_id.to_string();
+        // Find which server this link belongs to before we drop it so we
+        // can persist the post-delete state for that server.
+        let server_id = self
+            .join_links
+            .lock()
+            .iter()
+            .find(|l| l.link_id == link_id)
+            .map(|l| l.server_id.clone());
         self.join_links.lock().retain(|l| l.link_id != link_id);
+        if let Some(sid) = server_id {
+            self.persist_join_links_for(&sid);
+        }
+    }
+
+    /// Snapshot the current join-links for `server_id` and forward them
+    /// to the persistence actor. No-op when persistence is disabled (the
+    /// handler itself short-circuits in that case, but checking here
+    /// avoids an unnecessary actor round-trip).
+    fn persist_join_links_for(&self, server_id: &str) {
+        if !self.persistence_enabled {
+            return;
+        }
+        let links: Vec<ops::JoinLink> = self
+            .join_links
+            .lock()
+            .iter()
+            .filter(|l| l.server_id == server_id)
+            .cloned()
+            .collect();
+        let _ = self
+            .persistence_addr
+            .do_send(crate::persistence_actor::PersistJoinLinks {
+                server_id: server_id.to_string(),
+                links,
+            });
     }
 
     pub async fn set_display_name(&self, name: &str) {

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -808,7 +808,15 @@ impl<N: willow_network::Network> ClientHandle<N> {
             state_actors::DagState::default(),
         ));
         let topics: Arc<RwLock<HashMap<String, N::Topic>>> = Arc::new(RwLock::new(HashMap::new()));
-        let join_links = Arc::new(parking_lot::Mutex::new(Vec::new()));
+        // Hydrate join_links from per-server persistence so links survive a
+        // page reload (previously lost — see audit follow-up).
+        let mut initial_join_links: Vec<ops::JoinLink> = Vec::new();
+        if config.persistence {
+            for sid in state.servers.keys() {
+                initial_join_links.extend(storage::load_join_links(sid));
+            }
+        }
+        let join_links = Arc::new(parking_lot::Mutex::new(initial_join_links));
         let pending_joins = Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()));
 
         // Build StateRefs for derived actor sources.

--- a/crates/client/src/listeners.rs
+++ b/crates/client/src/listeners.rs
@@ -593,18 +593,77 @@ async fn process_received_message<T: TopicHandle>(
                 return;
             }
             let _ = peer_id; // the verified `signer` is the grant target below
-            let should_respond = {
+                             // Three possible outcomes:
+                             //   - Link valid → bump `used`, send `JoinResponse`.
+                             //   - Link found but not currently usable (disabled / expired /
+                             //     exhausted) → reply with `JoinDenied { reason }` so the
+                             //     joiner sees a concrete error instead of an opaque timeout.
+                             //   - Link not found → drop silently. This is the
+                             //     anti-enumeration property: if the inviter never created
+                             //     this `link_id`, attackers cannot probe by trial. Only
+                             //     `link_id`s that *exist* (and that this peer therefore
+                             //     plausibly created) receive a denial; everything else is
+                             //     indistinguishable from "wrong inviter."
+            #[derive(Clone)]
+            enum LinkOutcome {
+                Respond,
+                Deny(&'static str),
+                Silent,
+            }
+            // Track which server we charged the use against so we can
+            // persist the bumped `used` count once we drop the lock —
+            // otherwise the counter resets on restart and an exhausted
+            // link looks fresh again.
+            let mut bumped_server: Option<String> = None;
+            let outcome = {
                 let mut links = ctx.join_links.lock();
-                let valid = links
-                    .iter_mut()
-                    .find(|l| l.link_id == link_id && l.is_valid());
-                if let Some(link) = valid {
-                    link.used += 1;
-                    true
+                if let Some(link) = links.iter_mut().find(|l| l.link_id == link_id) {
+                    if link.is_valid() {
+                        link.used += 1;
+                        bumped_server = Some(link.server_id.clone());
+                        LinkOutcome::Respond
+                    } else if !link.active {
+                        LinkOutcome::Deny("link_disabled")
+                    } else {
+                        // Either `used >= max_uses` or `expires_at` is in
+                        // the past — spec collapses both under `link_expired`.
+                        LinkOutcome::Deny("link_expired")
+                    }
                 } else {
-                    false
+                    LinkOutcome::Silent
                 }
             };
+            if let Some(sid) = bumped_server {
+                let snapshot: Vec<crate::ops::JoinLink> = ctx
+                    .join_links
+                    .lock()
+                    .iter()
+                    .filter(|l| l.server_id == sid)
+                    .cloned()
+                    .collect();
+                warn_if_err(
+                    ctx.persistence
+                        .do_send(crate::persistence_actor::PersistJoinLinks {
+                            server_id: sid,
+                            links: snapshot,
+                        }),
+                    "persistence.do_send PersistJoinLinks (used++)",
+                );
+            }
+            let should_respond = matches!(outcome, LinkOutcome::Respond);
+            if let LinkOutcome::Deny(reason) = &outcome {
+                let msg = crate::ops::WireMessage::JoinDenied {
+                    link_id: link_id.clone(),
+                    target_peer: signer,
+                    reason: (*reason).to_string(),
+                };
+                if let Some(data) = crate::ops::pack_wire(&msg, &ctx.identity) {
+                    warn_if_err(
+                        topic.broadcast(bytes::Bytes::from(data)).await,
+                        "topic.broadcast JoinDenied",
+                    );
+                }
+            }
             if should_respond {
                 // Generate invite for the requesting peer using event_state + registry.
                 let server_registry = ctx.server_registry.clone();
@@ -1789,6 +1848,212 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, ClientEvent::JoinLinkResponse { .. })),
             "JoinResponse without matching pending entry must be ignored"
+        );
+    }
+
+    // ─── JoinDenied emission on the inviter side ───────────────────────
+    //
+    // The spec promises that when a joiner sends a `JoinRequest` for a
+    // link that exists but is disabled/expired/exhausted, the inviter
+    // replies with `JoinDenied { reason }` so the joiner sees a concrete
+    // error instead of a 30-second timeout. Anti-enumeration: unknown
+    // `link_id`s receive no reply (silent drop).
+    //
+    // The tests below subscribe a second peer (`observer`) to the same
+    // hub topic as the inviter, drive the inviter's listener with a
+    // signed `JoinRequest`, then assert on what the observer received
+    // from the inviter's outbound broadcast. `MemTopicEvents::next`
+    // skips self-messages, so the inviter cannot observe its own
+    // broadcasts; that's why we need the second peer.
+
+    /// Build an inviter `ListenerCtx` driven by a shared hub topic, plus
+    /// an `observer` topic on the same hub used to read the inviter's
+    /// outbound broadcasts.
+    async fn make_inviter_and_observer() -> (
+        ClientHandle<willow_network::mem::MemNetwork>,
+        ListenerCtx,
+        <willow_network::mem::MemNetwork as Network>::Topic,
+        <willow_network::mem::MemNetwork as Network>::Events,
+    ) {
+        let (client, _rx) = test_client();
+        let hub = willow_network::mem::MemHub::new();
+        let inviter_net = willow_network::mem::MemNetwork::new(&hub);
+        let (topic, _inviter_events) = inviter_net
+            .subscribe(willow_network::topic_id("join-denied-emit-test"), vec![])
+            .await
+            .expect("inviter subscribe must succeed");
+        let observer_net = willow_network::mem::MemNetwork::new(&hub);
+        let (_observer_topic, observer_events) = observer_net
+            .subscribe(willow_network::topic_id("join-denied-emit-test"), vec![])
+            .await
+            .expect("observer subscribe must succeed");
+        let ctx = ListenerCtx {
+            event_state: client.event_state_addr.clone(),
+            chat_meta: client.chat_meta_addr.clone(),
+            profiles: client.profile_state_addr.clone(),
+            network: client.network_meta_addr.clone(),
+            voice: client.voice_state_addr.clone(),
+            persistence: client.persistence_addr.clone(),
+            persistence_enabled: false,
+            event_broker: client.event_broker.clone(),
+            identity: client.identity.clone(),
+            join_links: Arc::clone(&client.join_links),
+            pending_joins: Arc::clone(&client.pending_joins),
+            dag: client.dag_addr.clone(),
+            server_registry: client.server_registry_addr.clone(),
+            on_neighbor_up: None,
+        };
+        (client, ctx, topic, observer_events)
+    }
+
+    /// Drain the next `JoinDenied` reason from the observer's topic
+    /// event stream, with a short settle window. Returns `None` if
+    /// nothing arrives in the deadline.
+    async fn next_join_denied_reason(
+        events: &mut <willow_network::mem::MemNetwork as Network>::Events,
+        deadline: std::time::Duration,
+    ) -> Option<String> {
+        use willow_network::{GossipEvent, TopicEvents};
+        let task = async {
+            loop {
+                let Some(Ok(evt)) = events.next().await else {
+                    return None;
+                };
+                let GossipEvent::Received(msg) = evt else {
+                    continue;
+                };
+                let Some((wire, _signer)) = crate::ops::unpack_wire(&msg.content) else {
+                    continue;
+                };
+                if let crate::ops::WireMessage::JoinDenied { reason, .. } = wire {
+                    return Some(reason);
+                }
+            }
+        };
+        tokio::time::timeout(deadline, task).await.ok().flatten()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn join_request_for_disabled_link_replies_with_link_disabled() {
+        let (client, ctx, topic, mut observer) = make_inviter_and_observer().await;
+        let link_id = "disabled-link".to_string();
+        client.join_links.lock().push(crate::ops::JoinLink {
+            link_id: link_id.clone(),
+            server_id: "unused".into(),
+            max_uses: 10,
+            used: 0,
+            active: false, // disabled by inviter
+            expires_at: None,
+            created_at: 0,
+        });
+
+        let bob = willow_identity::Identity::generate();
+        let bob_id = bob.endpoint_id();
+        let bytes = crate::ops::pack_wire(
+            &crate::ops::WireMessage::JoinRequest {
+                link_id: link_id.clone(),
+                peer_id: bob_id,
+            },
+            &bob,
+        )
+        .expect("pack must succeed");
+        process_received_message(&bytes, bob_id, &ctx, &topic).await;
+
+        let reason =
+            next_join_denied_reason(&mut observer, std::time::Duration::from_millis(500)).await;
+        assert_eq!(reason, Some("link_disabled".to_string()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn join_request_for_expired_link_replies_with_link_expired() {
+        let (client, ctx, topic, mut observer) = make_inviter_and_observer().await;
+        let link_id = "expired-link".to_string();
+        client.join_links.lock().push(crate::ops::JoinLink {
+            link_id: link_id.clone(),
+            server_id: "unused".into(),
+            max_uses: 10,
+            used: 0,
+            active: true,
+            // Expired one second before "now" — `current_time_ms()` is
+            // monotonic-ish; this guarantees `is_valid()` returns false.
+            expires_at: Some(crate::util::current_time_ms().saturating_sub(1_000)),
+            created_at: 0,
+        });
+
+        let bob = willow_identity::Identity::generate();
+        let bob_id = bob.endpoint_id();
+        let bytes = crate::ops::pack_wire(
+            &crate::ops::WireMessage::JoinRequest {
+                link_id: link_id.clone(),
+                peer_id: bob_id,
+            },
+            &bob,
+        )
+        .expect("pack must succeed");
+        process_received_message(&bytes, bob_id, &ctx, &topic).await;
+
+        let reason =
+            next_join_denied_reason(&mut observer, std::time::Duration::from_millis(500)).await;
+        assert_eq!(reason, Some("link_expired".to_string()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn join_request_for_exhausted_link_replies_with_link_expired() {
+        let (client, ctx, topic, mut observer) = make_inviter_and_observer().await;
+        let link_id = "exhausted-link".to_string();
+        client.join_links.lock().push(crate::ops::JoinLink {
+            link_id: link_id.clone(),
+            server_id: "unused".into(),
+            max_uses: 1,
+            used: 1, // already used up
+            active: true,
+            expires_at: None,
+            created_at: 0,
+        });
+
+        let bob = willow_identity::Identity::generate();
+        let bob_id = bob.endpoint_id();
+        let bytes = crate::ops::pack_wire(
+            &crate::ops::WireMessage::JoinRequest {
+                link_id: link_id.clone(),
+                peer_id: bob_id,
+            },
+            &bob,
+        )
+        .expect("pack must succeed");
+        process_received_message(&bytes, bob_id, &ctx, &topic).await;
+
+        // Spec collapses "max_uses reached" and "expires_at in the past"
+        // under the same `link_expired` reason — both mean "this link
+        // can no longer be used."
+        let reason =
+            next_join_denied_reason(&mut observer, std::time::Duration::from_millis(500)).await;
+        assert_eq!(reason, Some("link_expired".to_string()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn join_request_for_unknown_link_id_is_silent() {
+        let (_client, ctx, topic, mut observer) = make_inviter_and_observer().await;
+
+        let bob = willow_identity::Identity::generate();
+        let bob_id = bob.endpoint_id();
+        let bytes = crate::ops::pack_wire(
+            &crate::ops::WireMessage::JoinRequest {
+                link_id: "no-such-link".to_string(),
+                peer_id: bob_id,
+            },
+            &bob,
+        )
+        .expect("pack must succeed");
+        process_received_message(&bytes, bob_id, &ctx, &topic).await;
+
+        // Anti-enumeration: unknown `link_id` MUST NOT produce a reply.
+        // The inviter must look indistinguishable from "wrong inviter."
+        let reason =
+            next_join_denied_reason(&mut observer, std::time::Duration::from_millis(250)).await;
+        assert_eq!(
+            reason, None,
+            "unknown link_id must not produce a JoinDenied (anti-enumeration)"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes two audit-finding functional gaps in `docs/specs/2026-03-27-shareable-join-links-design.md`:

1. **JoinLinks are now persisted.** Previously create/delete/`used++` only mutated the in-memory Vec; the `PersistJoinLinks` actor message had zero send-sites; `ClientHandle::new` initialised the Vec to empty without ever calling `storage::load_join_links`. Net effect: create a link → refresh → link is gone. Used count also reset, so an exhausted link looked fresh after restart.
2. **Inviter now emits `JoinDenied { reason }` for invalid links.** Previously the listener set `should_respond = false` and silently dropped requests for disabled/expired/exhausted links — joiner saw a 30s timeout. Spec §Error Handling promises explicit denial.

## Changes

- `joining.rs`: `create_join_link` / `delete_join_link` snapshot per-server links and send `PersistJoinLinks` via `persist_join_links_for(&server_id)` helper. Short-circuits when `persistence_enabled` is false.
- `lib.rs`: `ClientHandle::new` hydrates `join_links` from `storage::load_join_links(sid)` for every loaded server.
- `listeners.rs::process_received_message`:
  - After successful `used += 1`, snapshot + persist (so used count survives restart).
  - On `link_id` match with `is_valid() == false`, distinguish:
    - `!active` → `JoinDenied { reason: "link_disabled" }`
    - `used >= max_uses` OR `expires_at < now` → `JoinDenied { reason: "link_expired" }`
  - Unknown `link_id` → silent drop (anti-enumeration; only links that exist receive denials).

## Anti-enumeration property

Preserved by design: unknown `link_id`s drop silently. Attackers cannot probe by trial — only `link_id`s that exist in the inviter's table receive denials.

## Tests

4 new `listeners::tests::join_request_for_*` cases:

- `..._disabled_link_replies_with_link_disabled`
- `..._expired_link_replies_with_link_expired`
- `..._exhausted_link_replies_with_link_expired`
- `..._unknown_link_id_is_silent`

Each subscribes a second peer to the inviter's hub topic (because `MemTopicEvents::next` skips self-messages — the inviter cannot observe its own broadcasts), drives the inviter's listener with a synthetic `JoinRequest`, and asserts on what the observer received.

## Follow-up

PR B in this series will add the `<details>` disclosure UI for max-uses + expiration selector to `settings.rs` (the third audit finding — hardcoded `max_uses=5` with no options input).

## Test plan
- [x] `just check` clean.
- [x] 4 new listener tests pass.
- [x] All 358 existing client tests still pass.
- [x] No clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)