### PR TITLE
docs(join-links): close out spec — flip [active]→[landed] + Realised-state addendum

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ Every entry below carries one of:
 - [Epoch-driven channel key rotation](specs/2026-04-24-epoch-key-rotation.md) — derives fresh channel encryption epoch from every membership-changing state event. `[active]`
 - [Direct messages — seal+gift-wrap deferral to MLS](specs/2026-04-24-seal-gift-wrap-dms.md) — captures NIP-17/44/59 investigation; defers DMs to a future MLS-over-Willow spec. `[active]`
 - [Bech32-with-HRP user-facing identifiers](specs/2026-04-24-bech32-identifiers.md) — all UI-visible identifiers encoded as bech32m strings with type-tagging human-readable prefix. `[active]`
-- [Shareable join links](specs/2026-03-27-shareable-join-links-design.md) — single URL triggers automatic P2P key exchange, replacing multi-step invite flow. `[active]`
+- [Shareable join links](specs/2026-03-27-shareable-join-links-design.md) — single URL triggers automatic P2P key exchange, replacing multi-step invite flow. `[landed]`
 
 **Plans**
 

--- a/docs/specs/2026-03-27-shareable-join-links-design.md
+++ b/docs/specs/2026-03-27-shareable-join-links-design.md
@@ -1,5 +1,77 @@
 # Shareable Join Links
 
+**Date:** 2026-03-27
+**Status:** landed — wire protocol, key-exchange handshake, link generation/deletion, JoinPage, routing, persistence, denial emission for invalid links, and max-uses/expiration UI controls all shipped. See [`docs/plans/2026-03-27-shareable-join-links.md`](../plans/2026-03-27-shareable-join-links.md) for the original migration. Persistence + JoinDenied gaps closed in PR #660 (2026-05-22); max-uses/expiration UI shipped in PR #661 (2026-05-22). One spec divergence preserved intentionally: silent-drop for *unknown* link_ids is kept as an anti-enumeration property — see *Realised state* below.
+**Implementation plan:** [`docs/plans/2026-03-27-shareable-join-links.md`](../plans/2026-03-27-shareable-join-links.md)
+
+> **Realised state (post-2026-05 audit + follow-up PRs).** The original
+> spec landed via the linked plan in late March 2026. A 2026-05 audit
+> surfaced nine misalignments, broken into three categories:
+>
+> **Substantive gaps — fixed in follow-up PRs:**
+>
+> - **JoinLinks now persist** across page reloads (PR #660). Previously
+>   `create_join_link` / `delete_join_link` only mutated the in-memory
+>   `Arc<Mutex<Vec<JoinLink>>>` and the listener's `used += 1` bump
+>   never reached disk, so creating a link → refreshing wiped it and
+>   exhausted links looked fresh after restart. `ClientHandle::new` now
+>   hydrates `join_links` from `storage::load_join_links(server_id)`
+>   for every loaded server, and mutation paths send `PersistJoinLinks`
+>   to the persistence actor.
+> - **Invalid-link denial now emits `JoinDenied { reason }`** (PR #660).
+>   The listener previously dropped requests silently for disabled /
+>   expired / exhausted links — joiner saw a 30-second timeout instead
+>   of the spec-promised explicit denial. Now distinguishes
+>   `link_disabled` (active = false) and `link_expired` (used >=
+>   max_uses OR expires_at < now) reasons.
+> - **Max-uses + expiration UI** shipped via a `<details>` disclosure
+>   in `settings.rs` (PR #661). Defaults to `max_uses=5` /
+>   `expires=Never`; selector offers Never / 1 hour / 24 hours / 7
+>   days. The `create_join_link(max_uses, expires_at)` signature was
+>   already correct; only the call site was hardcoded.
+>
+> **Intentional deviation from spec (anti-enumeration):**
+>
+> - **Unknown `link_id`s drop silently.** The spec's §Error Handling
+>   table lists `link_not_found` as a valid `JoinDenied` reason. The
+>   realised listener emits a denial for known-but-invalid links
+>   (`link_disabled` / `link_expired`) but drops requests for `link_id`s
+>   that aren't in the inviter's table at all. Rationale: replying for
+>   unknown link_ids would let attackers enumerate which link_ids exist
+>   ("I just need to find one that gets a Denied instead of a
+>   timeout"). Silent drop preserves the property that the inviter is
+>   indistinguishable from "wrong inviter" for unknown link_ids — only
+>   link_ids you *plausibly created* receive a denial.
+>
+> **Doc drift — spec text below is stale on these points:**
+>
+> - **Wire field types.** `JoinRequest.peer_id`, `JoinResponse.target_peer`,
+>   `JoinDenied.target_peer` are `EndpointId` in code, not `String`
+>   (the spec sketches use `String`). `JoinToken.inviter_peer_id` is
+>   likewise `EndpointId`. The wire protocol carries strongly-typed
+>   identities; the spec's String sketches are pseudocode.
+> - **`link_id` binding on responses.** `JoinResponse` and `JoinDenied`
+>   each carry an additional `link_id: String` field added for issue
+>   #309 / SEC-A-07 (signer-binding gating). The joiner records the
+>   expected inviter in `pending_joins` *before* broadcasting the
+>   `JoinRequest`, then drops responses whose `link_id` doesn't match
+>   the outstanding attempt or whose signer doesn't match the recorded
+>   inviter. Meaningful security mechanism not described in the spec's
+>   wire protocol section.
+> - **`JoinLink` extra fields.** The struct also carries `server_id:
+>   String` (required for per-server persistence) and `created_at: u64`
+>   (drives the UI's relative-age display).
+> - **Test coverage.** Spec §Testing calls for browser tests of the
+>   join-flow UI and link-management surfaces; realised coverage is
+>   at the client tier (state-actor + listener tests) plus a
+>   markup-contract browser test for the new options disclosure (PR
+>   #661). The end-to-end join flow itself is covered by
+>   `e2e/join-links.spec.ts`.
+>
+> The body below is preserved as the original target. The *Realised
+> state* list above is authoritative for current implementation shape;
+> do not edit the body in place to match it.
+
 ## Goal
 
 Replace the multi-step invite flow (share PeerId, generate per-recipient invite, paste blob) with a single shareable URL that triggers automatic P2P key exchange when clicked.


### PR DESCRIPTION
## Summary

All three substantive shareable-join-links audit findings have now landed in code:

- **PR #660** — JoinLink persistence (load_join_links at init, PersistJoinLinks on create/delete/used++).
- **PR #660** — `JoinDenied` emission for invalid links (`link_disabled` / `link_expired`), preserving anti-enumeration silent-drop for *unknown* link_ids.
- **PR #661** — Max-uses + expiration UI via `<details>` disclosure in settings.rs.

This PR flips the README badge `[active]` → `[landed]` and adds a **Realised state** addendum to the spec.

The addendum:

- Lists the substantive gaps that were closed and cites the PR that closed each.
- Documents the intentional deviation: spec §Error Handling lists `link_not_found` as a denial reason, but the realised listener drops unknown link_ids silently to preserve the anti-enumeration property. Only known-but-invalid links receive denials.
- Flags remaining doc drift (EndpointId vs String field types, the post-#309 `link_id` binding on `JoinResponse` / `JoinDenied`, extra `server_id` + `created_at` fields on `JoinLink`, test-tier breakdown).

Body preserved as original design target. Addendum is authoritative for current implementation shape.

## Test plan
- [x] Pure docs PR. No code changes.
- [x] README badge flipped.
- [x] All substantive gaps cited as resolved with PR numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)