### PR TITLE
fix(actor): deflake debounce/derived/liveness timing tests

### DIFF
--- a/crates/actor/src/debounce.rs
+++ b/crates/actor/src/debounce.rs
@@ -159,6 +159,25 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
 
+    // Poll `condition` every 10 ms until it returns true or `timeout_ms`
+    // elapses. Panics with `msg` on timeout.
+    //
+    // Use this for POSITIVE "X eventually happens" assertions in tests that
+    // depend on async delivery — actor timers and message routing can be
+    // slower than the test's wall clock under parallel suite load.
+    async fn wait_for(condition: impl Fn() -> bool, timeout_ms: u64, msg: &str) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+        loop {
+            if condition() {
+                return;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!("wait_for timeout after {timeout_ms}ms: {msg}");
+            }
+            runtime::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
     #[derive(Clone)]
     struct Ping(u32);
     impl Message for Ping {
@@ -207,7 +226,15 @@ mod tests {
         let debounce = system.spawn(Debounce::new(collector.into(), Duration::from_millis(50)));
 
         debounce.do_send(Enqueue(Ping(1))).unwrap();
-        runtime::sleep(Duration::from_millis(100)).await;
+
+        // Wait for the debounce flush to arrive — actor timer + message
+        // delivery can be slower than fixed sleeps under parallel suite load.
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 1,
+            2000,
+            "debounce should have forwarded exactly one message",
+        )
+        .await;
 
         assert_eq!(count.load(Ordering::SeqCst), 1);
         assert_eq!(*last.lock().unwrap(), Some(1));
@@ -223,7 +250,14 @@ mod tests {
         for i in 0..5 {
             debounce.do_send(Enqueue(Ping(i))).unwrap();
         }
-        runtime::sleep(Duration::from_millis(150)).await;
+
+        // Wait for the single coalesced flush to arrive.
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 1,
+            2000,
+            "debounce should have forwarded exactly one coalesced message",
+        )
+        .await;
 
         assert_eq!(count.load(Ordering::SeqCst), 1);
         assert_eq!(*last.lock().unwrap(), Some(4));
@@ -237,11 +271,27 @@ mod tests {
         let debounce = system.spawn(Debounce::new(collector.into(), Duration::from_millis(60)));
 
         debounce.do_send(Enqueue(Ping(1))).unwrap();
+        // Sleep for half the debounce window, then reset the timer with Ping(2).
         runtime::sleep(Duration::from_millis(30)).await;
         debounce.do_send(Enqueue(Ping(2))).unwrap();
         runtime::sleep(Duration::from_millis(30)).await;
-        assert_eq!(count.load(Ordering::SeqCst), 0);
-        runtime::sleep(Duration::from_millis(50)).await;
+        // Debounce window restarted from Ping(2); 30ms << 60ms — must not fire.
+        // This is an intentional timing invariant: fixed sleep is correct here
+        // because we're asserting a "not yet" condition within a known timed window.
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "timer should not have fired yet"
+        );
+
+        // Wait for the eventual flush via condition-based polling.
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 1,
+            2000,
+            "debounce should have forwarded Ping(2) after quiet period",
+        )
+        .await;
+
         assert_eq!(count.load(Ordering::SeqCst), 1);
         assert_eq!(*last.lock().unwrap(), Some(2));
         system.shutdown().await;
@@ -253,13 +303,26 @@ mod tests {
         let (collector, count, _) = setup_collector(&system);
         let debounce = system.spawn(Debounce::new(collector.into(), Duration::from_millis(30)));
 
+        // First burst — wait for it to flush before sending the second burst,
+        // so the two bursts are truly separate and each yields exactly one flush.
         debounce.do_send(Enqueue(Ping(1))).unwrap();
         debounce.do_send(Enqueue(Ping(2))).unwrap();
-        runtime::sleep(Duration::from_millis(80)).await;
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 1,
+            2000,
+            "first burst should have flushed",
+        )
+        .await;
 
+        // Second burst — wait for its flush too.
         debounce.do_send(Enqueue(Ping(3))).unwrap();
         debounce.do_send(Enqueue(Ping(4))).unwrap();
-        runtime::sleep(Duration::from_millis(80)).await;
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 2,
+            2000,
+            "second burst should have flushed",
+        )
+        .await;
 
         assert_eq!(count.load(Ordering::SeqCst), 2);
         system.shutdown().await;
@@ -272,7 +335,15 @@ mod tests {
         let throttle = system.spawn(Throttle::new(collector.into(), Duration::from_millis(100)));
 
         throttle.do_send(Enqueue(Ping(1))).unwrap();
-        runtime::sleep(Duration::from_millis(20)).await;
+
+        // Throttle forwards the first message immediately (before any cooldown
+        // fires). Wait for it to arrive rather than guessing a fixed sleep.
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 1,
+            2000,
+            "throttle should forward the first message immediately",
+        )
+        .await;
 
         assert_eq!(count.load(Ordering::SeqCst), 1);
         assert_eq!(*last.lock().unwrap(), Some(1));
@@ -286,12 +357,29 @@ mod tests {
         let throttle = system.spawn(Throttle::new(collector.into(), Duration::from_millis(100)));
 
         throttle.do_send(Enqueue(Ping(1))).unwrap();
-        runtime::sleep(Duration::from_millis(10)).await;
+        // First message is forwarded immediately. Wait for it so the cooldown
+        // window is known to have started before we queue more messages.
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 1,
+            2000,
+            "throttle should forward first message",
+        )
+        .await;
+
         throttle.do_send(Enqueue(Ping(2))).unwrap();
         throttle.do_send(Enqueue(Ping(3))).unwrap();
-        runtime::sleep(Duration::from_millis(20)).await;
 
-        assert_eq!(count.load(Ordering::SeqCst), 1);
+        // Cooldown is 100ms. Sleep for 20ms — well inside the cooldown window —
+        // and assert count is still 1. This is an intentional timing invariant:
+        // the cooldown MUST suppress extra messages during this window. A fixed
+        // sleep is correct here because we're asserting a "not yet" condition
+        // within a known timed window (20ms << 100ms cooldown).
+        runtime::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "throttle should suppress messages during cooldown"
+        );
         system.shutdown().await;
     }
 
@@ -302,9 +390,24 @@ mod tests {
         let throttle = system.spawn(Throttle::new(collector.into(), Duration::from_millis(50)));
 
         throttle.do_send(Enqueue(Ping(1))).unwrap();
-        runtime::sleep(Duration::from_millis(10)).await;
+        // Wait for first forward so we know the cooldown has started before
+        // queuing Ping(2).
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 1,
+            2000,
+            "throttle should forward first message",
+        )
+        .await;
+
         throttle.do_send(Enqueue(Ping(2))).unwrap();
-        runtime::sleep(Duration::from_millis(100)).await;
+
+        // After cooldown expires, pending Ping(2) should be forwarded.
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 2,
+            2000,
+            "throttle should forward pending message after cooldown",
+        )
+        .await;
 
         assert_eq!(count.load(Ordering::SeqCst), 2);
         assert_eq!(*last.lock().unwrap(), Some(2));
@@ -318,10 +421,24 @@ mod tests {
         let throttle = system.spawn(Throttle::new(collector.into(), Duration::from_millis(50)));
 
         throttle.do_send(Enqueue(Ping(1))).unwrap();
-        runtime::sleep(Duration::from_millis(10)).await;
+        // Wait for first forward so cooldown is active before queuing.
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 1,
+            2000,
+            "throttle should forward first message",
+        )
+        .await;
+
         throttle.do_send(Enqueue(Ping(2))).unwrap();
         throttle.do_send(Enqueue(Ping(3))).unwrap();
-        runtime::sleep(Duration::from_millis(100)).await;
+
+        // After cooldown, only the last pending (Ping(3)) should be forwarded.
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 2,
+            2000,
+            "throttle should forward only latest pending message after cooldown",
+        )
+        .await;
 
         assert_eq!(count.load(Ordering::SeqCst), 2);
         assert_eq!(*last.lock().unwrap(), Some(3));

--- a/crates/actor/src/derived.rs
+++ b/crates/actor/src/derived.rs
@@ -115,11 +115,15 @@ impl<Src: DeriveSource, T: PartialEq + Send + Sync + 'static> DerivedActor<Src, 
 
 impl<Src: DeriveSource, T: PartialEq + Send + Sync + 'static> Actor for DerivedActor<Src, T> {
     fn started(&mut self, ctx: &mut Context<Self>) -> impl Future<Output = ()> + Send {
-        // Subscribe to all sources
+        // Subscribe to all sources so we receive future changes.
         let recipient: Recipient<Notify> = ctx.address().into();
         self.sources.subscribe_all(recipient);
 
-        // Initial computation
+        // Compute the initial derived value via a spawned task.
+        // The task sends UpdateCache back to this actor; UpdateCache dedups
+        // against self.cached and sets dirty=true only when the value changes.
+        // This allows started() to return promptly so the mailbox processes
+        // incoming messages (e.g. Subscribe) without delay.
         let sources = self.sources.clone();
         let selector = Arc::clone(&self.selector);
         let addr = ctx.address();
@@ -282,6 +286,25 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::time::Duration;
 
+    // Poll `condition` every 10 ms until it returns true or `timeout_ms`
+    // elapses. Panics with `msg` on timeout.
+    //
+    // Use this for POSITIVE "X eventually happens" assertions in tests that
+    // depend on async actor message delivery, which can be slower than fixed
+    // sleeps under parallel suite load.
+    async fn wait_for(condition: impl Fn() -> bool, timeout_ms: u64, msg: &str) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+        loop {
+            if condition() {
+                return;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!("wait_for timeout after {timeout_ms}ms: {msg}");
+            }
+            runtime::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
     // Helper: actor that counts Notify messages
     struct NotifyCounter {
         count: Arc<AtomicU32>,
@@ -306,7 +329,7 @@ mod tests {
         let state = system.spawn(StateActor::new(10u32));
         let state_ref = StateRef::from(&state);
         let d = derived(&system.handle(), state_ref, |snap: &Arc<u32>| **snap * 2);
-        runtime::sleep(Duration::from_millis(50)).await;
+        // get() computes fresh through the mailbox if cache is not yet warm.
         let val = d.get().await;
         assert_eq!(*val, 20);
         system.shutdown().await;
@@ -314,22 +337,63 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn derived_caches_unchanged() {
+        // Verifies that DerivedActor does NOT notify subscribers when the
+        // computed derived value is unchanged.
+        //
+        // Race-free design:
+        //
+        // DerivedActor::started() spawns a task for the initial computation.
+        // If we subscribe a counter BEFORE that warm-up UpdateCache is
+        // processed, the cache transitions None→Some(2) AFTER our subscriber
+        // is registered, triggering a spurious notification.
+        //
+        // To eliminate this race we poll two consecutive `d.get().await`
+        // calls and wait until they return `Arc::ptr_eq` — which only happens
+        // when BOTH are served from the cached value (not fresh computes).
+        // At that point self.cached is definitely Some(2), so any subsequent
+        // UpdateCache(2) — including any late-arriving warm-up — will be
+        // deduplicated and produce no notification.
+        //
+        // State: 5u32 -> derived (/ 2) = 2
+        // Warm cache then subscribe.
+        // Set to 4: derived = 4/2 = 2 (SAME — must NOT notify).
+        // Wait 200ms, assert count == 0.
         let system = System::new();
         let state = system.spawn(StateActor::new(5u32));
         let state_ref = StateRef::from(&state);
         let count = Arc::new(AtomicU32::new(0));
         let d = derived(&system.handle(), state_ref, |snap: &Arc<u32>| **snap / 2); // 5/2=2
-        runtime::sleep(Duration::from_millis(50)).await;
 
+        // Wait until the actor's cache is warm: two consecutive get() calls
+        // that return Arc::ptr_eq guarantee both were served from self.cached
+        // (not fresh computes). After this, any UpdateCache(2) is a no-op.
+        let deadline = std::time::Instant::now() + Duration::from_millis(2000);
+        loop {
+            let a = d.get().await;
+            let b = d.get().await;
+            if Arc::ptr_eq(&a, &b) {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!("derived_caches_unchanged: timed out waiting for cache to warm");
+            }
+            runtime::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Now subscribe — cache is warm, any warm-up UpdateCache(2) will dedup.
         let counter = system.spawn(NotifyCounter {
             count: count.clone(),
         });
         d.subscribe(counter.into());
 
-        // Set to 4 — derived is still 2 (4/2=2), should not notify
+        // Set to 4 — derived is still 2 (4/2=2). DerivedActor must NOT notify.
         state.ask(crate::state::Set(4u32)).await.unwrap();
-        runtime::sleep(Duration::from_millis(100)).await;
-        assert_eq!(count.load(Ordering::SeqCst), 0);
+        runtime::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            0,
+            "derived value unchanged (5/2 == 4/2 == 2) — subscriber must not be notified"
+        );
         system.shutdown().await;
     }
 
@@ -345,7 +409,7 @@ mod tests {
             (r1, r2),
             |(a, b): &(Arc<u32>, Arc<u32>)| **a + **b,
         );
-        runtime::sleep(Duration::from_millis(50)).await;
+        // get() computes fresh through the mailbox if cache is not yet warm.
         assert_eq!(*d.get().await, 10);
         system.shutdown().await;
     }
@@ -364,7 +428,6 @@ mod tests {
             (r1, r2, r3),
             |(a, b, c): &(Arc<u32>, Arc<u32>, Arc<u32>)| **a + **b + **c,
         );
-        runtime::sleep(Duration::from_millis(50)).await;
         assert_eq!(*d.get().await, 6);
         system.shutdown().await;
     }
@@ -386,7 +449,6 @@ mod tests {
             ),
             |(a, b, c, d): &(Arc<u32>, Arc<u32>, Arc<u32>, Arc<u32>)| **a + **b + **c + **d,
         );
-        runtime::sleep(Duration::from_millis(50)).await;
         assert_eq!(*d.get().await, 10);
         system.shutdown().await;
     }
@@ -398,16 +460,23 @@ mod tests {
         let state_ref = StateRef::from(&state);
         let count = Arc::new(AtomicU32::new(0));
         let d = derived(&system.handle(), state_ref, |snap: &Arc<u32>| **snap * 2);
-        runtime::sleep(Duration::from_millis(50)).await;
 
         let counter = system.spawn(NotifyCounter {
             count: count.clone(),
         });
         d.subscribe(counter.into());
 
-        // Change value so derived changes: 5*2=10 -> 10*2=20
+        // Change value so derived changes: 5*2=10 -> 10*2=20.
         state.ask(crate::state::Set(10u32)).await.unwrap();
-        runtime::sleep(Duration::from_millis(100)).await;
+
+        // Wait for the subscriber to be notified via condition polling.
+        wait_for(
+            || count.load(Ordering::SeqCst) >= 1,
+            2000,
+            "subscriber should be notified when derived value changes (5->10)",
+        )
+        .await;
+
         assert!(
             count.load(Ordering::SeqCst) >= 1,
             "subscriber should be notified when derived value changes"
@@ -422,6 +491,8 @@ mod tests {
         let r = StateRef::from(&state);
         let d1 = derived(&system.handle(), r, |s: &Arc<u32>| **s * 2); // 10
         let d2 = derived(&system.handle(), d1, |s: &Arc<u32>| **s + 1); // 11
+                                                                        // Allow time for the chain to propagate initial values through two
+                                                                        // actor hops (d1 warm-up → d1 notifies d2 → d2 warm-up).
         runtime::sleep(Duration::from_millis(200)).await;
         assert_eq!(*d2.get().await, 11);
         system.shutdown().await;
@@ -434,6 +505,7 @@ mod tests {
         let r = StateRef::from(&state);
         let d1 = derived(&system.handle(), r, |s: &Arc<u32>| **s * 2); // 10
         let d2 = derived(&system.handle(), d1, |s: &Arc<u32>| **s + 1); // 11
+                                                                        // Allow chain to settle so both actors have populated their caches.
         runtime::sleep(Duration::from_millis(200)).await;
         let a = d2.get().await;
         let b = d2.get().await;
@@ -447,7 +519,7 @@ mod tests {
         let state = system.spawn(StateActor::new(42u32));
         let r = StateRef::from(&state);
         let d = derived(&system.handle(), r, |s: &Arc<u32>| **s);
-        runtime::sleep(Duration::from_millis(50)).await;
+        // get() computes fresh through the mailbox if cache is not yet warm.
         assert_eq!(*d.get().await, 42);
         system.shutdown().await;
     }
@@ -458,11 +530,26 @@ mod tests {
         let state = system.spawn(StateActor::new(1u32));
         let r = StateRef::from(&state);
         let d = derived(&system.handle(), r, |s: &Arc<u32>| **s * 10);
-        runtime::sleep(Duration::from_millis(50)).await;
         assert_eq!(*d.get().await, 10);
 
         state.ask(crate::state::Set(2u32)).await.unwrap();
-        runtime::sleep(Duration::from_millis(100)).await;
+
+        // Wait for the derived actor to process the source change and update
+        // its cache. Retry get() until it reflects the new value.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(2000);
+        loop {
+            let result = d.get().await;
+            if *result == 20 {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                panic!(
+                    "derived_update_cache_self_message: timed out waiting for value 20, got {}",
+                    *result
+                );
+            }
+            runtime::sleep(std::time::Duration::from_millis(10)).await;
+        }
         assert_eq!(*d.get().await, 20);
         system.shutdown().await;
     }
@@ -473,8 +560,7 @@ mod tests {
         let state = system.spawn(StateActor::new(7u32));
         let r = StateRef::from(&state);
         let d = derived(&system.handle(), r, |s: &Arc<u32>| **s + 3);
-        runtime::sleep(Duration::from_millis(50)).await;
-        // d is already a StateRef, verify it works
+        // get() computes fresh through the mailbox if cache is not yet warm.
         let val = d.get().await;
         assert_eq!(*val, 10);
         system.shutdown().await;

--- a/crates/actor/src/lib.rs
+++ b/crates/actor/src/lib.rs
@@ -979,6 +979,17 @@ mod tests {
         // Stop the actor.
         system.shutdown().await;
 
+        // shutdown() awaits done_rx, which fires when the mailbox loop calls
+        // done.send(()) — but the tokio task hasn't yet dropped the Receiver,
+        // so the channel's is_closed() can still return false for a brief
+        // window. Poll until the channel is truly closed before asserting.
+        for _ in 0..200 {
+            if !addr.is_alive() {
+                break;
+            }
+            runtime::sleep(Duration::from_millis(1)).await;
+        }
+
         // Trying to ask a dead actor should fail with Closed.
         let result = addr.ask(GetCount).await;
         assert!(matches!(result, Err(AskError::Closed)));
@@ -992,6 +1003,15 @@ mod tests {
         let addr = system.spawn(CounterActor::new());
 
         system.shutdown().await;
+
+        // Poll until the channel is truly closed (see ask_dead_actor_returns_closed
+        // for explanation of the done_rx vs is_closed() gap).
+        for _ in 0..200 {
+            if !addr.is_alive() {
+                break;
+            }
+            runtime::sleep(Duration::from_millis(1)).await;
+        }
 
         // send() on a dead actor should return the message.
         let result = addr.send(Increment);
@@ -1050,6 +1070,15 @@ mod tests {
         assert!(recipient.is_alive());
 
         system.shutdown().await;
+
+        // Poll until the channel is truly closed (see ask_dead_actor_returns_closed
+        // for explanation of the done_rx vs is_closed() gap).
+        for _ in 0..200 {
+            if !recipient.is_alive() {
+                break;
+            }
+            runtime::sleep(Duration::from_millis(1)).await;
+        }
 
         assert!(!recipient.is_alive());
         assert!(recipient.do_send(Increment).is_err());
@@ -1176,6 +1205,17 @@ mod tests {
         assert!(child.is_alive(), "child must be alive before shutdown");
 
         system.shutdown().await;
+
+        // Poll until both actors' channels are truly closed (see
+        // ask_dead_actor_returns_closed for explanation of the done_rx vs
+        // is_closed() gap that can cause immediate post-shutdown assertions
+        // to race).
+        for _ in 0..200 {
+            if !parent.is_alive() && !child.is_alive() {
+                break;
+            }
+            runtime::sleep(Duration::from_millis(1)).await;
+        }
 
         // After shutdown(), both parent AND child must be stopped — system
         // is the registry root, ctx.spawn registers with the same system.


### PR DESCRIPTION
## Summary

- **debounce_single_message, debounce_separate_bursts** (and all other debounce/throttle positive assertions): test race — fixed sleeps too short under parallel suite load. Replaced with `wait_for` condition polling (2 s timeout) on the exact atomic count that must change.
- **derived_caches_unchanged**: test race — `DerivedActor::started()` spawns an initial `UpdateCache` task; if the test's `Subscribe(counter)` was processed before that warm-up arrived, the actor's cache was `None` when `UpdateCache(2)` appeared, triggering a spurious dirty→notification cycle (`count 1`, expected `0`). Fixed by polling two consecutive `d.get().await` calls until `Arc::ptr_eq` — confirming `self.cached` is populated — *before* subscribing the counter.
- **ask_dead_actor_returns_closed, send_dead_actor_returns_send_error, recipient_dead_actor, system_shutdown_terminates_ctx_spawned_child**: test race — `system.shutdown().await` returns when `done_rx` fires (end of `run_mailbox`), but the tokio task has not yet dropped the `Receiver<T>`, so `tx.is_closed()` can still be `false` briefly. Added a ≤200 ms poll loop on `!addr.is_alive()` before asserting channel-closed semantics.

**No production code was changed.** All fixes are in the test modules of `debounce.rs`, `derived.rs`, and `lib.rs`.

## Test plan

- [x] Each of the 3 originally-reported flaky tests (`debounce_single_message`, `debounce_separate_bursts`, `derived_caches_unchanged`): **30/30 green in isolation**
- [x] All additionally hardened tests (remaining debounce/throttle, derived, liveness): **30/30 green in full suite** — confirmed by running `cargo test -p willow-actor --lib` **20 consecutive times** without a single failure
- [x] `cargo test -p willow-actor --lib` 5× consecutive: **94/94 tests, 5/5 runs**
- [x] `just check`: **zero warnings**, all crates green (fmt + clippy + test + WASM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)