### PR TITLE
fix(voice): make calls actually deliver media — five root-cause fixes

### DIFF
--- a/crates/client/src/listeners.rs
+++ b/crates/client/src/listeners.rs
@@ -644,19 +644,24 @@ pub(crate) async fn process_received_message<T: TopicHandle>(
             // per channel) dimensions of `VoiceState.participants`.
             // Without these gates, any signed peer can flood arbitrary
             // `channel_id`s and exhaust receiving clients' memory.
-            let known = willow_actor::state::select(&ctx.event_state, {
+            //
+            // The wire carries the canonical `channel_id` (UUID); voice state
+            // and UI events are keyed by the channel *name* (the whole UI is
+            // name-keyed). Resolve id -> name here: `None` both fails the
+            // existence gate and means "unknown channel".
+            let name = willow_actor::state::select(&ctx.event_state, {
                 let ch = channel_id.clone();
-                move |es| es.channels.contains_key(&ch)
+                move |es| es.channels.get(&ch).map(|c| c.name.clone())
             })
             .await;
-            if !known {
+            let Some(name) = name else {
                 tracing::debug!(
                     %signer, channel_id = %channel_id,
                     "dropping VoiceJoin: channel_id not in ServerState.channels"
                 );
                 return;
-            }
-            let ch = channel_id.clone();
+            };
+            let ch = name.clone();
             let inserted = willow_actor::state::mutate(&ctx.voice, move |v| {
                 let new_channel = !v.participants.contains_key(&ch);
                 if new_channel && v.participants.len() >= MAX_VOICE_CHANNELS {
@@ -680,7 +685,7 @@ pub(crate) async fn process_received_message<T: TopicHandle>(
             warn_if_err(
                 ctx.event_broker
                     .do_send(willow_actor::Publish(ClientEvent::VoiceJoined {
-                        channel_id,
+                        channel_id: name,
                         peer_id,
                     })),
                 "event_broker.do_send Publish(VoiceJoined)",
@@ -695,19 +700,21 @@ pub(crate) async fn process_received_message<T: TopicHandle>(
             // UI. The `participants` map is unaffected even without the
             // gate (`get_mut` returns None), but the event-broker fanout
             // would still leak attacker-controlled `channel_id`s.
-            let known = willow_actor::state::select(&ctx.event_state, {
+            // Resolve the wire `channel_id` (UUID) to the name used by voice
+            // state + UI events; `None` fails the existence gate.
+            let name = willow_actor::state::select(&ctx.event_state, {
                 let ch = channel_id.clone();
-                move |es| es.channels.contains_key(&ch)
+                move |es| es.channels.get(&ch).map(|c| c.name.clone())
             })
             .await;
-            if !known {
+            let Some(name) = name else {
                 tracing::debug!(
                     %signer, channel_id = %channel_id,
                     "dropping VoiceLeave: channel_id not in ServerState.channels"
                 );
                 return;
-            }
-            let ch = channel_id.clone();
+            };
+            let ch = name.clone();
             willow_actor::state::mutate(&ctx.voice, move |v| {
                 if let Some(p) = v.participants.get_mut(&ch) {
                     p.remove(&peer_id);
@@ -717,7 +724,7 @@ pub(crate) async fn process_received_message<T: TopicHandle>(
             warn_if_err(
                 ctx.event_broker
                     .do_send(willow_actor::Publish(ClientEvent::VoiceLeft {
-                        channel_id,
+                        channel_id: name,
                         peer_id,
                     })),
                 "event_broker.do_send Publish(VoiceLeft)",
@@ -734,22 +741,22 @@ pub(crate) async fn process_received_message<T: TopicHandle>(
                 // event handlers. Signals do not mutate `participants`
                 // directly, but the existence check shuts the same fanout
                 // gap as Join/Leave.
-                let known = willow_actor::state::select(&ctx.event_state, {
+                let name = willow_actor::state::select(&ctx.event_state, {
                     let ch = channel_id.clone();
-                    move |es| es.channels.contains_key(&ch)
+                    move |es| es.channels.get(&ch).map(|c| c.name.clone())
                 })
                 .await;
-                if !known {
+                let Some(name) = name else {
                     tracing::debug!(
                         %signer, channel_id = %channel_id,
                         "dropping VoiceSignal: channel_id not in ServerState.channels"
                     );
                     return;
-                }
+                };
                 warn_if_err(
                     ctx.event_broker
                         .do_send(willow_actor::Publish(ClientEvent::VoiceSignal {
-                            channel_id,
+                            channel_id: name,
                             from_peer: signer,
                             signal,
                         })),
@@ -1604,6 +1611,18 @@ mod tests {
             .expect("test_client must seed at least one channel")
     }
 
+    /// The display name of the first seeded channel. Voice state + events are
+    /// keyed by name (the wire carries the UUID `channel_id`, which the
+    /// listener resolves to this name), so state assertions look up by name.
+    async fn known_channel_name<N: willow_network::Network>(client: &ClientHandle<N>) -> String {
+        let snap = client.state_snapshot().await;
+        snap.channels
+            .values()
+            .next()
+            .map(|c| c.name.clone())
+            .expect("test_client must seed at least one channel")
+    }
+
     /// VoiceJoin against an unknown `channel_id` must not mutate
     /// `VoiceState.participants` (defends against attackers flooding
     /// random channel ids until memory is exhausted).
@@ -1652,7 +1671,10 @@ mod tests {
             .await
             .expect("subscribe must succeed");
         let ctx = make_ctx(&client);
+        // Wire is addressed by canonical channel_id (UUID); voice state is
+        // keyed by the resolved channel name.
         let channel_id = known_channel_id(&client).await;
+        let channel_name = known_channel_name(&client).await;
 
         let attacker = willow_identity::Identity::generate();
         let attacker_id = attacker.endpoint_id();
@@ -1665,7 +1687,7 @@ mod tests {
 
         let stored = poll_until_some(
             || {
-                let ch = channel_id.clone();
+                let ch = channel_name.clone();
                 willow_actor::state::select(&client.voice_state_addr, move |v| {
                     v.participants
                         .get(&ch)
@@ -1679,7 +1701,7 @@ mod tests {
         assert_eq!(
             stored,
             Some(1),
-            "VoiceJoin on a known channel must record the participant"
+            "VoiceJoin on a known channel must record the participant (keyed by name)"
         );
     }
 
@@ -1748,10 +1770,12 @@ mod tests {
             .await
             .expect("subscribe must succeed");
         let ctx = make_ctx(&client);
+        // Wire is addressed by channel_id (UUID); state is keyed by name.
         let channel_id = known_channel_id(&client).await;
+        let channel_name = known_channel_name(&client).await;
 
-        // Fill the cap with synthetic participants on the real channel.
-        let cap_channel = channel_id.clone();
+        // Fill the cap with synthetic participants on the real channel (by name).
+        let cap_channel = channel_name.clone();
         willow_actor::state::mutate(&client.voice_state_addr, move |v| {
             let set = v.participants.entry(cap_channel).or_default();
             for _ in 0..MAX_PARTICIPANTS_PER_CHANNEL {
@@ -1763,7 +1787,7 @@ mod tests {
         // Confirm preconditions.
         let pre = voice_snapshot(&client).await;
         assert_eq!(
-            pre.participants.get(&channel_id).map(|s| s.len()),
+            pre.participants.get(&channel_name).map(|s| s.len()),
             Some(MAX_PARTICIPANTS_PER_CHANNEL),
             "test setup must fill participants to cap"
         );
@@ -1781,7 +1805,7 @@ mod tests {
         let snap = voice_snapshot(&client).await;
         let set = snap
             .participants
-            .get(&channel_id)
+            .get(&channel_name)
             .expect("channel set must still exist");
         assert_eq!(
             set.len(),

--- a/crates/client/src/mutations.rs
+++ b/crates/client/src/mutations.rs
@@ -156,6 +156,30 @@ impl<N: willow_network::Network> ClientMutations<N> {
         channel_id.ok_or_else(|| anyhow::anyhow!("channel not found: {channel}"))
     }
 
+    /// Resolve a channel reference (already a `channel_id`, or a display name)
+    /// to the canonical `channel_id` (UUID) used on the wire.
+    ///
+    /// Voice signaling (`VoiceJoin`/`VoiceLeave`/`VoiceSignal`) must address
+    /// channels by their canonical id so the receiver's existence gate — which
+    /// validates against `ServerState.channels` (keyed by id) — accepts them.
+    /// The UI keys voice state by name, so this accepts either form: an exact
+    /// id match wins, otherwise it falls back to a name lookup. Returns `None`
+    /// if the channel is unknown.
+    pub(crate) async fn channel_id_for_voice(&self, channel: &str) -> Option<String> {
+        let ch = channel.to_string();
+        willow_actor::state::select(&self.event_state, move |es| {
+            if es.channels.contains_key(&ch) {
+                Some(ch.clone())
+            } else {
+                es.channels
+                    .iter()
+                    .find(|(_, c)| c.name == ch)
+                    .map(|(id, _)| id.clone())
+            }
+        })
+        .await
+    }
+
     /// Sync event_state mirror from ManagedDag, persist, and emit
     /// ClientEvents. Called after build_event succeeds — ManagedDag has
     /// already applied the event to its internal state atomically.
@@ -699,21 +723,33 @@ impl<N: willow_network::Network> ClientMutations<N> {
 
 impl<N: willow_network::Network> ClientMutations<N> {
     /// Join a voice channel.
-    pub async fn join_voice(&self, channel_id: &str) {
+    ///
+    /// `channel` is a channel name (the UI's identifier) or a `channel_id`.
+    /// Local voice state stays keyed by the channel *name* (consistent with the
+    /// name-keyed UI); the broadcast `VoiceJoin` carries the canonical
+    /// `channel_id` (UUID) so remote peers' existence gate accepts it.
+    pub async fn join_voice(&self, channel: &str) {
         let in_voice =
             willow_actor::state::select(&self.voice, |v| v.active_channel.is_some()).await;
         if in_voice {
             self.leave_voice().await;
         }
-        let ch = channel_id.to_string();
+        // Local voice state is keyed by the caller's reference (the UI's
+        // channel name), so the UI — which reads the same key — matches.
         let my_peer_id = self.identity.endpoint_id();
+        let ch = channel.to_string();
         willow_actor::state::mutate(&self.voice, move |v| {
             v.active_channel = Some(ch.clone());
             v.participants.entry(ch).or_default().insert(my_peer_id);
         })
         .await;
+        // Broadcast addressed by canonical channel_id so peers accept it.
+        let Some(channel_id) = self.channel_id_for_voice(channel).await else {
+            tracing::warn!(%channel, "join_voice: unknown channel, not broadcasting");
+            return;
+        };
         let msg = ops::WireMessage::VoiceJoin {
-            channel_id: channel_id.to_string(),
+            channel_id,
             peer_id: my_peer_id,
         };
         if let Some(data) = ops::pack_wire(&msg, &self.identity) {
@@ -736,8 +772,14 @@ impl<N: willow_network::Network> ClientMutations<N> {
         })
         .await;
         if let Some(ch) = maybe_ch {
+            // `ch` is the local key (channel name); address the wire message
+            // by canonical channel_id so peers' existence gate accepts it.
+            let Some(channel_id) = self.channel_id_for_voice(&ch).await else {
+                tracing::warn!(channel = %ch, "leave_voice: unknown channel, not broadcasting");
+                return;
+            };
             let msg = ops::WireMessage::VoiceLeave {
-                channel_id: ch,
+                channel_id,
                 peer_id: my_peer_id,
             };
             if let Some(data) = ops::pack_wire(&msg, &self.identity) {

--- a/crates/client/src/voice.rs
+++ b/crates/client/src/voice.rs
@@ -40,14 +40,23 @@ impl<N: willow_network::Network> ClientHandle<N> {
         willow_actor::state::select(&self.voice_state_addr, |v| v.deafened).await
     }
 
-    pub fn send_voice_signal(
+    /// Send a WebRTC signaling message to a peer.
+    ///
+    /// `channel` is the UI's channel reference (name) or a `channel_id`; it is
+    /// resolved to the canonical `channel_id` (UUID) so the receiver's
+    /// existence gate accepts it. Async because resolution reads event state.
+    pub async fn send_voice_signal(
         &self,
-        channel_id: &str,
+        channel: &str,
         target: willow_identity::EndpointId,
         signal: ops::VoiceSignalPayload,
     ) {
+        let Some(channel_id) = self.mutation_handle.channel_id_for_voice(channel).await else {
+            tracing::warn!(%channel, "send_voice_signal: unknown channel");
+            return;
+        };
         let msg = ops::WireMessage::VoiceSignal {
-            channel_id: channel_id.to_string(),
+            channel_id,
             target_peer: target,
             signal,
         };

--- a/crates/common/src/wire.rs
+++ b/crates/common/src/wire.rs
@@ -240,6 +240,17 @@ const SIGNALING_CAP: usize = 4 * 1024;
 /// fall-through for variants that don't have a dedicated cap.
 const DEFAULT_CAP: usize = 64 * 1024;
 
+/// Per-variant size cap for WebRTC SDP signaling: 64 KB.
+///
+/// [`WireMessage::VoiceSignal`] carries SDP offers/answers, **not** just tiny
+/// ICE-candidate blobs. A real video offer (multiple codecs, RTP header
+/// extensions, trickle-ICE history) routinely runs 5-15 KB and can grow larger
+/// after renegotiation, so the 4 KB [`SIGNALING_CAP`] silently dropped them
+/// (see `docs/reports/2026-06-07-voice-media-connectivity-investigation.md`).
+/// 64 KB leaves ample headroom while staying inside the transport-level
+/// [`willow_transport::MAX_DESER_SIZE`] (256 KB) ceiling.
+const SDP_CAP: usize = 64 * 1024;
+
 impl WireMessage {
     /// Returns the maximum permitted serialized size, in bytes, for this
     /// variant when it appears on the wire.
@@ -267,9 +278,12 @@ impl WireMessage {
     ///   formal length limit yet, but 64 KB is wildly more than any
     ///   reasonable display name.
     /// - **Signaling variants** (`TypingIndicator`, `VoiceJoin`,
-    ///   `VoiceLeave`, `VoiceSignal`, `JoinRequest`, `JoinResponse`,
-    ///   `JoinDenied`, `SyncRequest`): `SIGNALING_CAP` (4 KB). These
-    ///   carry only ids, short strings, and SDP/ICE blobs — all small.
+    ///   `VoiceLeave`, `JoinRequest`, `JoinResponse`, `JoinDenied`,
+    ///   `SyncRequest`): `SIGNALING_CAP` (4 KB). These carry only ids, short
+    ///   strings, and tiny control payloads.
+    /// - **`VoiceSignal`**: `SDP_CAP` (64 KB). Carries WebRTC SDP
+    ///   offers/answers, which are far larger than the other signaling
+    ///   variants — see [`SDP_CAP`].
     pub fn max_size(&self) -> usize {
         match self {
             // User-generated bodies, batched payloads, and topic announces:
@@ -301,10 +315,11 @@ impl WireMessage {
             | WireMessage::TypingIndicator { .. }
             | WireMessage::VoiceJoin { .. }
             | WireMessage::VoiceLeave { .. }
-            | WireMessage::VoiceSignal { .. }
             | WireMessage::JoinRequest { .. }
             | WireMessage::JoinResponse { .. }
             | WireMessage::JoinDenied { .. } => SIGNALING_CAP,
+            // WebRTC SDP offers/answers are far larger than other signaling.
+            WireMessage::VoiceSignal { .. } => SDP_CAP,
         }
     }
 
@@ -1095,6 +1110,71 @@ mod tests {
             }
             _ => panic!("expected VoiceSignal"),
         }
+    }
+
+    /// Build an SDP blob of approximately `kb` kilobytes that looks like a
+    /// real video offer (the size, not the exact grammar, is what matters
+    /// for the per-variant cap test).
+    fn fake_video_sdp(kb: usize) -> String {
+        // A real video SDP is dominated by repeated codec/fmtp/rtcp-fb and
+        // ICE candidate lines. Emit enough to reach ~kb KB.
+        let line = "a=rtpmap:96 VP9/90000\r\na=fmtp:96 profile-id=0;max-fs=12288;max-fr=60\r\na=rtcp-fb:96 nack pli\r\n";
+        let mut sdp = String::from("v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n");
+        while sdp.len() < kb * 1024 {
+            sdp.push_str(line);
+        }
+        sdp
+    }
+
+    #[test]
+    fn voice_signal_offer_survives_realistic_video_sdp() {
+        // A real video SDP offer (multiple codecs, header extensions, trickle
+        // ICE history) routinely runs 5-15 KB. It must survive the wire
+        // round-trip — the per-variant cap for VoiceSignal has to leave room
+        // for SDP, not just tiny ICE-candidate blobs.
+        let id = Identity::generate();
+        let target = Identity::generate().endpoint_id();
+        let sdp = fake_video_sdp(10); // ~10 KB
+        assert!(
+            sdp.len() > 4 * 1024,
+            "test SDP must exceed the old 4 KB cap"
+        );
+        let msg = WireMessage::VoiceSignal {
+            channel_id: "voice-1".to_string(),
+            target_peer: target,
+            signal: VoiceSignalPayload::Offer(sdp.clone()),
+        };
+        let data = pack_wire(&msg, &id).unwrap();
+        let decoded = unpack_wire(&data);
+        assert!(
+            decoded.is_some(),
+            "a ~10 KB video SDP offer must not be dropped by the per-variant cap"
+        );
+        match decoded.unwrap().0 {
+            WireMessage::VoiceSignal {
+                signal: VoiceSignalPayload::Offer(got),
+                ..
+            } => assert_eq!(got, sdp),
+            other => panic!("expected VoiceSignal Offer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oversize_voice_signal_is_still_rejected() {
+        // The SDP cap still bounds abuse: a payload past the cap is dropped.
+        let id = Identity::generate();
+        let target = Identity::generate().endpoint_id();
+        let huge = fake_video_sdp(100); // 100 KB, past the SDP cap
+        let msg = WireMessage::VoiceSignal {
+            channel_id: "voice-1".to_string(),
+            target_peer: target,
+            signal: VoiceSignalPayload::Offer(huge),
+        };
+        let data = pack_wire(&msg, &id).unwrap();
+        assert!(
+            unpack_wire(&data).is_none(),
+            "a VoiceSignal past the SDP cap must still be rejected"
+        );
     }
 
     #[test]

--- a/crates/web/src/app.rs
+++ b/crates/web/src/app.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::rc::Rc;
 
 use leptos::prelude::*;
@@ -51,8 +50,13 @@ const LOADING_TIMEOUT_MS: u32 = 5_000;
 /// Wrapper around `willow_client::ClientHandle` that is `Send` for single-threaded WASM.
 pub type WebClientHandle = SendWrapper<ClientHandle<willow_network::iroh::IrohNetwork>>;
 
-/// Wrapper around `Rc<RefCell<VoiceManager>>` that is `Send` for single-threaded WASM.
-pub type VoiceManagerHandle = SendWrapper<Rc<RefCell<VoiceManager>>>;
+/// Wrapper around `Rc<VoiceManager>` that is `Send` for single-threaded WASM.
+///
+/// No outer `RefCell`: `VoiceManager` owns its mutable state behind interior
+/// mutability and exposes only `&self` methods, so callers can `.await` the
+/// async signaling methods without holding a borrow across the await point
+/// (which previously risked a `RefCell` double-borrow panic mid-negotiation).
+pub type VoiceManagerHandle = SendWrapper<Rc<VoiceManager>>;
 
 /// Default relay URL for the deployed Willow relay server.
 pub const DEFAULT_RELAY_URL: &str = "https://willow.intendednull.com:9443";
@@ -313,35 +317,39 @@ pub fn App() -> impl IntoView {
     let voice_channel_for_signal = app_state.voice.voice_channel;
     let set_remote_streams = write.voice.set_remote_video_streams;
     let set_speaking = write.voice.set_speaking_peers;
-    let voice_manager: VoiceManagerHandle =
-        SendWrapper::new(Rc::new(RefCell::new(VoiceManager::new(
-            local_peer_id,
-            move |target_peer: &str, signal_type: &str, payload: &str| {
-                let ch_id = voice_channel_for_signal.get_untracked().unwrap_or_default();
-                let signal = match signal_type {
-                    "offer" => VoiceSignalPayload::Offer(payload.to_string()),
-                    "answer" => VoiceSignalPayload::Answer(payload.to_string()),
-                    "ice" => VoiceSignalPayload::IceCandidate(payload.to_string()),
-                    _ => return,
-                };
-                if let Ok(target) = target_peer.parse::<willow_identity::EndpointId>() {
-                    voice_signal_handle.send_voice_signal(&ch_id, target, signal);
-                }
-            },
-            move |peer_id: &str, stream: Option<web_sys::MediaStream>| {
-                let pid = peer_id.to_string();
-                set_remote_streams.update(move |map| {
-                    if let Some(s) = stream {
-                        map.insert(pid, send_wrapper::SendWrapper::new(s));
-                    } else {
-                        map.remove(&pid);
-                    }
+    let voice_manager: VoiceManagerHandle = SendWrapper::new(Rc::new(VoiceManager::new(
+        local_peer_id,
+        move |target_peer: &str, signal_type: &str, payload: &str| {
+            let ch_id = voice_channel_for_signal.get_untracked().unwrap_or_default();
+            let signal = match signal_type {
+                "offer" => VoiceSignalPayload::Offer(payload.to_string()),
+                "answer" => VoiceSignalPayload::Answer(payload.to_string()),
+                "ice" => VoiceSignalPayload::IceCandidate(payload.to_string()),
+                _ => return,
+            };
+            if let Ok(target) = target_peer.parse::<willow_identity::EndpointId>() {
+                // send_voice_signal resolves the channel name -> canonical id
+                // (async), so dispatch it on the local task queue.
+                let h = voice_signal_handle.clone();
+                wasm_bindgen_futures::spawn_local(async move {
+                    h.send_voice_signal(&ch_id, target, signal).await;
                 });
-            },
-            move |peers: std::collections::HashSet<String>| {
-                set_speaking.set(peers);
-            },
-        ))));
+            }
+        },
+        move |peer_id: &str, stream: Option<web_sys::MediaStream>| {
+            let pid = peer_id.to_string();
+            set_remote_streams.update(move |map| {
+                if let Some(s) = stream {
+                    map.insert(pid, send_wrapper::SendWrapper::new(s));
+                } else {
+                    map.remove(&pid);
+                }
+            });
+        },
+        move |peers: std::collections::HashSet<String>| {
+            set_speaking.set(peers);
+        },
+    )));
 
     provide_context(voice_manager.clone());
 
@@ -773,7 +781,7 @@ pub fn App() -> impl IntoView {
     let on_voice_mute = move |_: ()| {
         let new_muted = !app_state.voice.voice_muted.get_untracked();
         write.voice.set_voice_muted.set(new_muted);
-        vm_mute.borrow().set_muted(new_muted);
+        vm_mute.set_muted(new_muted);
     };
 
     // Voice deafen handler.
@@ -783,10 +791,10 @@ pub fn App() -> impl IntoView {
         write.voice.set_voice_deafened.set(new_deafened);
         if new_deafened {
             write.voice.set_voice_muted.set(true);
-            vm_deafen.borrow().set_muted(true);
+            vm_deafen.set_muted(true);
         } else {
             write.voice.set_voice_muted.set(false);
-            vm_deafen.borrow().set_muted(false);
+            vm_deafen.set_muted(false);
         }
     };
 
@@ -798,7 +806,7 @@ pub fn App() -> impl IntoView {
         wasm_bindgen_futures::spawn_local(async move {
             handle_voice_leave.leave_voice().await;
         });
-        vm_disconnect.borrow_mut().close_all();
+        vm_disconnect.close_all();
         write.voice.reset();
         write.ui.set_show_call_page.set(false);
         write
@@ -1053,7 +1061,7 @@ pub fn App() -> impl IntoView {
                                         wasm_bindgen_futures::spawn_local(async move {
                                             vc_leave.leave_voice().await;
                                         });
-                                        vm.borrow_mut().close_all();
+                                        vm.close_all();
                                         write.voice.reset();
                                     }
 
@@ -1098,7 +1106,7 @@ pub fn App() -> impl IntoView {
                                     let on_success = wasm_bindgen::closure::Closure::once(move |stream: wasm_bindgen::JsValue| {
                                         use wasm_bindgen::JsCast;
                                         let stream: web_sys::MediaStream = stream.unchecked_into();
-                                        vm2.borrow_mut().set_local_stream(stream);
+                                        vm2.set_local_stream(stream);
                                         wasm_bindgen_futures::spawn_local(async move {
                                             vc.join_voice(&ch_name).await;
 
@@ -1540,32 +1548,21 @@ pub fn App() -> impl IntoView {
 
 /// Helper to create a WebRTC offer in a spawned future.
 ///
-/// The `RefCell` borrow is held across await but this is safe on
-/// single-threaded WASM where there is no preemption.
-#[allow(clippy::await_holding_refcell_ref)]
+/// `VoiceManager` exposes `&self` async methods over interior mutability, so no
+/// `RefCell` borrow is held across the await — concurrent signaling tasks
+/// (offers, answers, ICE candidates) can interleave safely.
 pub async fn handle_voice_create_offer(vm: VoiceManagerHandle, peer_id: String) {
-    let mut mgr = vm.borrow_mut();
-    mgr.create_offer(&peer_id).await.ok();
+    vm.create_offer(&peer_id).await.ok();
 }
 
 /// Helper to handle an incoming WebRTC offer.
-///
-/// The `RefCell` borrow is held across await but this is safe on
-/// single-threaded WASM where there is no preemption.
-#[allow(clippy::await_holding_refcell_ref)]
 pub async fn handle_voice_offer(vm: VoiceManagerHandle, from: String, sdp: String) {
-    let mut mgr = vm.borrow_mut();
-    mgr.handle_offer(&from, &sdp).await.ok();
+    vm.handle_offer(&from, &sdp).await.ok();
 }
 
 /// Helper to handle an incoming WebRTC answer.
-///
-/// The `RefCell` borrow is held across await but this is safe on
-/// single-threaded WASM where there is no preemption.
-#[allow(clippy::await_holding_refcell_ref)]
 pub async fn handle_voice_answer(vm: VoiceManagerHandle, from: String, sdp: String) {
-    let mgr = vm.borrow();
-    mgr.handle_answer(&from, &sdp).await.ok();
+    vm.handle_answer(&from, &sdp).await.ok();
 }
 
 #[cfg(test)]

--- a/crates/web/src/components/call_page.rs
+++ b/crates/web/src/components/call_page.rs
@@ -199,7 +199,7 @@ pub fn CallPage(
 
         if current_source == Some(VideoSource::Camera) {
             // Toggle off — stop camera.
-            vm_camera.borrow_mut().stop_video_share();
+            vm_camera.stop_video_share();
             write.voice.set_video_source.set(None);
             write.voice.set_local_video_stream.set(None);
             return;
@@ -207,7 +207,7 @@ pub fn CallPage(
 
         // Stop any existing share first.
         if current_source.is_some() {
-            vm_camera.borrow_mut().stop_video_share();
+            vm_camera.stop_video_share();
             write.voice.set_video_source.set(None);
             write.voice.set_local_video_stream.set(None);
         }
@@ -236,7 +236,7 @@ pub fn CallPage(
             use wasm_bindgen::JsCast;
             let stream: web_sys::MediaStream = stream.unchecked_into();
             let stream_for_signal = SendWrapper::new(stream.clone());
-            vm2.borrow_mut().start_camera(stream);
+            vm2.start_camera(stream);
             write2.voice.set_video_source.set(Some(VideoSource::Camera));
             write2
                 .voice
@@ -260,7 +260,7 @@ pub fn CallPage(
 
         if current_source == Some(VideoSource::Screen) {
             // Toggle off — stop screen share.
-            vm_screen.borrow_mut().stop_video_share();
+            vm_screen.stop_video_share();
             write.voice.set_video_source.set(None);
             write.voice.set_local_video_stream.set(None);
             return;
@@ -268,7 +268,7 @@ pub fn CallPage(
 
         // Stop any existing share first.
         if current_source.is_some() {
-            vm_screen.borrow_mut().stop_video_share();
+            vm_screen.stop_video_share();
             write.voice.set_video_source.set(None);
             write.voice.set_local_video_stream.set(None);
         }
@@ -295,7 +295,7 @@ pub fn CallPage(
             use wasm_bindgen::JsCast;
             let stream: web_sys::MediaStream = stream.unchecked_into();
             let stream_for_signal = SendWrapper::new(stream.clone());
-            vm2.borrow_mut().start_screen_share(stream.clone());
+            vm2.start_screen_share(stream.clone());
             write2.voice.set_video_source.set(Some(VideoSource::Screen));
             write2
                 .voice
@@ -309,7 +309,7 @@ pub fn CallPage(
                 let track: web_sys::MediaStreamTrack = track_val.unchecked_into();
                 let vm_ended = vm2.clone();
                 let on_ended = Closure::once(move || {
-                    vm_ended.borrow_mut().stop_video_share();
+                    vm_ended.stop_video_share();
                     write2.voice.set_local_video_stream.set(None);
                     write2.voice.set_video_source.set(None);
                 });

--- a/crates/web/src/event_processing.rs
+++ b/crates/web/src/event_processing.rs
@@ -85,7 +85,10 @@ pub fn process_event_batch(
                         participants.push(pid.clone());
                     }
                 });
-                if state.voice.voice_channel.get_untracked() == Some(ch) {
+                // Existing participants offer to the new joiner (one offerer per
+                // pair). Skip our own echoed join so we never offer to ourselves.
+                if state.voice.voice_channel.get_untracked() == Some(ch) && pid != handle.peer_id()
+                {
                     let vm = voice_manager.clone();
                     let p = pid;
                     wasm_bindgen_futures::spawn_local(handle_voice_create_offer(vm, p));
@@ -106,9 +109,7 @@ pub fn process_event_batch(
                 write.voice.set_remote_video_streams.update(|m| {
                     m.remove(&pid_for_stream);
                 });
-                voice_manager
-                    .borrow_mut()
-                    .close_connection(&peer_id.to_string());
+                voice_manager.close_connection(&peer_id.to_string());
             }
             ClientEvent::VoiceSignal {
                 from_peer, signal, ..
@@ -125,7 +126,7 @@ pub fn process_event_batch(
                         wasm_bindgen_futures::spawn_local(handle_voice_answer(vm, from, s));
                     }
                     VoiceSignalPayload::IceCandidate(json) => {
-                        if let Err(e) = vm.borrow().handle_ice_candidate(&from, json) {
+                        if let Err(e) = vm.handle_ice_candidate(&from, json) {
                             tracing::warn!(?e, "handle_ice_candidate failed");
                         }
                     }

--- a/crates/web/src/voice.rs
+++ b/crates/web/src/voice.rs
@@ -20,11 +20,11 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use wasm_bindgen::closure::Closure;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{
     AnalyserNode, AudioContext, MediaStream, MediaStreamAudioSourceNode, RtcConfiguration,
     RtcIceServer, RtcPeerConnection, RtcPeerConnectionIceEvent, RtcRtpSender, RtcSdpType,
-    RtcSessionDescriptionInit, RtcTrackEvent,
+    RtcSessionDescriptionInit, RtcSignalingState, RtcTrackEvent,
 };
 
 use crate::state::VideoSource;
@@ -200,6 +200,36 @@ struct PeerConnectionState {
     /// Shared flag: `true` while we are in the process of creating and sending
     /// an offer. Shared with the `onnegotiationneeded` closure via `Rc<Cell>`.
     making_offer: Rc<Cell<bool>>,
+    /// `true` once `setRemoteDescription` has succeeded on this connection.
+    ///
+    /// Remote ICE candidates that arrive before this is set cannot be added —
+    /// the browser rejects `addIceCandidate` while `remoteDescription` is null
+    /// (it buffers only the *local* end's candidates, not remote ones). We
+    /// queue such candidates in [`VoiceManager::pending_ice`] and flush them
+    /// once this flips true. Reading `pc.remote_description()` directly would
+    /// require the `RtcSessionDescription` web-sys feature; a flag is both
+    /// cheaper and deterministically testable.
+    remote_set: Rc<Cell<bool>>,
+}
+
+/// Cheaply-cloned handles to a peer connection, returned from
+/// [`VoiceManager::get_or_create_connection`] so the caller can drive the
+/// async SDP exchange without holding a `RefCell` borrow across `.await`.
+struct ConnHandles {
+    pc: RtcPeerConnection,
+    making_offer: Rc<Cell<bool>>,
+    remote_set: Rc<Cell<bool>>,
+}
+
+impl PeerConnectionState {
+    /// Clone the cheap handles (JS reference + `Rc` flags) out of this state.
+    fn handles(&self) -> ConnHandles {
+        ConnHandles {
+            pc: self.pc.clone(),
+            making_offer: self.making_offer.clone(),
+            remote_set: self.remote_set.clone(),
+        }
+    }
 }
 
 /// Manages WebRTC connections for voice chat.
@@ -213,22 +243,32 @@ pub struct VoiceManager {
     /// Our own peer ID, used for polite/impolite determination.
     local_peer_id: String,
     /// One `PeerConnectionState` per remote peer.
-    connections: HashMap<String, PeerConnectionState>,
+    ///
+    /// All mutable state lives behind interior mutability (`RefCell`/`Cell`) so
+    /// every public method can take `&self`. This lets callers hold the manager
+    /// behind a plain `Rc<VoiceManager>` (no outer `RefCell`) and `.await` the
+    /// async signaling methods without holding any borrow across the await
+    /// point. Internal `RefCell` guards are always dropped before any `.await`.
+    connections: RefCell<HashMap<String, PeerConnectionState>>,
     /// Local microphone stream (acquired once).
-    local_stream: Option<MediaStream>,
+    local_stream: RefCell<Option<MediaStream>>,
     /// Callback to send signaling data: `(target_peer, signal_type, payload)`.
     on_signal: SignalCallback,
     /// Callback invoked when a remote video track arrives or ends.
     on_video_track: VideoTrackCallback,
     /// Active video stream (camera or screen share).
-    video_stream: Option<MediaStream>,
+    video_stream: RefCell<Option<MediaStream>>,
     /// Which video source is currently active.
-    video_source: Option<VideoSource>,
+    video_source: Cell<Option<VideoSource>>,
     /// RTP senders for the video track, keyed by remote peer ID.
     /// Stored so we can call `remove_track` later.
-    video_senders: HashMap<String, RtcRtpSender>,
+    video_senders: RefCell<HashMap<String, RtcRtpSender>>,
+    /// Remote ICE candidates that arrived before their connection had a remote
+    /// description set. Flushed by [`VoiceManager::flush_pending_ice`] once
+    /// `setRemoteDescription` succeeds. Keyed by remote peer ID.
+    pending_ice: RefCell<PendingIceCandidates>,
     /// Audio volume analyser for speaking detection.
-    speaking_detector: Option<SpeakingDetector>,
+    speaking_detector: RefCell<Option<SpeakingDetector>>,
     /// Stored so `close_all()` can recreate the `SpeakingDetector` for the next session.
     speaking_change_cb: Option<Rc<dyn Fn(HashSet<String>)>>,
 }
@@ -264,14 +304,15 @@ impl VoiceManager {
         }
         Self {
             local_peer_id,
-            connections: HashMap::new(),
-            local_stream: None,
+            connections: RefCell::new(HashMap::new()),
+            local_stream: RefCell::new(None),
             on_signal: Rc::new(on_signal),
             on_video_track: Rc::new(on_video_track),
-            video_stream: None,
-            video_source: None,
-            video_senders: HashMap::new(),
-            speaking_detector: detector,
+            video_stream: RefCell::new(None),
+            video_source: Cell::new(None),
+            video_senders: RefCell::new(HashMap::new()),
+            pending_ice: RefCell::new(PendingIceCandidates::default()),
+            speaking_detector: RefCell::new(detector),
             speaking_change_cb: Some(speaking_cb),
         }
     }
@@ -280,19 +321,20 @@ impl VoiceManager {
     ///
     /// Also adds the stream to the speaking detector so the local user's
     /// volume is analysed alongside remote peers.
-    pub fn set_local_stream(&mut self, stream: MediaStream) {
-        if let Some(ref mut detector) = self.speaking_detector {
+    pub fn set_local_stream(&self, stream: MediaStream) {
+        if let Some(ref mut detector) = *self.speaking_detector.borrow_mut() {
             detector.add_stream(&self.local_peer_id, &stream);
         }
-        self.local_stream = Some(stream);
+        *self.local_stream.borrow_mut() = Some(stream);
     }
 
-    /// Build an `RTCConfiguration` honouring the configured STUN URL list.
+    /// Build an `RTCConfiguration` honouring the configured ICE server list.
     ///
-    /// See [`resolve_stun_urls`] for the privacy-first default (empty list)
-    /// and the `window.__WILLOW_STUN_URLS` override knob.
+    /// See [`resolve_ice_servers`] for the privacy-first default (empty list)
+    /// and the `window.__WILLOW_ICE_SERVERS` / `window.__WILLOW_STUN_URLS`
+    /// override knobs.
     fn rtc_config() -> RtcConfiguration {
-        build_rtc_config(&resolve_stun_urls())
+        build_rtc_config(&resolve_ice_servers())
     }
 
     /// Test-only accessor for the resolved `RTCConfiguration`.
@@ -313,7 +355,7 @@ impl VoiceManager {
     /// can store it in `video_senders` for later removal.
     fn add_local_tracks(&self, pc: &RtcPeerConnection) -> Option<RtcRtpSender> {
         // Audio tracks.
-        if let Some(ref stream) = self.local_stream {
+        if let Some(ref stream) = *self.local_stream.borrow() {
             let tracks = stream.get_audio_tracks();
             for i in 0..tracks.length() {
                 let track: web_sys::MediaStreamTrack = tracks.get(i).unchecked_into();
@@ -321,7 +363,7 @@ impl VoiceManager {
             }
         }
         // Video track if currently sharing.
-        if let Some(ref video_stream) = self.video_stream {
+        if let Some(ref video_stream) = *self.video_stream.borrow() {
             let tracks = video_stream.get_video_tracks();
             if tracks.length() > 0 {
                 let track: web_sys::MediaStreamTrack = tracks.get(0).unchecked_into();
@@ -362,12 +404,11 @@ impl VoiceManager {
         // Share the detector's analysers map, sources map, and audio context
         // with the closure so it can register incoming remote audio streams
         // for speaking detection.
-        let detector_analysers = self.speaking_detector.as_ref().map(|d| d.analysers.clone());
-        let detector_sources = self.speaking_detector.as_ref().map(|d| d.sources.clone());
-        let detector_ctx = self
-            .speaking_detector
-            .as_ref()
-            .map(|d| d.audio_context.clone());
+        let detector_ref = self.speaking_detector.borrow();
+        let detector_analysers = detector_ref.as_ref().map(|d| d.analysers.clone());
+        let detector_sources = detector_ref.as_ref().map(|d| d.sources.clone());
+        let detector_ctx = detector_ref.as_ref().map(|d| d.audio_context.clone());
+        drop(detector_ref);
 
         let on_track = Closure::wrap(Box::new(move |ev: RtcTrackEvent| {
             let track: web_sys::MediaStreamTrack = ev.track();
@@ -507,24 +548,63 @@ impl VoiceManager {
         on_negotiation.forget();
     }
 
+    /// Log ICE / connection state transitions for a peer connection.
+    ///
+    /// Without this, a failed ICE negotiation (the common cause of "joined but
+    /// no media") is completely silent. We read the state via `Reflect` so no
+    /// extra web-sys enum features are required, and warn on `failed` /
+    /// `disconnected`. This is diagnostics only — it changes no behaviour.
+    fn setup_connection_logging(pc: &RtcPeerConnection, remote_peer: &str) {
+        fn state_str(pc: &RtcPeerConnection, key: &str) -> String {
+            js_sys::Reflect::get(pc, &JsValue::from_str(key))
+                .ok()
+                .and_then(|v| v.as_string())
+                .unwrap_or_else(|| "unknown".to_string())
+        }
+
+        let pc_ice = pc.clone();
+        let peer_ice = remote_peer.to_string();
+        let on_ice_state = Closure::wrap(Box::new(move || {
+            let state = state_str(&pc_ice, "iceConnectionState");
+            if state == "failed" || state == "disconnected" {
+                tracing::warn!(peer = %peer_ice, %state, "ICE connection state");
+            } else {
+                tracing::debug!(peer = %peer_ice, %state, "ICE connection state");
+            }
+        }) as Box<dyn FnMut()>);
+        pc.set_oniceconnectionstatechange(Some(on_ice_state.as_ref().unchecked_ref()));
+        on_ice_state.forget();
+
+        let pc_conn = pc.clone();
+        let peer_conn = remote_peer.to_string();
+        let on_conn_state = Closure::wrap(Box::new(move || {
+            let state = state_str(&pc_conn, "connectionState");
+            if state == "failed" {
+                tracing::warn!(peer = %peer_conn, %state, "peer connection state");
+            } else {
+                tracing::debug!(peer = %peer_conn, %state, "peer connection state");
+            }
+        }) as Box<dyn FnMut()>);
+        pc.set_onconnectionstatechange(Some(on_conn_state.as_ref().unchecked_ref()));
+        on_conn_state.forget();
+    }
+
     /// Get an existing connection or create a new one with all handlers wired up.
     ///
-    /// If a connection already exists for `remote_peer`, it is returned as-is.
-    /// Otherwise a new `RTCPeerConnection` is created, local tracks are added,
-    /// and ICE / track / negotiation handlers are installed.
+    /// If a connection already exists for `remote_peer`, its handles are cloned
+    /// and returned. Otherwise a new `RTCPeerConnection` is created, local
+    /// tracks are added, and ICE / track / negotiation handlers are installed.
     ///
-    /// Returns a reference to the `PeerConnectionState` and an optional
-    /// `RtcRtpSender` for the video track (if one was added to a new connection).
+    /// Returns **owned, cloned** handles (the `RtcPeerConnection` is a cheap JS
+    /// reference; `making_offer`/`remote_set` are `Rc`s) plus an optional
+    /// `RtcRtpSender` for a video track added to a *newly created* connection.
+    /// No `RefCell` borrow escapes, so callers may freely `.await` afterwards.
     fn get_or_create_connection(
-        &mut self,
+        &self,
         remote_peer: &str,
-    ) -> Result<(&PeerConnectionState, Option<RtcRtpSender>), String> {
-        if self.connections.contains_key(remote_peer) {
-            let state = self
-                .connections
-                .get(remote_peer)
-                .expect("key just inserted");
-            return Ok((state, None));
+    ) -> Result<(ConnHandles, Option<RtcRtpSender>), String> {
+        if let Some(state) = self.connections.borrow().get(remote_peer) {
+            return Ok((state.handles(), None));
         }
 
         let pc = RtcPeerConnection::new_with_configuration(&Self::rtc_config())
@@ -533,20 +613,21 @@ impl VoiceManager {
         let video_sender = self.add_local_tracks(&pc);
         self.setup_ice_handler(&pc, remote_peer);
         self.setup_track_handler(&pc, remote_peer);
+        Self::setup_connection_logging(&pc, remote_peer);
 
         let making_offer = Rc::new(Cell::new(false));
         self.setup_negotiation_handler(&pc, remote_peer, making_offer.clone());
 
-        self.connections.insert(
-            remote_peer.to_string(),
-            PeerConnectionState { pc, making_offer },
-        );
-
-        let state = self
-            .connections
-            .get(remote_peer)
-            .expect("key just inserted");
-        Ok((state, video_sender))
+        let state = PeerConnectionState {
+            pc,
+            making_offer,
+            remote_set: Rc::new(Cell::new(false)),
+        };
+        let handles = state.handles();
+        self.connections
+            .borrow_mut()
+            .insert(remote_peer.to_string(), state);
+        Ok((handles, video_sender))
     }
 
     /// Create an SDP offer and send it to a remote peer.
@@ -554,10 +635,10 @@ impl VoiceManager {
     /// If a connection already exists it is reused; otherwise a new one is
     /// created with local tracks and all handlers. The offer is created on
     /// the (possibly existing) connection and sent via the signal callback.
-    pub async fn create_offer(&mut self, remote_peer: &str) -> Result<(), String> {
-        let (state, video_sender) = self.get_or_create_connection(remote_peer)?;
-        let pc = state.pc.clone();
-        let making_offer = state.making_offer.clone();
+    pub async fn create_offer(&self, remote_peer: &str) -> Result<(), String> {
+        let (handles, video_sender) = self.get_or_create_connection(remote_peer)?;
+        let pc = handles.pc;
+        let making_offer = handles.making_offer;
 
         // Prevent the onnegotiationneeded handler from firing a duplicate offer
         // while we are creating one here.
@@ -565,7 +646,9 @@ impl VoiceManager {
 
         // Store video sender if a new connection was created with video.
         if let Some(sender) = video_sender {
-            self.video_senders.insert(remote_peer.to_string(), sender);
+            self.video_senders
+                .borrow_mut()
+                .insert(remote_peer.to_string(), sender);
         }
 
         // Create offer.
@@ -602,31 +685,38 @@ impl VoiceManager {
 
     /// Handle an incoming SDP offer from a remote peer.
     ///
-    /// Implements the "perfect negotiation" pattern:
-    /// - If we are the **impolite** peer (higher ID) and are currently making
-    ///   an offer, we ignore the incoming offer (our offer wins).
-    /// - If we are the **polite** peer (lower ID) and are making an offer,
-    ///   we rollback our local description and accept the remote offer.
-    /// - Otherwise we accept the offer normally.
-    pub async fn handle_offer(&mut self, remote_peer: &str, sdp: &str) -> Result<(), String> {
-        let (state, video_sender) = self.get_or_create_connection(remote_peer)?;
-        let pc = state.pc.clone();
-        let currently_making_offer = state.making_offer.get();
+    /// Implements the canonical "perfect negotiation" pattern (see MDN
+    /// "Establishing a connection: The WebRTC perfect negotiation pattern"):
+    /// - An **offer collision** is `making_offer || signalingState != "stable"`.
+    /// - The **impolite** peer (higher ID) ignores a colliding offer — its own
+    ///   offer wins.
+    /// - The **polite** peer (lower ID) rolls back its pending local offer and
+    ///   accepts the remote one.
+    ///
+    /// Once `setRemoteDescription` succeeds, any ICE candidates that arrived
+    /// early (and were queued) are flushed.
+    pub async fn handle_offer(&self, remote_peer: &str, sdp: &str) -> Result<(), String> {
+        let (handles, video_sender) = self.get_or_create_connection(remote_peer)?;
+        let pc = handles.pc;
 
         // Store video sender if a new connection was created with video.
         if let Some(sender) = video_sender {
-            self.video_senders.insert(remote_peer.to_string(), sender);
+            self.video_senders
+                .borrow_mut()
+                .insert(remote_peer.to_string(), sender);
         }
 
-        // Perfect negotiation collision detection.
+        // Perfect-negotiation collision detection. `polite` = lower peer ID.
         let polite = self.local_peer_id.as_str() < remote_peer;
+        let stable = pc.signaling_state() == RtcSignalingState::Stable;
+        if should_ignore_offer(polite, handles.making_offer.get(), stable) {
+            // Impolite peer in a collision: keep our own offer, drop theirs.
+            return Ok(());
+        }
 
-        if currently_making_offer {
-            if !polite {
-                // We are impolite and already making an offer — ignore incoming.
-                return Ok(());
-            }
-            // We are polite — rollback our pending local description.
+        // Polite peer in a collision (or any non-stable state): roll back our
+        // pending local offer so we can accept the remote one.
+        if !stable {
             let rollback = RtcSessionDescriptionInit::new(RtcSdpType::Rollback);
             let _ = wasm_bindgen_futures::JsFuture::from(pc.set_local_description(&rollback)).await;
         }
@@ -637,6 +727,9 @@ impl VoiceManager {
         wasm_bindgen_futures::JsFuture::from(pc.set_remote_description(&remote_desc))
             .await
             .map_err(|_| "set_remote_description failed")?;
+        handles.remote_set.set(true);
+        // Remote description is in place — apply any candidates that arrived early.
+        self.flush_pending_ice(remote_peer, &pc);
 
         // Create answer.
         let answer = wasm_bindgen_futures::JsFuture::from(pc.create_answer())
@@ -661,44 +754,79 @@ impl VoiceManager {
     }
 
     /// Handle an incoming SDP answer from a remote peer.
+    ///
+    /// After `setRemoteDescription` succeeds, flushes any ICE candidates that
+    /// arrived before the answer.
     pub async fn handle_answer(&self, remote_peer: &str, sdp: &str) -> Result<(), String> {
-        let state = self
-            .connections
-            .get(remote_peer)
-            .ok_or("no connection for peer")?;
+        let handles = {
+            let conns = self.connections.borrow();
+            conns
+                .get(remote_peer)
+                .map(|s| s.handles())
+                .ok_or("no connection for peer")?
+        };
 
         let desc = RtcSessionDescriptionInit::new(RtcSdpType::Answer);
         desc.set_sdp(sdp);
-        wasm_bindgen_futures::JsFuture::from(state.pc.set_remote_description(&desc))
+        wasm_bindgen_futures::JsFuture::from(handles.pc.set_remote_description(&desc))
             .await
             .map_err(|_| "set_remote_description failed")?;
+        handles.remote_set.set(true);
+        self.flush_pending_ice(remote_peer, &handles.pc);
         Ok(())
     }
 
     /// Handle an incoming ICE candidate from a remote peer.
+    ///
+    /// `addIceCandidate` rejects when the connection has no remote description
+    /// yet (the browser buffers only *local* candidates, not remote ones), so a
+    /// candidate that arrives before its offer/answer must be queued rather than
+    /// dropped. Queued candidates are flushed by [`Self::flush_pending_ice`]
+    /// once `setRemoteDescription` succeeds. Candidates for a peer with no
+    /// connection yet are also queued (the connection is created when its offer
+    /// arrives).
     pub fn handle_ice_candidate(
         &self,
         remote_peer: &str,
         candidate_json: &str,
     ) -> Result<(), String> {
-        let state = self
-            .connections
-            .get(remote_peer)
-            .ok_or("no connection for peer")?;
+        // Validate the JSON up front so malformed candidates are rejected
+        // rather than silently queued forever.
+        if js_sys::JSON::parse(candidate_json).is_err() {
+            return Err("invalid ICE candidate JSON".to_string());
+        }
 
-        let candidate_obj =
-            js_sys::JSON::parse(candidate_json).map_err(|_| "invalid ICE candidate JSON")?;
-        // Use add_ice_candidate with the parsed JS object directly.
-        // The browser accepts RTCIceCandidateInit dictionaries natively.
-        let _ = state
-            .pc
-            .add_ice_candidate_with_opt_rtc_ice_candidate_init(Some(candidate_obj.unchecked_ref()));
+        let ready = {
+            let conns = self.connections.borrow();
+            conns
+                .get(remote_peer)
+                .map(|state| (state.pc.clone(), state.remote_set.get()))
+        };
+
+        match ready {
+            Some((pc, true)) => apply_ice_candidate(&pc, candidate_json),
+            Some((_, false)) | None => {
+                // Connection missing or remote description not set yet — queue.
+                self.pending_ice
+                    .borrow_mut()
+                    .push(remote_peer, candidate_json);
+            }
+        }
         Ok(())
+    }
+
+    /// Apply every queued ICE candidate for `remote_peer` to `pc`, in arrival
+    /// order. Called once the connection's remote description is set.
+    fn flush_pending_ice(&self, remote_peer: &str, pc: &RtcPeerConnection) {
+        let queued = self.pending_ice.borrow_mut().take(remote_peer);
+        for json in queued {
+            apply_ice_candidate(pc, &json);
+        }
     }
 
     /// Mute or unmute the local microphone.
     pub fn set_muted(&self, muted: bool) {
-        if let Some(ref stream) = self.local_stream {
+        if let Some(ref stream) = *self.local_stream.borrow() {
             let tracks = stream.get_audio_tracks();
             for i in 0..tracks.length() {
                 let track: web_sys::MediaStreamTrack = tracks.get(i).unchecked_into();
@@ -712,21 +840,25 @@ impl VoiceManager {
     /// Stops any existing video share first. The video track is added to every
     /// existing peer connection; `onnegotiationneeded` fires automatically and
     /// handles the renegotiation.
-    pub fn start_video(&mut self, stream: MediaStream, source: VideoSource) {
+    pub fn start_video(&self, stream: MediaStream, source: VideoSource) {
         self.stop_video_share();
-        self.video_stream = Some(stream.clone());
-        self.video_source = Some(source);
+        *self.video_stream.borrow_mut() = Some(stream.clone());
+        self.video_source.set(Some(source));
 
         let video_tracks = stream.get_video_tracks();
         if video_tracks.length() > 0 {
             let track: web_sys::MediaStreamTrack = video_tracks.get(0).unchecked_into();
-            // Collect peer IDs first to avoid borrowing `self` in the loop.
-            let peer_ids: Vec<String> = self.connections.keys().cloned().collect();
-            for peer_id in peer_ids {
-                if let Some(state) = self.connections.get(&peer_id) {
-                    let sender = state.pc.add_track_0(&track, &stream);
-                    self.video_senders.insert(peer_id, sender);
-                }
+            // Snapshot (peer_id, pc) pairs so we don't hold the connections
+            // borrow while mutating video_senders.
+            let targets: Vec<(String, RtcRtpSender)> = self
+                .connections
+                .borrow()
+                .iter()
+                .map(|(peer_id, state)| (peer_id.clone(), state.pc.add_track_0(&track, &stream)))
+                .collect();
+            let mut senders = self.video_senders.borrow_mut();
+            for (peer_id, sender) in targets {
+                senders.insert(peer_id, sender);
             }
         }
         // onnegotiationneeded fires automatically from addTrack.
@@ -736,50 +868,55 @@ impl VoiceManager {
     ///
     /// Stops the underlying `MediaStreamTrack` (turns off camera LED) and
     /// removes the RTP sender from each connection, triggering renegotiation.
-    pub fn stop_video_share(&mut self) {
-        let senders: Vec<(String, RtcRtpSender)> = self.video_senders.drain().collect();
-        for (peer_id, sender) in senders {
-            if let Some(state) = self.connections.get(&peer_id) {
-                state.pc.remove_track(&sender);
+    pub fn stop_video_share(&self) {
+        let senders: Vec<(String, RtcRtpSender)> =
+            self.video_senders.borrow_mut().drain().collect();
+        {
+            let conns = self.connections.borrow();
+            for (peer_id, sender) in &senders {
+                if let Some(state) = conns.get(peer_id) {
+                    state.pc.remove_track(sender);
+                }
             }
         }
-        if let Some(ref stream) = self.video_stream {
+        if let Some(ref stream) = *self.video_stream.borrow() {
             let tracks = stream.get_video_tracks();
             for i in 0..tracks.length() {
                 let track: web_sys::MediaStreamTrack = tracks.get(i).unchecked_into();
                 track.stop();
             }
         }
-        self.video_stream = None;
-        self.video_source = None;
+        *self.video_stream.borrow_mut() = None;
+        self.video_source.set(None);
     }
 
     /// Start sharing the screen. Convenience wrapper around `start_video`.
-    pub fn start_screen_share(&mut self, stream: MediaStream) {
+    pub fn start_screen_share(&self, stream: MediaStream) {
         self.start_video(stream, VideoSource::Screen);
     }
 
     /// Start sharing the camera. Convenience wrapper around `start_video`.
-    pub fn start_camera(&mut self, stream: MediaStream) {
+    pub fn start_camera(&self, stream: MediaStream) {
         self.start_video(stream, VideoSource::Camera);
     }
 
     /// Return the currently active video source, if any.
     pub fn video_source(&self) -> Option<VideoSource> {
-        self.video_source
+        self.video_source.get()
     }
 
     /// Close the connection to a specific remote peer.
     ///
     /// Also removes the `<audio>` element created for this peer's remote
     /// audio playback so elements do not accumulate across reconnects.
-    pub fn close_connection(&mut self, remote_peer: &str) {
-        self.video_senders.remove(remote_peer);
-        if let Some(ref mut detector) = self.speaking_detector {
+    pub fn close_connection(&self, remote_peer: &str) {
+        self.video_senders.borrow_mut().remove(remote_peer);
+        self.pending_ice.borrow_mut().take(remote_peer);
+        if let Some(ref mut detector) = *self.speaking_detector.borrow_mut() {
             detector.remove_peer(remote_peer);
         }
         (self.on_video_track)(remote_peer, None);
-        if let Some(state) = self.connections.remove(remote_peer) {
+        if let Some(state) = self.connections.borrow_mut().remove(remote_peer) {
             state.pc.close();
         }
         // Remove the <audio> element from the DOM.
@@ -799,115 +936,297 @@ impl VoiceManager {
     /// `<audio>` elements are removed from the DOM and the speaking detector
     /// is cleaned up per-peer. The detector is then destroyed and recreated
     /// so speaking detection works on the next voice session.
-    pub fn close_all(&mut self) {
+    pub fn close_all(&self) {
         self.stop_video_share();
         // Close each peer individually to remove <audio> elements and clean
         // up per-peer detector state.
-        let peers: Vec<String> = self.connections.keys().cloned().collect();
+        let peers: Vec<String> = self.connections.borrow().keys().cloned().collect();
         for peer in peers {
             self.close_connection(&peer);
         }
-        // Destroy the detector after per-peer cleanup.
-        if let Some(ref mut detector) = self.speaking_detector {
+        self.pending_ice.borrow_mut().clear();
+        // Destroy the detector after per-peer cleanup, then recreate it so
+        // speaking detection works on rejoin.
+        if let Some(ref mut detector) = *self.speaking_detector.borrow_mut() {
             detector.destroy();
         }
-        self.speaking_detector = None;
-        // Recreate the detector so speaking detection works on rejoin.
+        *self.speaking_detector.borrow_mut() = None;
         if let Some(ref cb) = self.speaking_change_cb {
             let cb_clone = cb.clone();
-            self.speaking_detector = SpeakingDetector::new(move |s| cb_clone(s)).ok();
-            if let Some(ref mut d) = self.speaking_detector {
+            let mut detector = SpeakingDetector::new(move |s| cb_clone(s)).ok();
+            if let Some(ref mut d) = detector {
                 d.start_polling();
             }
+            *self.speaking_detector.borrow_mut() = detector;
         }
-        if let Some(ref stream) = self.local_stream {
+        if let Some(ref stream) = *self.local_stream.borrow() {
             let tracks = stream.get_tracks();
             for i in 0..tracks.length() {
                 let track: web_sys::MediaStreamTrack = tracks.get(i).unchecked_into();
                 track.stop();
             }
         }
-        self.local_stream = None;
+        *self.local_stream.borrow_mut() = None;
     }
 }
 
-/// Resolve the list of STUN server URLs to use for WebRTC ICE gathering.
+/// A single ICE server entry: one or more URLs plus optional TURN credentials.
+///
+/// STUN servers need only `urls`. TURN servers additionally require
+/// `username` + `credential`; without them the browser silently cannot use the
+/// TURN server, which is why the previous STUN-only config could never relay
+/// media across symmetric NATs.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct IceServerConfig {
+    /// `stun:` / `turn:` / `turns:` URLs for this server.
+    pub urls: Vec<String>,
+    /// TURN username (omit for STUN-only entries).
+    pub username: Option<String>,
+    /// TURN credential / shared secret (omit for STUN-only entries).
+    pub credential: Option<String>,
+}
+
+/// Resolve the list of ICE servers to use for WebRTC ICE gathering.
 ///
 /// # Privacy-first default
 ///
-/// Returns an **empty list** by default. WebRTC will then rely on host
-/// candidates plus whatever relay path the iroh layer provides — no
-/// third-party STUN server learns the user's IP address.
+/// Returns an **empty list** by default. WebRTC then relies on host candidates
+/// only — no third-party STUN/TURN server learns the user's IP address.
+/// Hardcoding `stun:stun.l.google.com:19302` (the original behaviour) leaked
+/// every voice-call participant's public IP to Google (issue #179).
 ///
-/// Hardcoding `stun:stun.l.google.com:19302` (the previous behaviour) leaked
-/// every voice-call participant's public IP to Google. See issue #179.
+/// **Empty means no NAT traversal**: host-only candidates connect on the same
+/// machine / flat LAN but fail across any NAT boundary. To make cross-network
+/// calls work *without* leaking IPs to a third party, deployments should point
+/// these knobs at a self-hosted STUN/TURN server (e.g. coturn co-located with
+/// the Willow relay). See
+/// `docs/specs/2026-06-07-webrtc-nat-traversal-design.md`.
 ///
-/// # Override
+/// # Override knobs (read at boot, before the WASM module starts)
 ///
-/// Deployments that need NAT traversal via STUN can set the
-/// `window.__WILLOW_STUN_URLS` global to an array of STUN URLs *before* the
-/// WASM module boots, e.g. in `init.js`:
-///
+/// `window.__WILLOW_ICE_SERVERS` — full entries incl. TURN credentials:
 /// ```js
-/// // Opt back into Google's public STUN server (leaks your IP to Google):
-/// window.__WILLOW_STUN_URLS = ['stun:stun.l.google.com:19302'];
-///
-/// // Or point at a self-hosted STUN server:
-/// window.__WILLOW_STUN_URLS = ['stun:stun.example.com:3478'];
+/// window.__WILLOW_ICE_SERVERS = [
+///   { urls: 'stun:stun.willow.example:3478' },
+///   { urls: ['turn:turn.willow.example:3478'],
+///     username: 'ephemeral-user', credential: 'hmac-token' },
+/// ];
 /// ```
 ///
-/// Values that are not a JS array, or entries that are not strings, are
-/// silently ignored.
+/// `window.__WILLOW_STUN_URLS` — legacy STUN-only array, still honoured:
+/// ```js
+/// window.__WILLOW_STUN_URLS = ['stun:stun.willow.example:3478'];
+/// ```
 ///
-/// # Follow-up
-///
-/// - Medium term: ship a self-hosted STUN server alongside the relay.
-/// - Long term: use the iroh relay path for ICE traversal directly so STUN
-///   becomes unnecessary.
-pub fn resolve_stun_urls() -> Vec<String> {
+/// Entries that are not objects/strings, or lack any usable URL, are ignored.
+pub fn resolve_ice_servers() -> Vec<IceServerConfig> {
     let Some(window) = web_sys::window() else {
         return Vec::new();
     };
-    let raw = match js_sys::Reflect::get(
+    let full = js_sys::Reflect::get(
+        &window,
+        &wasm_bindgen::JsValue::from_str("__WILLOW_ICE_SERVERS"),
+    )
+    .ok()
+    .map(parse_ice_servers)
+    .unwrap_or_default();
+    let legacy = js_sys::Reflect::get(
         &window,
         &wasm_bindgen::JsValue::from_str("__WILLOW_STUN_URLS"),
-    ) {
-        Ok(v) => v,
-        Err(_) => return Vec::new(),
-    };
-    if raw.is_undefined() || raw.is_null() {
-        return Vec::new();
-    }
+    )
+    .ok()
+    .map(parse_legacy_stun_urls)
+    .unwrap_or_default();
+    merge_ice_servers(full, legacy)
+}
+
+/// Parse a `window.__WILLOW_ICE_SERVERS` value (array of `{urls, username?,
+/// credential?}` objects) into [`IceServerConfig`]s. Tolerant of junk: bad
+/// entries are skipped, and `urls` accepts either a string or an array of
+/// strings.
+fn parse_ice_servers(raw: wasm_bindgen::JsValue) -> Vec<IceServerConfig> {
     let Ok(array) = raw.dyn_into::<js_sys::Array>() else {
         return Vec::new();
     };
-    let mut out = Vec::with_capacity(array.length() as usize);
-    for i in 0..array.length() {
-        if let Some(s) = array.get(i).as_string() {
+    let mut out = Vec::new();
+    for entry in array.iter() {
+        let urls_val = js_sys::Reflect::get(&entry, &"urls".into()).unwrap_or(JsValue::UNDEFINED);
+        let mut urls = Vec::new();
+        if let Some(s) = urls_val.as_string() {
             if !s.is_empty() {
-                out.push(s);
+                urls.push(s);
             }
+        } else if let Ok(arr) = urls_val.dyn_into::<js_sys::Array>() {
+            for u in arr.iter() {
+                if let Some(s) = u.as_string() {
+                    if !s.is_empty() {
+                        urls.push(s);
+                    }
+                }
+            }
+        }
+        if urls.is_empty() {
+            continue;
+        }
+        let username = js_sys::Reflect::get(&entry, &"username".into())
+            .ok()
+            .and_then(|v| v.as_string())
+            .filter(|s| !s.is_empty());
+        let credential = js_sys::Reflect::get(&entry, &"credential".into())
+            .ok()
+            .and_then(|v| v.as_string())
+            .filter(|s| !s.is_empty());
+        out.push(IceServerConfig {
+            urls,
+            username,
+            credential,
+        });
+    }
+    out
+}
+
+/// Parse the legacy `window.__WILLOW_STUN_URLS` string array into a single
+/// credential-less [`IceServerConfig`] (or nothing if empty/invalid).
+fn parse_legacy_stun_urls(raw: wasm_bindgen::JsValue) -> Vec<IceServerConfig> {
+    let Ok(array) = raw.dyn_into::<js_sys::Array>() else {
+        return Vec::new();
+    };
+    let urls: Vec<String> = array
+        .iter()
+        .filter_map(|v| v.as_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if urls.is_empty() {
+        Vec::new()
+    } else {
+        vec![IceServerConfig {
+            urls,
+            username: None,
+            credential: None,
+        }]
+    }
+}
+
+/// Combine the full `__WILLOW_ICE_SERVERS` entries with any legacy STUN-only
+/// entries, dropping legacy URLs already covered by a full entry so we don't
+/// emit duplicate servers. Pure — unit-tested.
+fn merge_ice_servers(
+    full: Vec<IceServerConfig>,
+    legacy: Vec<IceServerConfig>,
+) -> Vec<IceServerConfig> {
+    let known: std::collections::HashSet<&String> =
+        full.iter().flat_map(|s| s.urls.iter()).collect();
+    let mut out = full.clone();
+    for mut entry in legacy {
+        entry.urls.retain(|u| !known.contains(u));
+        if !entry.urls.is_empty() {
+            out.push(entry);
         }
     }
     out
 }
 
-/// Build an `RTCConfiguration` from a resolved list of STUN URLs.
+/// Build an `RTCConfiguration` from a resolved list of ICE servers.
 ///
-/// An empty `urls` list yields a config with **no** `iceServers` entries —
-/// the privacy-first default. See [`resolve_stun_urls`] for rationale.
-fn build_rtc_config(urls: &[String]) -> RtcConfiguration {
+/// An empty `servers` list yields a config with **no** `iceServers` entries —
+/// the privacy-first default. TURN entries carry their `username`/`credential`
+/// so the browser can actually authenticate to the relay (the previous
+/// implementation only ever set `urls`, so it could not drive TURN at all).
+fn build_rtc_config(servers: &[IceServerConfig]) -> RtcConfiguration {
     let config = RtcConfiguration::new();
     let ice_servers = js_sys::Array::new();
-    if !urls.is_empty() {
-        let server = RtcIceServer::new();
-        let url_array = js_sys::Array::new();
-        for u in urls {
-            url_array.push(&wasm_bindgen::JsValue::from_str(u));
+    for server in servers {
+        if server.urls.is_empty() {
+            continue;
         }
-        server.set_urls(&url_array);
-        ice_servers.push(&server);
+        let entry = RtcIceServer::new();
+        let url_array = js_sys::Array::new();
+        for u in &server.urls {
+            url_array.push(&JsValue::from_str(u));
+        }
+        entry.set_urls(&url_array);
+        if let Some(ref username) = server.username {
+            entry.set_username(username);
+        }
+        if let Some(ref credential) = server.credential {
+            entry.set_credential(credential);
+        }
+        ice_servers.push(&entry);
     }
     config.set_ice_servers(&ice_servers);
     config
+}
+
+/// Test-only accessor for [`build_rtc_config`] so browser tests can assert that
+/// TURN credentials propagate into the `RTCConfiguration`.
+#[doc(hidden)]
+pub fn build_rtc_config_for_test(servers: &[IceServerConfig]) -> RtcConfiguration {
+    build_rtc_config(servers)
+}
+
+/// Decide whether an incoming SDP offer should be ignored under the perfect
+/// negotiation pattern.
+///
+/// An offer *collides* when we are mid-offer (`making_offer`) or our signaling
+/// state is not `stable`. The **impolite** peer ignores a colliding offer (its
+/// own offer wins); the **polite** peer accepts it (rolling back its own). When
+/// there is no collision, the offer is always accepted.
+///
+/// This mirrors the canonical MDN/W3C condition
+/// `ignoreOffer = !polite && (makingOffer || signalingState !== "stable")`.
+pub fn should_ignore_offer(polite: bool, making_offer: bool, stable: bool) -> bool {
+    let collision = making_offer || !stable;
+    !polite && collision
+}
+
+/// Buffer of remote ICE candidates that arrived before their connection had a
+/// remote description, keyed by remote peer ID. Pure data structure (no
+/// web-sys), so the queue/flush logic is unit-testable off-browser.
+#[derive(Debug, Default)]
+pub struct PendingIceCandidates {
+    by_peer: HashMap<String, Vec<String>>,
+}
+
+impl PendingIceCandidates {
+    /// Queue a candidate JSON blob for `peer`.
+    pub fn push(&mut self, peer: &str, candidate_json: &str) {
+        self.by_peer
+            .entry(peer.to_string())
+            .or_default()
+            .push(candidate_json.to_string());
+    }
+
+    /// Remove and return every queued candidate for `peer`, in arrival order.
+    pub fn take(&mut self, peer: &str) -> Vec<String> {
+        self.by_peer.remove(peer).unwrap_or_default()
+    }
+
+    /// Number of peers with queued candidates (test/diagnostics helper).
+    pub fn peers_pending(&self) -> usize {
+        self.by_peer.len()
+    }
+
+    /// Drop all queued candidates (session teardown).
+    pub fn clear(&mut self) {
+        self.by_peer.clear();
+    }
+}
+
+/// Parse and apply a single remote ICE candidate to `pc`.
+///
+/// The browser accepts an `RTCIceCandidateInit` dictionary natively. The add is
+/// async; we spawn it and log (rather than silently swallow) any rejection so a
+/// genuinely bad candidate is visible instead of mysteriously breaking ICE.
+fn apply_ice_candidate(pc: &RtcPeerConnection, candidate_json: &str) {
+    let Ok(candidate_obj) = js_sys::JSON::parse(candidate_json) else {
+        tracing::warn!("apply_ice_candidate: invalid candidate JSON");
+        return;
+    };
+    let promise =
+        pc.add_ice_candidate_with_opt_rtc_ice_candidate_init(Some(candidate_obj.unchecked_ref()));
+    wasm_bindgen_futures::spawn_local(async move {
+        if let Err(e) = wasm_bindgen_futures::JsFuture::from(promise).await {
+            tracing::warn!(?e, "addIceCandidate rejected");
+        }
+    });
 }

--- a/crates/web/tests/browser.rs
+++ b/crates/web/tests/browser.rs
@@ -13072,10 +13072,11 @@ mod service_worker_bridge {
 
 mod stun_config {
     //! Tests that the WebRTC ICE configuration honours the
-    //! `window.__WILLOW_STUN_URLS` override and defaults to an empty
-    //! `iceServers` list (privacy-first — no third-party STUN by default).
+    //! `window.__WILLOW_STUN_URLS` / `window.__WILLOW_ICE_SERVERS` overrides and
+    //! defaults to an empty `iceServers` list (privacy-first — no third-party
+    //! STUN by default).
     //!
-    //! See `crates/web/src/voice.rs::resolve_stun_urls` and
+    //! See `crates/web/src/voice.rs::resolve_ice_servers` and
     //! `crates/web/src/voice.rs::VoiceManager::rtc_config`.
 
     use wasm_bindgen::JsCast;
@@ -13109,22 +13110,27 @@ mod stun_config {
     #[wasm_bindgen_test]
     fn default_resolves_to_empty_list() {
         clear_override();
-        let urls = voice::resolve_stun_urls();
+        let servers = voice::resolve_ice_servers();
         assert!(
-            urls.is_empty(),
-            "default STUN URL list must be empty for privacy (got {urls:?})"
+            servers.is_empty(),
+            "default ICE server list must be empty for privacy (got {servers:?})"
         );
     }
 
     #[wasm_bindgen_test]
     fn override_resolves_to_supplied_urls() {
         set_override(&["stun:foo:1234", "stun:bar:5678"]);
-        let urls = voice::resolve_stun_urls();
+        let servers = voice::resolve_ice_servers();
         clear_override();
+        // The legacy STUN-only override collapses to a single credential-less
+        // server entry carrying both URLs.
+        assert_eq!(servers.len(), 1, "legacy STUN urls form one server entry");
         assert_eq!(
-            urls,
+            servers[0].urls,
             vec!["stun:foo:1234".to_string(), "stun:bar:5678".to_string()]
         );
+        assert!(servers[0].username.is_none());
+        assert!(servers[0].credential.is_none());
     }
 
     #[wasm_bindgen_test]
@@ -13171,6 +13177,124 @@ mod stun_config {
         assert_eq!(urls_arr.length(), 1);
         let first = urls_arr.get(0).as_string().expect("url is a string");
         assert_eq!(first, "stun:example.com:3478");
+    }
+}
+
+// ── Voice signaling logic (RC1 TURN config, perfect-negotiation, ICE buffer) ─
+
+mod voice_logic {
+    //! Unit tests for the pure decision points extracted from
+    //! `crates/web/src/voice.rs`:
+    //! * [`voice::should_ignore_offer`] — perfect-negotiation collision rule.
+    //! * [`voice::PendingIceCandidates`] — early-ICE buffer (RC3).
+    //! * [`voice::merge_ice_servers`] is exercised indirectly via
+    //!   [`voice::resolve_ice_servers`] in `stun_config`.
+    //! * [`voice::build_rtc_config_for_test`] — TURN credentials propagate (RC1).
+    //!
+    //! See `docs/reports/2026-06-07-voice-media-connectivity-investigation.md`.
+
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_test::*;
+    use willow_web::voice::{
+        self, build_rtc_config_for_test, should_ignore_offer, IceServerConfig, PendingIceCandidates,
+    };
+
+    #[wasm_bindgen_test]
+    fn impolite_ignores_offer_only_on_collision() {
+        // Impolite (polite=false): ignore when making an offer OR not stable.
+        assert!(
+            should_ignore_offer(false, true, true),
+            "making_offer collision"
+        );
+        assert!(
+            should_ignore_offer(false, false, false),
+            "non-stable collision"
+        );
+        assert!(
+            !should_ignore_offer(false, false, true),
+            "no collision: accept even when impolite"
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn polite_never_ignores_offer() {
+        // Polite peer always accepts (rolls back its own offer instead).
+        assert!(!should_ignore_offer(true, true, false));
+        assert!(!should_ignore_offer(true, true, true));
+        assert!(!should_ignore_offer(true, false, true));
+    }
+
+    #[wasm_bindgen_test]
+    fn pending_ice_queues_and_drains_in_order() {
+        let mut q = PendingIceCandidates::default();
+        assert_eq!(q.peers_pending(), 0);
+        q.push("peerA", "c1");
+        q.push("peerA", "c2");
+        q.push("peerB", "c3");
+        assert_eq!(q.peers_pending(), 2);
+
+        // Draining peerA returns its candidates in arrival order and clears it.
+        assert_eq!(q.take("peerA"), vec!["c1".to_string(), "c2".to_string()]);
+        assert_eq!(
+            q.take("peerA"),
+            Vec::<String>::new(),
+            "second take is empty"
+        );
+        assert_eq!(q.peers_pending(), 1, "peerB still queued");
+
+        q.clear();
+        assert_eq!(q.peers_pending(), 0);
+    }
+
+    #[wasm_bindgen_test]
+    fn build_rtc_config_propagates_turn_credentials() {
+        // RC1: a TURN entry must carry url + username + credential, otherwise
+        // the browser cannot authenticate to the relay and media never flows
+        // across symmetric NAT.
+        let servers = vec![IceServerConfig {
+            urls: vec!["turn:turn.example:3478".to_string()],
+            username: Some("ephemeral-user".to_string()),
+            credential: Some("hmac-token".to_string()),
+        }];
+        let cfg = build_rtc_config_for_test(&servers);
+
+        let ice_servers =
+            js_sys::Reflect::get(&cfg, &"iceServers".into()).expect("read iceServers");
+        let arr: js_sys::Array = ice_servers.dyn_into().expect("iceServers array");
+        assert_eq!(arr.length(), 1);
+        let server = arr.get(0);
+        let username = js_sys::Reflect::get(&server, &"username".into())
+            .ok()
+            .and_then(|v| v.as_string());
+        let credential = js_sys::Reflect::get(&server, &"credential".into())
+            .ok()
+            .and_then(|v| v.as_string());
+        assert_eq!(username.as_deref(), Some("ephemeral-user"));
+        assert_eq!(credential.as_deref(), Some("hmac-token"));
+    }
+
+    #[wasm_bindgen_test]
+    fn full_ice_servers_override_carries_credentials() {
+        // The richer `__WILLOW_ICE_SERVERS` knob carries TURN credentials end
+        // to end through `resolve_ice_servers`.
+        let window = web_sys::window().expect("window");
+        let entry = js_sys::Object::new();
+        let urls = js_sys::Array::new();
+        urls.push(&"turn:turn.example:3478".into());
+        js_sys::Reflect::set(&entry, &"urls".into(), &urls).unwrap();
+        js_sys::Reflect::set(&entry, &"username".into(), &"u".into()).unwrap();
+        js_sys::Reflect::set(&entry, &"credential".into(), &"c".into()).unwrap();
+        let arr = js_sys::Array::new();
+        arr.push(&entry);
+        js_sys::Reflect::set(&window, &"__WILLOW_ICE_SERVERS".into(), &arr).unwrap();
+
+        let servers = voice::resolve_ice_servers();
+        let _ = js_sys::Reflect::delete_property(&window, &"__WILLOW_ICE_SERVERS".into());
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].urls, vec!["turn:turn.example:3478".to_string()]);
+        assert_eq!(servers[0].username.as_deref(), Some("u"));
+        assert_eq!(servers[0].credential.as_deref(), Some("c"));
     }
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -141,6 +141,10 @@ Every entry below carries one of:
 
 See also: [`plans/STATUS.md`](plans/STATUS.md) — point-in-time audit of which UI-phase plans have landed.
 
+**Reports**
+
+- [Voice/video media-connectivity investigation](reports/2026-06-07-voice-media-connectivity-investigation.md) — root-cause of "joined a call but no audio/video reached the remote peer": voice wire messages addressed by channel name while the SEC-V-03 gates validate UUIDs (dropped *all* voice), plus the WebRTC media plane broken at four layers (4 KB signaling cap dropping video SDP, dropped early ICE candidates, RefCell-across-await, no STUN/TURN NAT traversal). All but cross-NAT traversal fixed + proven by a 2-peer Playwright media test; coturn deployment tracked separately. `[landed]`
+
 ### Agent / MCP
 
 **Specs**

--- a/docs/reports/2026-06-07-voice-media-connectivity-investigation.md
+++ b/docs/reports/2026-06-07-voice-media-connectivity-investigation.md
@@ -1,0 +1,249 @@
+# Voice/Video Media Failure — Root-Cause Investigation
+
+**Date:** 2026-06-07
+**Status:** investigation complete. Immediate code fixes (RC0, RC2, RC3, RC4,
+perfect-negotiation, RC5 logging, RC1 *config plumbing*) implemented, tested,
+and proven end-to-end (2-peer Playwright media test: remote audio both ways +
+screen-share renegotiation). Cross-NAT traversal (RC1 — self-hosted coturn
+deployment) tracked as follow-up.
+**Area:** voice/video (WebRTC media + iroh signaling)
+
+## Symptom
+
+A user can join a voice/video call and see the other participants in the roster,
+but media does not work: the remote peer cannot hear the microphone and cannot
+see the camera/screen share. The user's **own** screen-share shows correctly in
+their **local** preview.
+
+That split is the whole story: **presence/roster rides iroh gossip (works)**;
+**media rides browser WebRTC (broken)**; **local preview is a local `MediaStream`
+bound to a `<video>` with no peer connection (works)**. Remote media needs a
+negotiated WebRTC path with working ICE, which is broken at three layers
+simultaneously.
+
+## Method
+
+Multi-agent review: 4 parallel code-audit passes (WebRTC manager, signaling +
+concurrency, UI/state, design docs), 4 parallel web-research passes (perfect
+negotiation, ICE/STUN/TURN behaviour, P2P reference apps, Rust-WebRTC/iroh
+capabilities), then adversarial verification of every candidate root cause
+(15 verdicts) and a synthesis pass. Headline causes (RC1–RC3) were
+re-verified by hand against source.
+
+## How the system works — two planes
+
+**Signaling plane (iroh gossip — WORKS).** Presence via
+`WireMessage::VoiceJoin`/`VoiceLeave` on `SERVER_OPS_TOPIC`. When a peer joins,
+existing participants each spawn `create_offer` toward the joiner; the joiner
+answers (one offerer per pair). SDP/ICE serialized to strings and gossiped as
+`WireMessage::VoiceSignal { channel_id, target_peer, signal }`. Sent in
+`crates/client/src/voice.rs::send_voice_signal`; dispatched to the `VoiceManager`
+in `crates/web/src/event_processing.rs:113-133`.
+
+**Media plane (browser WebRTC — BROKEN).** One `RtcPeerConnection` per remote
+peer, owned by `VoiceManager` (`crates/web/src/voice.rs`). `RtcConfiguration`
+built from `resolve_stun_urls()` → **empty `iceServers`** by default. Remote
+video renders only when `ontrack` fires → `on_video_track` callback →
+`set_remote_video_streams` → `ParticipantTile` binds `srcObject`. The UI plane is
+correct; it never receives a stream because the media plane never connects.
+
+## Root causes (ranked, all confirmed)
+
+### RC0 — Voice wire messages addressed by name, gates validate by UUID
+- **Severity:** Critical (broke **all voice**, before media even mattered).
+  Discovered by the new end-to-end media test after the RC1-RC4 fixes landed.
+- **Where:** the UI passes the channel *name* into `join_voice` /
+  `send_voice_signal`, so `VoiceJoin`/`VoiceLeave`/`VoiceSignal` carried the
+  name — but the SEC-V-03 existence gates (`crates/client/src/listeners.rs`)
+  validate `channel_id` against `ServerState.channels`, which is keyed by the
+  canonical UUID (`mutations.rs` `create_channel` generates
+  `uuid::Uuid::new_v4()`). Every voice message was dropped with
+  `"dropping VoiceJoin: channel_id not in ServerState.channels"` — no
+  participant ever appeared in a call, no signaling was ever delivered.
+- **Fix (landed):** boundary translation. The wire now carries the canonical
+  `channel_id` (UUID): senders resolve name→id via
+  `ClientMutations::channel_id_for_voice` (accepts either form); the three
+  listener gates resolve id→name and key voice state / `ClientEvent`s by name
+  (consistent with the name-keyed UI). Security tests updated to assert the
+  UUID-on-wire / name-in-state contract.
+
+### RC1 — Empty ICE config: no STUN/TURN, no NAT traversal
+- **Severity:** Critical (breaks **all cross-network calls**, any media type).
+- **Where:** `crates/web/src/voice.rs:867-893` (`resolve_stun_urls()` returns
+  empty `Vec` by design); `899-913` (`build_rtc_config()` calls `set_urls()` only —
+  never `set_username()`/`set_credential()`, so it cannot drive TURN even if
+  configured); unimplemented intent at `voice.rs:862-866`.
+- **Mechanism:** With zero `iceServers`, the browser gathers only **host**
+  candidates (obfuscated as `.local` mDNS). No server-reflexive (needs STUN), no
+  relay (needs TURN). Same-machine and flat same-LAN may connect; **any NAT
+  boundary fails** — no candidate pair forms, connection stalls and times out.
+- **Note:** The empty default is a deliberate privacy choice (issue #179: Google
+  STUN was leaking every caller's IP). The bug is that **no privacy-preserving
+  replacement was built** — NAT traversal is simply absent.
+
+### RC2 — 4 KB `SIGNALING_CAP` silently drops video SDP
+- **Severity:** Critical (breaks **video calls on any network**, incl. same-LAN).
+- **Where:** `crates/common/src/wire.rs:118` (`SIGNALING_CAP = 4*1024`), `172`
+  (`VoiceSignal` mapped to `SIGNALING_CAP`), enforced post-decode in `unpack_wire`
+  (drops oversize with a `tracing::warn`, returns `None`).
+- **Mechanism:** Audio-only SDP (< ~2 KB) passes. Video offers/answers with
+  H.264/VP8/VP9/AV1 codec lists + RTP header extensions routinely run 5–15 KB.
+  The message deserializes, then the per-variant cap drops it. The offerer never
+  receives an answer; no user-visible error. The cap's own doc comment
+  (`wire.rs:152-155`) wrongly claims "SDP/ICE blobs — all small."
+
+### RC3 — Early/ordering-lost remote ICE candidates (silent failure)
+- **Severity:** Critical for connectivity.
+- **Where:** `crates/web/src/voice.rs:679-697` — `handle_ice_candidate` early-
+  returns `no connection for peer` (687) if the connection doesn't exist yet, and
+  discards the `add_ice_candidate` result with `let _` (693-695). Candidate
+  handling is **synchronous** (`event_processing.rs:128`, `vm.borrow()`) while
+  offer/answer are **async** (`spawn_local`, `event_processing.rs:121,125`).
+- **Mechanism:** Per W3C/MDN, `addIceCandidate()` rejects (`InvalidStateError` /
+  `OperationError`) when `remoteDescription` is null — browsers do **not** buffer
+  *remote* candidates. Gossip gives no ordering guarantee, and within one event
+  batch the synchronous ICE handler runs before the spawned offer/answer task.
+  Candidates arriving before `setRemoteDescription` are rejected, the rejection is
+  swallowed, and the candidate is lost forever → missing candidate pairs → no
+  media even when the SDP exchange succeeds. Classic "negotiation completes but
+  media never flows."
+
+### RC4 — `RefCell<VoiceManager>` borrow held across `await`
+- **Severity:** Critical when it fires; intermittent.
+- **Where:** `crates/web/src/app.rs:1465-1488` — `handle_voice_create_offer`/
+  `handle_voice_offer` hold `borrow_mut()` across `.await`; `handle_voice_answer`
+  holds `borrow()` across `.await`. Incorrect "no preemption" comment at
+  `1462-1463`; `#[allow(clippy::await_holding_refcell_ref)]` suppresses the lint.
+- **Mechanism:** Single-threaded WASM has no OS preemption, but `.await` is a
+  cooperative yield point — `spawn_local` tasks interleave there. While one
+  handler holds the borrow across its await, a second inbound `VoiceSignal`
+  handler (incl. the synchronous `vm.borrow()` ICE path, fired many times by
+  trickle ICE) → `BorrowMutError` panic, leaving the connection half-initialised
+  and not retried. Adversarial verdicts split confirmed/partial on whether this is
+  *the* reproducing cause, but agree it is a real hazard that must be fixed.
+
+### Ruled out / secondary
+- **Perfect-negotiation collision check uses only `making_offer`, not
+  `signalingState != "stable"`** (`voice.rs:464-502, 622`) — real defect, breaks
+  renegotiation/glare (screen-share added after connect), but not the primary
+  cause of total media absence. Fix alongside RC3.
+- **Self-echo offer to self** (no `local_peer_id` filter at
+  `event_processing.rs:76-92`) — secondary; amplifies RC4.
+- **Audio `RtcRtpSender` discarded** (`voice.rs:314-322`) — ruled out as a cause;
+  tracks are still transmitted (monitoring gap only).
+- **UI rendering pipeline** (`participant_tile.rs`, `call_page.rs`, `state.rs`) —
+  ruled out; correct and ready to display the instant a stream arrives.
+
+## Reference projects & how they solve this
+
+| Project | Topology | Transport / NAT traversal | Lesson for Willow |
+|---|---|---|---|
+| **Jami** | full-mesh | ICE; public IP from OpenDHT (no 3rd-party STUN); TURN fallback | Serverless app deriving peer IP from its own overlay — Willow's "iroh replaces STUN" aspiration, but native. |
+| **SimpleX Chat** | 1:1 mesh | browser WebRTC; signal over existing E2E connection; self-hosted relay hides IPs | Best precedent for "signal SDP over the channel you already have" + IP-hiding via own relay. |
+| **Matrix / Element Call + LiveKit** | mesh → SFU | WebRTC + STUN/TURN; E2E frames through SFU | Where mesh breaks (>4–6) and how to keep E2E through an SFU. Long-term only. |
+| **Jitsi Meet** | mesh small / SFU large | operator-run STUN/TURN/SFU | Canonical small=mesh / large=SFU boundary. |
+| **Tox / qTox** | P2P mesh | custom UDP, DHT, own hole-punch + TCP relay, no 3rd-party STUN/TURN | Direct P2P media works without SFU/STUN — but bespoke native, not browser. |
+| **js-libp2p WebRTC** | browser↔browser | WebRTC data channels; still needs STUN + signaling relay | Even with known peer identity, **browser↔browser still needs STUN** to learn its own public IP. Data only. |
+| **iroh callme / iroh-roq / iroh-live (n0)** | native P2P | RTP/MoQ over QUIC over iroh; hole-punch + relay; no STUN/TURN | Native media-over-iroh is proven — but native Rust; browser viewing needs a WebTransport↔WebRTC bridge. |
+
+**Full-mesh vs SFU:** full-mesh is correct for Willow's target size (2–6); mesh
+fails past ~4–6 (quadratic upload, N-1 decoders). The call-page spec already
+scopes SFU out — that matches. SFU is a future concern, not a fix for this bug.
+
+**RTP-over-QUIC / iroh-carried media for the browser leg — not feasible today.**
+In browsers iroh is **relay-only over WebSocket**, does **not** hole-punch (no raw
+UDP in browsers), has **no native A/V**, and its relays are **proprietary, not
+TURN/ICE-compatible** — a browser `RtcPeerConnection` cannot use an iroh relay as
+an ICE candidate. The `voice.rs:862-866` TODO ("use the iroh relay path for ICE")
+is therefore **infeasible as written** and should be retired. Native↔native media
+over iroh (iroh-roq/MoQ) is the right long-horizon direction but means leaving
+browser WebRTC media + adding a WebTransport↔WebRTC bridge — a major rewrite.
+
+## Recommended fixes
+
+### (a) Immediate code fixes — no architecture change
+
+1. **Stop holding `RefCell` across `await` (RC4).** Restructure `VoiceManager`
+   methods so the borrow scope ends before the first `await`: clone the
+   `RtcPeerConnection` (cheap JS handle) out under a short borrow, drop the
+   borrow, then await on the clone. Remove the `#[allow(...)]` and the false
+   "no preemption" comment. Add the self-peer filter while here.
+2. **Add a per-connection ICE candidate queue (RC3).** `pending_candidates` per
+   connection. In `handle_ice_candidate`: create/queue if no connection yet; push
+   to queue if `remoteDescription` is null; else add immediately. Drain after
+   `setRemoteDescription` resolves in `handle_offer`/`handle_answer`. Stop
+   discarding the result — `await` it and log rejections (simple-peer/Pion pattern).
+3. **Fix perfect-negotiation collision condition.** Guard on
+   `offer && (making_offer || signaling_state() != Stable)`. Prefer no-arg
+   `setLocalDescription()` in `onnegotiationneeded`; wrap the `making_offer`
+   flag in a finally-equivalent; drop explicit `{type:'rollback'}` (modern
+   browsers auto-rollback in `setRemoteDescription`).
+4. **Raise the signaling cap for SDP (RC2).** Add a dedicated `SDP_CAP` (e.g.
+   64 KB = `DEFAULT_CAP`) and map `VoiceSignal` to it instead of `SIGNALING_CAP`
+   (`wire.rs:156-177`). Fix the misleading comment. Add a wire round-trip test
+   with a realistic ~10 KB video SDP. (Runner-up rejected: splitting `VoiceSignal`
+   into offer/answer vs candidate variants — more churn, no benefit.)
+5. **Add connection-state + ICE-failure logging.** Wire
+   `oniceconnectionstatechange` / `onconnectionstatechange` /
+   `onicegatheringstatechange` to `tracing::warn` on `failed`/`disconnected` and
+   log the selected candidate pair. Surface the `unpack_wire` cap-drop warn for
+   `VoiceSignal` during bring-up. Converts silent failures into signal.
+
+### (b) NAT traversal strategy
+
+**Shortest path — self-host coturn (STUN+TURN) co-located with the Willow relay.**
+Cross-network traversal fundamentally requires a reflexive path (STUN, fails on
+symmetric NAT) or a media relay (TURN, universal). Because the TURN server is
+*ours*, no third party learns participant IPs — this **preserves the privacy
+property** that motivated the empty default. Extend `build_rtc_config()` to carry
+TURN URL + username + **time-limited HMAC credential** (coturn `use-auth-secret` /
+TURN REST), served to the client at boot (extend/replace the `__WILLOW_STUN_URLS`
+hook to carry full `iceServers` entries). Keep mDNS for same-LAN; optionally add a
+self-hosted STUN entry so only hard-NAT pairs consume relay bandwidth.
+
+**Long-term (record, don't build now):** native↔native media over iroh
+(iroh-roq/MoQ) + a WebTransport↔WebRTC bridge for browsers. Rejected for
+near/medium term: the browser leg still requires WebRTC, MoQ still needs
+relay/SFU infra, and it's a major rewrite that loses the mature browser A/V
+pipeline.
+
+## Verification plan
+
+| Fix | Tier | Assert | Location |
+|---|---|---|---|
+| RC2 cap | client/common (Rust) | ~10 KB video SDP survives `pack_wire`/`unpack_wire` as `VoiceSignal::Offer` | `crates/common/src/wire.rs` tests |
+| RC4 borrow | client (Rust) | interleaved offer/answer/ICE handlers → no `BorrowMutError` | `crates/client/src/tests/` |
+| RC3 queue | browser (wasm-pack) | candidate before `setRemoteDescription` is applied after, not lost | `crates/web/tests/browser.rs` |
+| neg. guard | browser (wasm-pack) | simulated glare → both reach `stable` | `crates/web/tests/browser.rs` |
+| RC1 TURN wiring | browser (wasm-pack) | `build_rtc_config()` emits `RtcIceServer` with URL **and** username/credential | `crates/web/tests/browser.rs` |
+| E2E media | Playwright | remote `ontrack` fires, remote tile renders live stream | `e2e/voice-video.spec.ts` (new) |
+
+Automated tiers cannot prove cross-NAT (shared network). **Manual 2-machine
+protocol** (genuinely different NATs, e.g. home Wi-Fi + mobile tether): join,
+confirm roster, open `chrome://webrtc-internals` and verify ICE state reaches
+`connected`/`completed`, `srflx`/`relay` candidates appear (not host-only), the
+selected pair is `relay`↔`relay` cross-NAT, and `getStats` inbound-rtp
+`packetsReceived`/`bytesReceived` increase on both ends (do **not** trust
+`iceConnectionState=connected` alone). Repeat for audio / camera / screen share.
+Negative control: disable TURN → cross-NAT fails.
+
+## Docs to update (when fixes land)
+
+- **This report** documents the investigation.
+- **Create `docs/specs/2026-06-07-webrtc-nat-traversal-design.md`** — target:
+  self-hosted coturn beside the relay; ephemeral TURN credentials; client config
+  delivery; privacy rationale; explicit rejection of the infeasible "iroh relay
+  for ICE"; SFU/MoQ recorded as out-of-scope future; candidate-queue +
+  perfect-negotiation correctness as the media-signaling contract.
+- **Qualify `[landed]` on `docs/specs/2026-03-26-screen-sharing-call-page-design.md`**
+  / its plan — the "joiner immediately receives screen share in the initial
+  offer" assumption is false (no NAT traversal; video SDP dropped by the cap).
+  Downgrade to `[active]` or add a Realised-state addendum; cross-link the new
+  spec as a blocking dependency.
+- **Update `docs/specs/2026-03-29-iroh-migration-design.md`** Voice/WebRTC section
+  to point at the new traversal spec and correct the implication that the iroh
+  relay can serve browser ICE.
+- **Update `docs/README.md`** to register the new report + spec.
+- **Code-comment cleanup:** replace the infeasible "iroh relay path for ICE" at
+  `voice.rs:862-866`; fix the false "no preemption" comment at `app.rs:1462-1463`;
+  fix the "SDP/ICE blobs — all small" comment at `wire.rs:152-155`.

--- a/e2e/voice-video.spec.ts
+++ b/e2e/voice-video.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect, Page } from '@playwright/test';
+import { setupTwoPeers } from './helpers/peers';
+import { visibleShell } from './helpers/ui';
+
+// End-to-end proof that real WebRTC media flows between two peers.
+//
+// Runs ONLY under the `voice-chrome` Playwright project, which launches
+// Chromium with `--use-fake-device-for-media-stream` /
+// `--use-fake-ui-for-media-stream`: a synthetic mic + camera (no hardware) and
+// auto-granted media permissions. Two browser contexts on this one machine
+// then establish a *real* RTCPeerConnection over loopback host candidates — no
+// STUN/TURN needed same-host — so this exercises the whole media path
+// (signaling over iroh gossip → SDP exchange → ICE → tracks) end to end.
+//
+// Cross-NAT traversal (RC1) cannot be proven here (both contexts share the
+// host network); that needs the manual 2-machine protocol in
+// docs/reports/2026-06-07-voice-media-connectivity-investigation.md.
+//
+// What this guards:
+//   * RC2 — video SDP exceeding the old 4 KB cap now survives the wire.
+//   * RC3 — early ICE candidates are buffered, not dropped, so ICE connects.
+//   * RC4 — concurrent signaling no longer panics mid-negotiation.
+//   * perfect-negotiation — screen-share renegotiation reaches the remote peer.
+//
+// The observable proof of "remote media arrived" is the `ontrack` side effect
+// in crates/web/src/voice.rs: a remote audio track appends
+// `<audio id="willow-audio-{peer}">` to the document, and a remote video track
+// populates a participant tile `<video>`.
+
+test.describe('voice/video media flow (real WebRTC over loopback)', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  // Collect this project's contexts only.
+  test.beforeEach(({}, testInfo) => {
+    test.skip(
+      testInfo.project.name !== 'voice-chrome',
+      'voice media tests require the voice-chrome project (fake media devices)',
+    );
+  });
+
+  /** Create a voice channel from the channel sidebar (kind picker → voice). */
+  async function createVoiceChannel(page: Page, name: string) {
+    const scope = visibleShell(page);
+    await page.locator(`${scope} .channel-add-btn`).first().click();
+    await page
+      .locator(`${scope} .tree-kind-picker__item`, { hasText: 'voice' })
+      .first()
+      .click();
+    const nameInput = page.locator(`${scope} .tree-slot__input`).first();
+    await nameInput.waitFor({ timeout: 5_000 });
+    await nameInput.fill(name);
+    await nameInput.press('Enter');
+    await page
+      .locator(`${scope} .voice-channel`, { hasText: name })
+      .waitFor({ timeout: 10_000 });
+  }
+
+  /** Click a voice channel to join it, then wait for the call page. */
+  async function joinVoiceChannel(page: Page, name: string) {
+    const scope = visibleShell(page);
+    await page
+      .locator(`${scope} .voice-channel`, { hasText: name })
+      .first()
+      .click();
+    await page.locator('.call-page').waitFor({ timeout: 15_000 });
+  }
+
+  test('both peers receive each other audio track', async ({ browser }) => {
+    const { ctx1, ctx2, page1, page2 } = await setupTwoPeers(browser);
+    try {
+      await createVoiceChannel(page1, 'voice-room');
+      // Wait for the channel to sync to peer 2 over gossip.
+      await page2
+        .locator(`${visibleShell(page2)} .voice-channel`, { hasText: 'voice-room' })
+        .waitFor({ timeout: 20_000 });
+
+      await joinVoiceChannel(page1, 'voice-room');
+      await joinVoiceChannel(page2, 'voice-room');
+
+      // The load-bearing assertion: each peer's ontrack fired, meaning the
+      // remote audio track crossed the connection. Before the fixes, ICE never
+      // connected (dropped candidates) / the offer was dropped (4 KB cap), so
+      // this element never appeared.
+      await expect(page1.locator('audio[id^="willow-audio-"]'))
+        .toHaveCount(1, { timeout: 25_000 });
+      await expect(page2.locator('audio[id^="willow-audio-"]'))
+        .toHaveCount(1, { timeout: 25_000 });
+    } finally {
+      await ctx1.close();
+      await ctx2.close();
+    }
+  });
+
+  test('remote peer sees a screen share (renegotiation)', async ({ browser }) => {
+    const { ctx1, ctx2, page1, page2 } = await setupTwoPeers(browser);
+    try {
+      await createVoiceChannel(page1, 'voice-room');
+      await page2
+        .locator(`${visibleShell(page2)} .voice-channel`, { hasText: 'voice-room' })
+        .waitFor({ timeout: 20_000 });
+
+      await joinVoiceChannel(page1, 'voice-room');
+      await joinVoiceChannel(page2, 'voice-room');
+
+      // Audio must be flowing before we add video (proves base connection up).
+      await expect(page2.locator('audio[id^="willow-audio-"]'))
+        .toHaveCount(1, { timeout: 25_000 });
+
+      // Peer 1 shares its (fake) screen. This adds a video track to an already
+      // connected peer connection → onnegotiationneeded → renegotiation.
+      await page1.locator('.call-btn[title="Share Screen"]').click();
+
+      // Peer 2 is NOT sharing video, so any participant-tile <video> on its
+      // page is the remote screen share arriving via ontrack.
+      await expect(page2.locator('.participant-tile video').first())
+        .toBeVisible({ timeout: 25_000 });
+    } finally {
+      await ctx1.close();
+      await ctx2.close();
+    }
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,6 +29,27 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
     {
+      // Dedicated project for WebRTC voice/video media tests. The fake-media
+      // flags give Chromium a synthetic mic/camera (no hardware) and
+      // auto-grant the getUserMedia/getDisplayMedia permission prompt, so two
+      // browser contexts on this machine can establish a *real* peer
+      // connection over loopback host candidates (no STUN/TURN needed
+      // same-host) and actually exchange media. Used by e2e/voice-video.spec.ts.
+      name: 'voice-chrome',
+      testMatch: /voice-video\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: [
+            '--use-fake-device-for-media-stream',
+            '--use-fake-ui-for-media-stream',
+            '--autoplay-policy=no-user-gesture-required',
+          ],
+        },
+        permissions: ['microphone', 'camera'],
+      },
+    },
+    {
       name: 'mobile-chrome',
       use: { ...devices['Pixel 7'] },
     },


### PR DESCRIPTION
## Problem

Joining a voice/video call worked (roster visible), but **no audio/video ever reached the remote peer** — mic inaudible, camera/screen-share invisible remotely while the local preview worked.

## Investigation

Multi-agent root-cause review + reference research, written up in [`docs/reports/2026-06-07-voice-media-connectivity-investigation.md`](docs/reports/2026-06-07-voice-media-connectivity-investigation.md) (includes how Jami/SimpleX/Matrix/Tox/iroh-roq solve media transport, and the verification trail). Five independent, compounding bugs:

| # | Bug | Effect |
|---|---|---|
| RC0 | Voice wire messages addressed by channel **name**; SEC-V-03 gates validate **UUID** keys | **All** voice presence + signaling silently dropped |
| RC2 | 4 KB `SIGNALING_CAP` on `VoiceSignal` | Video SDP (5–15 KB) silently dropped → no answer ever |
| RC3 | Early remote ICE candidates rejected (`remoteDescription` null) + error swallowed | Missing candidate pairs → no media even when SDP exchanged |
| RC4 | `RefCell<VoiceManager>` borrow held across `await` | Double-borrow panic mid-negotiation under trickle ICE |
| PN | Collision check missing `signalingState != stable` | Screen-share renegotiation breaks under glare |

## Fixes

- **RC0**: wire carries canonical `channel_id` (UUID) — senders resolve via `channel_id_for_voice`; listener gates resolve id→name; voice state/UI stay name-keyed. Security tests updated to the UUID-on-wire contract.
- **RC2**: dedicated 64 KB `SDP_CAP` for `VoiceSignal` (oversize still rejected).
- **RC3**: per-peer `PendingIceCandidates` queue, flushed after `setRemoteDescription`; rejections logged.
- **RC4**: `VoiceManager` rewritten to interior mutability with `&self` methods; handle is `Rc<VoiceManager>` (no outer `RefCell`); `#[allow(clippy::await_holding_refcell_ref)]` removed so the lint enforces the invariant.
- **PN**: canonical `should_ignore_offer(polite, making_offer, stable)`; self-offer filter; ICE/connection-state logging; TURN credential plumbing (`window.__WILLOW_ICE_SERVERS` with `{urls, username, credential}` — previously TURN could not be configured at all).

**Not in scope** (follow-up, needs infra + spec): cross-NAT traversal. Default stays privacy-first empty `iceServers` (#179); recommendation is self-hosted coturn beside the relay — see report §5b. The old "iroh relay path for ICE" TODO was researched and is infeasible for browsers.

## Tests

- Native: ~10 KB video SDP survives `pack_wire`/`unpack_wire`; oversize rejected; all listener security tests green on the new contract.
- wasm-pack: ICE buffer queue/drain, collision rule, TURN credential propagation, ICE-config knobs.
- **New `e2e/voice-video.spec.ts`** under a `voice-chrome` Playwright project (fake media devices): two real browsers negotiate over loopback — asserts remote **audio both directions** and **screen-share via renegotiation**. Both pass (56.9s). Failed before the fixes (caught RC0).
- `just check` green (fmt, clippy `-D warnings`, all tests, wasm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)